### PR TITLE
Implement output buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE    := reckless
-MODEL  := v3-72b3fc58.nnue
+MODEL  := v4-ae46ed54.nnue
 REPO   := https://github.com/codedeliveryservice/RecklessNetworks/raw/main
 
 ifeq ($(OS),Windows_NT)

--- a/src/board.rs
+++ b/src/board.rs
@@ -136,7 +136,7 @@ impl Board {
 
     /// Calculates the score of the current position from the perspective of the side to move.
     pub fn evaluate(&self) -> i32 {
-        let eval = self.nnue.evaluate(self.side_to_move);
+        let eval = self.nnue.evaluate(self.side_to_move, self.occupancies().count());
         // Clamp static evaluation within mate bounds
         eval.clamp(-Score::MATE_BOUND + 1, Score::MATE_BOUND - 1)
     }


### PR DESCRIPTION
```
Elo   | 3.03 +- 2.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 27152 W: 7242 L: 7005 D: 12905
Penta | [366, 3190, 6281, 3319, 420]
```

```
Elo   | 6.91 +- 4.56 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7296 W: 1939 L: 1794 D: 3563
Penta | [59, 852, 1714, 931, 92]
```

Aligning NNUE parameters gives an extra ~2.8% speedup on top of the network test.
