### PR TITLE
Tune NMP constants

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -213,8 +213,8 @@ impl super::SearchThread<'_> {
     /// If giving a free move to the opponent leads to a beta cutoff, it's highly likely
     /// to result in a cutoff after a real move is made, so the node can be pruned.
     pub fn null_move_pruning<const PV: bool>(&mut self, depth: i32, beta: i32, eval: i32) -> Option<i32> {
-        if depth >= NMP_DEPTH && eval > beta && !self.board.is_last_move_null() && self.board.has_non_pawn_material() {
-            let r = NMP_REDUCTION + depth / NMP_DIVISOR + ((eval - beta) / 200).min(3);
+        if depth >= 4 && eval > beta && !self.board.is_last_move_null() && self.board.has_non_pawn_material() {
+            let r = 3 + depth / 3 + ((eval - beta) / 200).min(4);
 
             self.board.make_null_move();
             let score = -self.alpha_beta::<PV, false>(-beta, -beta + 1, depth - r);

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -1,10 +1,6 @@
 pub const RFP_MARGIN: i32 = 75;
 pub const RFP_DEPTH: i32 = 7;
 
-pub const NMP_DEPTH: i32 = 3;
-pub const NMP_REDUCTION: i32 = 3;
-pub const NMP_DIVISOR: i32 = 4;
-
 pub const RAZORING_DEPTH: i32 = 4;
 pub const RAZORING_MARGIN: i32 = 220;
 pub const RAZORING_FIXED_MARGIN: i32 = 135;


### PR DESCRIPTION
```
Elo   | 6.86 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7492 W: 1979 L: 1831 D: 3682
Penta | [79, 852, 1753, 966, 96]
```