### PR TITLE
Increase SEE piece values

### DIFF
--- a/src/search/see.rs
+++ b/src/search/see.rs
@@ -3,7 +3,7 @@ use crate::{
     types::{Bitboard, Color, Move, Piece, Square},
 };
 
-const PIECE_VALUES: [i32; Piece::NUM] = [100, 300, 300, 500, 900, 0];
+const PIECE_VALUES: [i32; Piece::NUM] = [100, 400, 400, 650, 1200, 0];
 
 impl super::SearchThread<'_> {
     /// Returns `true` if the static exchange evaluation of the given move


### PR DESCRIPTION
```
Elo   | 6.22 +- 5.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8876 W: 2302 L: 2143 D: 4431
Penta | [116, 1010, 2039, 1145, 128]
```