### PR TITLE
Adjust time based on best move stability

### DIFF
--- a/src/search/deepening.rs
+++ b/src/search/deepening.rs
@@ -36,6 +36,8 @@ impl super::SearchThread<'_> {
             self.sel_depth = 0;
             self.finished_depth = depth;
 
+            self.time_manager.update(depth, result.best_move);
+
             let effort = self.node_table.get(result.best_move) as f64 / self.nodes.local() as f64;
             if self.time_manager.if_finished(depth, effort) {
                 break;

--- a/src/timeman.rs
+++ b/src/timeman.rs
@@ -59,7 +59,7 @@ impl TimeManager {
                 Limits::FixedNodes(nodes) => nodes.max(MIN_NODES),
                 _ => u64::MAX,
             },
-            stability: 0,
+            stability: 1,
             last_best_move: None,
         }
     }
@@ -75,7 +75,7 @@ impl TimeManager {
             self.stability += 1;
         } else {
             self.last_best_move = Some(best_move);
-            self.stability = 0;
+            self.stability = 1;
         }
     }
 
@@ -94,7 +94,7 @@ impl TimeManager {
             soft_bound *= (1.5 - effort) * NODE_TM_MULTIPLIER;
 
             // Adjust based on stability of the best move between iterations
-            soft_bound *= 0.75 + 0.75 / self.stability.min(6) as f64;
+            soft_bound *= 0.75 + 0.75 / self.stability.min(7) as f64;
         }
 
         self.start_time.elapsed() >= Duration::from_secs_f64(soft_bound)


### PR DESCRIPTION
```
Elo   | 4.74 +- 4.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12164 W: 3071 L: 2905 D: 6188
Penta | [123, 1370, 2975, 1446, 168]
```