### PR TITLE
Disable quiescence search pruning for recaptures

### DIFF
--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -48,6 +48,8 @@ impl super::SearchThread<'_> {
             return eval;
         }
 
+        let last_target = self.board.tail_move(1).target();
+
         let mut best_move = Move::NULL;
         let mut best_score = eval;
 
@@ -59,9 +61,9 @@ impl super::SearchThread<'_> {
                 continue;
             }
 
-            // Delta pruning
+            // Futility pruning
             #[cfg(not(feature = "datagen"))]
-            if eval + self.maximum_gain(mv) < alpha && best_score > -Score::MATE_BOUND {
+            if best_score > -Score::MATE_BOUND && mv.target() != last_target && eval + self.maximum_gain(mv) < alpha {
                 break;
             }
 


### PR DESCRIPTION
```
Elo   | 3.31 +- 3.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 23174 W: 5952 L: 5731 D: 11491
Penta | [329, 2729, 5272, 2906, 351]
```