### PR TITLE
Treat non-winning captures as unfavorable in quiescence search

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -108,7 +108,7 @@ impl super::SearchThread<'_> {
         let mut moves_played = 0;
         let mut quiets = MoveList::default();
         let mut moves = self.board.generate_all_moves();
-        let mut ordering = self.build_ordering(&moves, entry.map(|entry| entry.mv));
+        let mut ordering = self.build_ordering(&moves, entry.map(|entry| entry.mv), 0);
 
         while let Some(mv) = moves.next(&mut ordering) {
             #[cfg(not(feature = "datagen"))]

--- a/src/search/ordering.rs
+++ b/src/search/ordering.rs
@@ -7,22 +7,22 @@ impl super::SearchThread<'_> {
     const BAD_NOISY: i32 = -100_000_000;
 
     /// Returns an array of move ratings for the specified move list.
-    pub fn build_ordering(&self, moves: &MoveList, tt_move: Option<Move>) -> [i32; MAX_MOVES] {
+    pub fn build_ordering(&self, moves: &MoveList, tt_move: Option<Move>, threshold: i32) -> [i32; MAX_MOVES] {
         let continuations = [1, 2].map(|ply| self.board.tail_move(ply));
         let mut ordering = [0; MAX_MOVES];
         for index in 0..moves.len() {
-            ordering[index] = self.get_move_rating(moves[index], tt_move, &continuations);
+            ordering[index] = self.get_move_rating(moves[index], tt_move, threshold, &continuations);
         }
         ordering
     }
 
     /// Returns the rating of the specified move.
-    fn get_move_rating(&self, mv: Move, tt_move: Option<Move>, continuations: &[FullMove; 2]) -> i32 {
+    fn get_move_rating(&self, mv: Move, tt_move: Option<Move>, threshold: i32, continuations: &[FullMove; 2]) -> i32 {
         if Some(mv) == tt_move {
             return Self::HASH_MOVE;
         }
         if mv.is_capture() {
-            let base = if self.see(mv, 0) { Self::GOOD_NOISY } else { Self::BAD_NOISY };
+            let base = if self.see(mv, threshold) { Self::GOOD_NOISY } else { Self::BAD_NOISY };
             return base + self.mvv_lva(mv);
         }
         if self.killers[self.ply] == mv {

--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -53,7 +53,7 @@ impl super::SearchThread<'_> {
         let mut best_score = eval;
 
         let mut moves = self.board.generate_capture_moves();
-        let mut ordering = self.build_ordering(&moves, None);
+        let mut ordering = self.build_ordering(&moves, None, 1);
 
         while let Some(mv) = moves.next(&mut ordering) {
             if !mv.is_capture() {


### PR DESCRIPTION
```
Elo   | 2.65 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 32768 W: 8356 L: 8106 D: 16306
Penta | [331, 3861, 7781, 4049, 362]
```