### PR TITLE
Implement quiet SEE pruning

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -126,7 +126,9 @@ impl super::SearchThread<'_> {
                 }
 
                 // Static Exchange Evaluation Pruning. Skip moves that are losing material.
-                if mv.is_capture() && depth < SEE_DEPTH && !self.see(mv, -SEE_MARGIN * depth) {
+                if depth < SEE_DEPTH
+                    && !self.see(mv, -[SEE_QUIET_MARGIN, SEE_NOISY_MARGIN][mv.is_capture() as usize] * depth)
+                {
                     continue;
                 }
             }

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -24,7 +24,8 @@ pub const LMP_MARGIN: i32 = 3;
 pub const DEEPER_SEARCH_MARGIN: i32 = 80;
 pub const IIR_DEPTH: i32 = 4;
 
-pub const SEE_MARGIN: i32 = 100;
+pub const SEE_NOISY_MARGIN: i32 = 100;
+pub const SEE_QUIET_MARGIN: i32 = 70;
 pub const SEE_DEPTH: i32 = 6;
 
 pub struct Parameters {

--- a/src/search/see.rs
+++ b/src/search/see.rs
@@ -9,6 +9,10 @@ impl super::SearchThread<'_> {
     /// indicating that the sequence of captures on a single square, starting with the move,
     /// results in a non-negative balance for the side to move.
     pub fn see(&self, mv: Move, threshold: i32) -> bool {
+        if mv.is_promotion() || mv.is_castling() {
+            return true;
+        }
+
         // In the best case, we win a piece, but still end up with a negative balance
         let mut balance = self.move_value(mv) - threshold;
         if balance < 0 {

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -105,6 +105,10 @@ impl Move {
         matches!(self.kind(), MoveKind::EnPassant)
     }
 
+    pub const fn is_castling(&self) -> bool {
+        matches!(self.kind(), MoveKind::Castling)
+    }
+
     pub const fn promotion_piece(self) -> Option<Piece> {
         match self.kind() {
             MoveKind::PromotionN | MoveKind::PromotionCaptureN => Some(Piece::Knight),


### PR DESCRIPTION
```
Elo   | 5.95 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8812 W: 2191 L: 2040 D: 4581
Penta | [85, 984, 2128, 1113, 96]
```