### PR TITLE
Simplify quiescence search by using TT score directly

### DIFF
--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 
 use super::parameters::OPT_PIECE_VALUES;
 use crate::{
-    tables::{Bound, Entry},
+    tables::Bound,
     types::{Move, Piece, Score, MAX_PLY},
 };
 
@@ -33,11 +33,10 @@ impl super::SearchThread<'_> {
             }
         }
 
-        let mut eval = self.board.evaluate();
-
-        if let Some(entry) = entry {
-            adjust_eval(&mut eval, &entry);
-        }
+        let eval = match entry {
+            Some(entry) => entry.score,
+            None => self.board.evaluate(),
+        };
 
         alpha = max(alpha, eval);
 
@@ -104,18 +103,5 @@ impl super::SearchThread<'_> {
         } else {
             OPT_PIECE_VALUES[piece]
         }
-    }
-}
-
-fn adjust_eval(eval: &mut i32, entry: &Entry) {
-    // If the TT entry has an exact bound or indicates that the current static evaluation
-    // exceeds a bound (lower or upper), we can believe that the TT score is more accurate
-    if match entry.bound {
-        Bound::Exact => true,
-        Bound::Lower => entry.score > *eval,
-        Bound::Upper => entry.score < *eval,
-    } && entry.score.abs() < Score::MATE_BOUND
-    {
-        *eval = entry.score;
     }
 }


### PR DESCRIPTION
```
Elo   | 0.02 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 27968 W: 6817 L: 6815 D: 14336
Penta | [285, 3387, 6642, 3381, 289]
```