### PR TITLE
Avoid using static evaluation when in check

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -52,7 +52,12 @@ impl super::Searcher<'_> {
             depth -= 1;
         }
 
-        let eval = entry.map_or_else(|| self.board.evaluate(), |entry| entry.score);
+        let eval = match entry {
+            Some(entry) => entry.score,
+            None if in_check => -Score::INFINITY,
+            None => self.board.evaluate(),
+        };
+
         let improving = !in_check && self.board.ply > 1 && eval > self.eval_stack[self.board.ply - 2];
 
         self.eval_stack[self.board.ply] = eval;


### PR DESCRIPTION
```
Elo   | 5.48 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10964 W: 2879 L: 2706 D: 5379
Penta | [153, 1267, 2496, 1386, 180]
```