### PR TITLE
Reduce checks less

### DIFF
--- a/src/search/selectivity.rs
+++ b/src/search/selectivity.rs
@@ -66,6 +66,8 @@ impl super::Searcher<'_> {
             reduction -= self.history.get(mv) / LMR_HISTORY_DIVISOR;
             // Reduce PV nodes less
             reduction -= i32::from(PV);
+            // Reduce checks less
+            reduction -= i32::from(self.board.is_in_check());
             // Avoid negative reductions
             reduction.clamp(0, depth)
         } else {


### PR DESCRIPTION
```
Elo   | 4.32 +- 3.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16016 W: 4136 L: 3937 D: 7943
Penta | [260, 1880, 3549, 2039, 280]
```