### PR TITLE
Position check extensions before the move loop

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -79,6 +79,10 @@ impl super::SearchThread<'_> {
             }
         }
 
+        // Check extensions. Extend the search depth due to low branching
+        // and the possibility of being in a forced sequence of moves
+        depth += i32::from(in_check);
+
         let original_alpha = alpha;
         let mut best_score = -Score::INFINITY;
         let mut best_move = Move::NULL;
@@ -109,16 +113,13 @@ impl super::SearchThread<'_> {
                 continue;
             }
 
-            // Check extensions. Extend the search depth due to low branching
-            // and the possibility of being in a forced sequence of moves
-            let new_depth = depth + i32::from(in_check);
             let nodes_before = self.nodes.local();
 
             let score = if moves_played == 0 {
-                -self.alpha_beta::<PV, false>(-beta, -alpha, new_depth - 1)
+                -self.alpha_beta::<PV, false>(-beta, -alpha, depth - 1)
             } else {
                 let reduction = self.calculate_reduction::<PV>(mv, depth, moves_played);
-                self.principle_variation_search::<PV>(alpha, beta, new_depth, reduction, best_score)
+                self.principle_variation_search::<PV>(alpha, beta, depth, reduction, best_score)
             };
 
             self.board.undo_move::<true>();


### PR DESCRIPTION
```
Elo   | 3.86 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17660 W: 4449 L: 4253 D: 8958
Penta | [240, 2035, 4071, 2257, 227]
```