### PR TITLE
Ensure non-negative depth in the alpha-beta search

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -35,6 +35,8 @@ impl super::SearchThread<'_> {
             return self.quiescence_search(alpha, beta);
         }
 
+        depth = depth.max(0);
+
         // Update UCI statistics after the quiescence search to avoid counting the same node twice
         self.nodes.inc();
         self.sel_depth = self.sel_depth.max(self.board.ply);


### PR DESCRIPTION
This patch somehow does not affect the bench, but is functional. Nevertheless, it's a safety measure that should be in place, thus it has been tested with regression bounds instead.

```
Elo   | 2.96 +- 5.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 8926 W: 2256 L: 2180 D: 4490
Penta | [80, 960, 2317, 1016, 90]
```