### PR TITLE
History tuning

### DIFF
--- a/src/search/selectivity.rs
+++ b/src/search/selectivity.rs
@@ -15,7 +15,7 @@ const LMR_MOVES_PLAYED: i32 = 3;
 const LMR_DEPTH: i32 = 3;
 const LMR_BASE: f64 = 0.75;
 const LMR_DIVISOR: f64 = 2.25;
-const LMR_HISTORY_DIVISOR: f64 = 6400.0;
+const LMR_HISTORY_DIVISOR: f64 = 6200.0;
 
 const QLMP_DEPTH: i32 = 4;
 const QLMP_QUIETS_PLAYED: i32 = 3;

--- a/src/tables/history.rs
+++ b/src/tables/history.rs
@@ -85,12 +85,12 @@ impl History {
 
 /// Returns the bonus for a move based on the depth of the search.
 fn bonus(depth: i32) -> i32 {
-    (150 * depth - 25).min(1780)
+    130 * depth.min(14) - 30
 }
 
 /// Returns the malus for a move based on the depth of the search.
 fn malus(depth: i32) -> i32 {
-    (160 * depth + 15).min(1800)
+    180 * depth.min(9) + 20
 }
 
 /// Updates the score of an entry using a gravity function.


### PR DESCRIPTION
```
Elo   | 5.92 +- 4.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9214 W: 2348 L: 2191 D: 4675
Penta | [100, 1051, 2187, 1130, 139]
```