### PR TITLE
Separate bonus and malus

### DIFF
--- a/src/tables/history.rs
+++ b/src/tables/history.rs
@@ -77,15 +77,21 @@ impl History {
 
 /// Returns the bonus for a move based on the depth of the search.
 fn bonus(depth: i32) -> i32 {
-    (150 * depth).min(1800)
+    (150 * depth - 25).min(1780)
+}
+
+/// Returns the malus for a move based on the depth of the search.
+fn malus(depth: i32) -> i32 {
+    (160 * depth + 15).min(1800)
 }
 
 /// Updates the score of an entry using a gravity function.
 fn update<const IS_GOOD: bool>(v: &mut i32, depth: i32) {
-    let bonus = bonus(depth);
     if IS_GOOD {
+        let bonus = bonus(depth);
         *v += bonus - bonus * *v / MAX_HISTORY;
     } else {
-        *v -= bonus + bonus * *v / MAX_HISTORY;
+        let malus = malus(depth);
+        *v -= malus + malus * *v / MAX_HISTORY;
     }
 }


### PR DESCRIPTION
```
Elo   | 3.44 +- 3.25 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 22394 W: 5846 L: 5624 D: 10924
Penta | [348, 2653, 5026, 2769, 401]
```

The values are derived from a 20k-game tuning session.
