### PR TITLE
Reset killer moves before null move pruning

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -62,6 +62,9 @@ impl super::Searcher<'_> {
 
         self.eval_stack[self.board.ply] = eval;
 
+        // Reset the killer moves for child nodes
+        self.killers.clear(self.board.ply + 1);
+
         // Node pruning strategies prior to the move loop
         if !ROOT && !PV && !in_check {
             if let Some(score) = self.reverse_futility_pruning(depth, beta, eval, improving) {
@@ -74,9 +77,6 @@ impl super::Searcher<'_> {
                 return score;
             }
         }
-
-        // Reset the killer moves for child nodes
-        self.killers.clear(self.board.ply + 1);
 
         let original_alpha = alpha;
         let mut best_score = -Score::INFINITY;


### PR DESCRIPTION
```
Elo   | 2.06 +- 1.91 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 65226 W: 16968 L: 16582 D: 31676
Penta | [1057, 7764, 14661, 7998, 1133]
```