### PR TITLE
Reset killer moves for child nodes

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -70,6 +70,9 @@ impl super::Searcher<'_> {
             }
         }
 
+        // Reset the killer moves for child nodes
+        self.killers.clear(self.board.ply + 1);
+
         let original_alpha = alpha;
         let mut best_score = -Score::INFINITY;
         let mut best_move = Move::NULL;

--- a/src/tables/killers.rs
+++ b/src/tables/killers.rs
@@ -6,7 +6,7 @@ use crate::types::{Move, MAX_PLY};
 /// See [Killer Heuristic](https://www.chessprogramming.org/Killer_Heuristic)
 /// for more information.
 pub struct KillerMoves {
-    table: [[Move; 2]; MAX_PLY],
+    table: [[Move; 2]; MAX_PLY + 1],
 }
 
 impl KillerMoves {
@@ -20,12 +20,18 @@ impl KillerMoves {
     pub fn contains(&self, mv: Move, ply: usize) -> bool {
         self.table[ply][0] == mv || self.table[ply][1] == mv
     }
+
+    /// Clears the killer moves for the specified ply.
+    pub fn clear(&mut self, ply: usize) {
+        self.table[ply][0] = Move::NULL;
+        self.table[ply][1] = Move::NULL;
+    }
 }
 
 impl Default for KillerMoves {
     fn default() -> Self {
         Self {
-            table: [[Move::NULL; 2]; MAX_PLY],
+            table: [[Move::NULL; 2]; MAX_PLY + 1],
         }
     }
 }


### PR DESCRIPTION
```
Elo   | 2.27 +- 2.13 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 4.00]
Games | N: 51952 W: 13447 L: 13108 D: 25397
Penta | [790, 6198, 11746, 6367, 875]
```