### PR TITLE
Increase research depth when LMR search results are promising

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -4,6 +4,7 @@ use crate::{
     types::{Move, Score, MAX_PLY},
 };
 
+const DEEPER_SEARCH_MARGIN: i32 = 80;
 const IIR_DEPTH: i32 = 4;
 
 impl super::Searcher<'_> {
@@ -114,7 +115,7 @@ impl super::Searcher<'_> {
                 -self.alpha_beta::<PV, false>(-beta, -alpha, new_depth - 1)
             } else {
                 let reduction = self.calculate_reduction::<PV>(mv, depth, moves_played);
-                self.principle_variation_search::<PV>(alpha, beta, new_depth, reduction)
+                self.principle_variation_search::<PV>(alpha, beta, new_depth, reduction, best_score)
             };
 
             self.board.undo_move::<true>();
@@ -164,13 +165,15 @@ impl super::Searcher<'_> {
 
     /// Performs a Principal Variation Search (PVS), optimizing the search efforts by testing moves
     /// with a null window and re-searching when promising. It also applies late move reductions.
-    fn principle_variation_search<const PV: bool>(&mut self, alpha: i32, beta: i32, depth: i32, reduction: i32) -> i32 {
+    fn principle_variation_search<const PV: bool>(&mut self, alpha: i32, beta: i32, depth: i32, reduction: i32, best_score: i32) -> i32 {
         // Null window search with possible late move reduction
         let mut score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, depth - reduction - 1);
 
         // If the search fails and reduction applied, re-search with full depth
         if alpha < score && reduction > 0 {
-            score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, depth - 1);
+            // Adjust the search depth based on results of the LMR search
+            let extension = i32::from(score > best_score + DEEPER_SEARCH_MARGIN);
+            score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, depth + extension - 1);
         }
 
         // If the search fails again, proceed to a full window search with full depth

--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -166,19 +166,22 @@ impl super::Searcher<'_> {
     /// Performs a Principal Variation Search (PVS), optimizing the search efforts by testing moves
     /// with a null window and re-searching when promising. It also applies late move reductions.
     fn principle_variation_search<const PV: bool>(&mut self, alpha: i32, beta: i32, depth: i32, reduction: i32, best_score: i32) -> i32 {
+        let mut new_depth = depth - 1;
+
         // Null window search with possible late move reduction
-        let mut score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, depth - reduction - 1);
+        let mut score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, new_depth - reduction);
 
         // If the search fails and reduction applied, re-search with full depth
         if alpha < score && reduction > 0 {
             // Adjust the search depth based on results of the LMR search
-            let extension = i32::from(score > best_score + DEEPER_SEARCH_MARGIN);
-            score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, depth + extension - 1);
+            new_depth += i32::from(score > best_score + DEEPER_SEARCH_MARGIN);
+
+            score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, new_depth);
         }
 
         // If the search fails again, proceed to a full window search with full depth
         if alpha < score && score < beta {
-            score = -self.alpha_beta::<PV, false>(-beta, -alpha, depth - 1);
+            score = -self.alpha_beta::<PV, false>(-beta, -alpha, new_depth);
         }
 
         score


### PR DESCRIPTION
```
Elo   | 3.21 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 23592 W: 5948 L: 5730 D: 11914
Penta | [297, 2754, 5499, 2926, 320]
```