### PR TITLE
Score stability in time management

### DIFF
--- a/src/search/deepening.rs
+++ b/src/search/deepening.rs
@@ -36,7 +36,7 @@ impl super::SearchThread<'_> {
             self.sel_depth = 0;
             self.finished_depth = depth;
 
-            self.time_manager.update(depth, result.best_move);
+            self.time_manager.update(depth, score, result.best_move);
 
             let effort = self.node_table.get(result.best_move) as f64 / self.nodes.local() as f64;
             if self.time_manager.if_finished(depth, effort) {


### PR DESCRIPTION
```
Elo   | 5.92 +- 4.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8808 W: 2332 L: 2182 D: 4294
Penta | [75, 982, 2164, 1084, 99]
```