### PR TITLE
Faster repetition detection

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -146,7 +146,12 @@ impl Board {
     ///
     /// This method does not count the number of encounters.
     pub fn draw_by_repetition(&self) -> bool {
-        self.state_stack.iter().rev().any(|state| state.hash == self.hash())
+        self.state_stack.iter()
+            .rev()
+            .skip(1)
+            .step_by(2)
+            .take(self.state.halfmove_clock as usize + 1)
+            .any(|state| state.hash == self.state.hash)
     }
 
     /// Returns `true` if the current position is a known draw by insufficient material:


### PR DESCRIPTION
```
Elo   | 13.67 +- 9.27 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 2720 W: 739 L: 632 D: 1349
Penta | [24, 270, 680, 347, 39]
```