### PR TITLE
Allocate a quiet move list on the stack

### DIFF
--- a/src/search/ordering.rs
+++ b/src/search/ordering.rs
@@ -10,7 +10,7 @@ impl super::SearchThread<'_> {
     pub fn build_ordering(&self, moves: &MoveList, tt_move: Option<Move>) -> [i32; MAX_MOVES] {
         let continuations = [1, 2].map(|ply| self.board.tail_move(ply));
         let mut ordering = [0; MAX_MOVES];
-        for index in 0..moves.length() {
+        for index in 0..moves.len() {
             ordering[index] = self.get_move_rating(moves[index], tt_move, &continuations);
         }
         ordering

--- a/src/types/movelist.rs
+++ b/src/types/movelist.rs
@@ -55,8 +55,12 @@ impl MoveList {
         Some(self.moves[self.length])
     }
 
+    pub fn as_slice(&self) -> &[Move] {
+        &self.moves[..self.length]
+    }
+
     /// Returns the number of moves in the list.
-    pub const fn length(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.length
     }
 


### PR DESCRIPTION
```
Elo   | 5.15 +- 3.73 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10940 W: 3061 L: 2899 D: 4980
Penta | [142, 1139, 2755, 1283, 151]
```