### PR TITLE
Fail-soft null move pruning

### DIFF
--- a/src/search/selectivity.rs
+++ b/src/search/selectivity.rs
@@ -1,4 +1,4 @@
-use crate::types::Move;
+use crate::types::{Move, Score};
 
 const RFP_MARGIN: i32 = 75;
 const RFP_DEPTH: i32 = 8;
@@ -42,8 +42,13 @@ impl super::Searcher<'_> {
             let score = -self.alpha_beta::<PV, false>(-beta, -beta + 1, depth - NMP_REDUCTION - depth / NMP_DIVISOR);
             self.board.undo_move::<false>();
 
-            if score >= beta {
+            // Avoid returning false mates
+            if score >= Score::MATE_BOUND {
                 return Some(beta);
+            }
+
+            if score >= beta {
+                return Some(score);
             }
         }
         None


### PR DESCRIPTION
```
Elo   | 7.21 +- 5.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7418 W: 1894 L: 1740 D: 3784
Penta | [105, 832, 1689, 970, 113]
```