### PR TITLE
Implement global node counter

### DIFF
--- a/src/search/counter.rs
+++ b/src/search/counter.rs
@@ -1,0 +1,36 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub struct NodeCounter<'a> {
+    buffer: u64,
+    local: u64,
+    global: &'a AtomicU64,
+}
+
+impl<'a> NodeCounter<'a> {
+    pub fn new(global: &'a AtomicU64) -> Self {
+        Self { buffer: 0, local: 0, global }
+    }
+
+    pub fn inc(&mut self) {
+        const BUFFER_SIZE: u64 = 2048;
+
+        self.buffer += 1;
+        if self.buffer >= BUFFER_SIZE {
+            self.flush();
+        }
+    }
+
+    pub fn local(&self) -> u64 {
+        self.local + self.buffer
+    }
+
+    pub fn global(&self) -> u64 {
+        self.global.load(Ordering::Relaxed) + self.buffer
+    }
+
+    fn flush(&mut self) {
+        self.local += self.buffer;
+        self.global.fetch_add(self.buffer, Ordering::Relaxed);
+        self.buffer = 0;
+    }
+}

--- a/src/search/deepening.rs
+++ b/src/search/deepening.rs
@@ -31,12 +31,12 @@ impl super::Searcher<'_> {
 
             result.best_move = self.pv_table.get_best_move();
             result.score = score;
-            result.nodes = self.nodes;
+            result.nodes = self.nodes.global();
 
             self.sel_depth = 0;
             self.finished_depth = depth;
 
-            let effort = self.node_table.get(result.best_move) as f64 / self.nodes as f64;
+            let effort = self.node_table.get(result.best_move) as f64 / self.nodes.local() as f64;
             if self.time_manager.is_soft_bound_reached(depth, effort) {
                 break;
             }
@@ -50,7 +50,7 @@ impl super::Searcher<'_> {
 
     /// Reports the result of a search iteration using the `info` UCI command.
     fn report_search_result(&mut self, depth: i32, score: i32, stopwatch: Instant) {
-        let nps = self.nodes as f64 / stopwatch.elapsed().as_secs_f64();
+        let nps = self.nodes.global() as f64 / stopwatch.elapsed().as_secs_f64();
         let ms = stopwatch.elapsed().as_millis();
 
         let hashfull = self.tt.get_load_factor();
@@ -58,7 +58,7 @@ impl super::Searcher<'_> {
 
         print!(
             "info depth {depth} seldepth {} score {score} nodes {} time {ms} nps {nps:.0} hashfull {hashfull} pv",
-            self.sel_depth, self.nodes,
+            self.sel_depth, self.nodes.global(),
         );
         self.pv_table.get_line().iter().for_each(|mv| print!(" {mv}"));
         println!();

--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -15,7 +15,7 @@ impl super::Searcher<'_> {
     /// See [Quiescence Search](https://www.chessprogramming.org/Quiescence_Search)
     /// for more information.
     pub fn quiescence_search(&mut self, mut alpha: i32, beta: i32) -> i32 {
-        self.nodes += 1;
+        self.nodes.inc();
         self.sel_depth = self.sel_depth.max(self.board.ply);
 
         // Prevent overflows


### PR DESCRIPTION
In a multi-threaded search, the UCI info only contained local nodes from the main search thread. The global counter fixes this.

```
Elo   | -0.90 +- 2.36 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [-6.00, 0.00]
Games | N: 43026 W: 11049 L: 11161 D: 20816
Penta | [549, 4665, 11159, 4629, 511]
```