### PR TITLE
Improve time management for cyclic TC

### DIFF
--- a/src/timeman.rs
+++ b/src/timeman.rs
@@ -19,6 +19,11 @@ const TIME_OVERHEAD_MS: u64 = 15;
 const HARD_BOUND: u64 = 8;
 const SOFT_BOUND: u64 = 40;
 
+const INCREMENT_MULT: f64 = 0.75;
+
+const TOURNAMENT_SOFT_MULT: f64 = 1.0;
+const TOURNAMENT_HARD_MULT: f64 = 5.0;
+
 const MAX_DEPTH: i32 = MAX_PLY as i32;
 const MIN_NODES: u64 = 1024;
 
@@ -79,8 +84,15 @@ fn calculate_time_ms(limits: &Limits) -> (u64, u64) {
             (time / SOFT_BOUND, time / HARD_BOUND)
         }
         Limits::Tournament(main, inc, moves) => {
-            let time = (main / moves + inc).saturating_sub(TIME_OVERHEAD_MS);
-            (time, time)
+            let base = (main as f64 / moves as f64) + INCREMENT_MULT * inc as f64;
+
+            let soft = (TOURNAMENT_SOFT_MULT * base) as u64;
+            let hard = (TOURNAMENT_HARD_MULT * base) as u64;
+
+            let soft = soft.min(main + inc).saturating_sub(TIME_OVERHEAD_MS);
+            let hard = hard.min(main + inc).saturating_sub(TIME_OVERHEAD_MS);
+
+            (soft, hard)
         }
         _ => (u64::MAX, u64::MAX),
     }


### PR DESCRIPTION
```
Elo   | 59.58 +- 23.89 (95%)
SPRT  | 40/8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 10.00]
Games | N: 424 W: 144 L: 72 D: 208
Penta | [4, 24, 92, 80, 12]
```