### PR TITLE
Maintain a mailbox representation in addition to bitboards

### DIFF
--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -69,7 +69,7 @@ impl<'a> SearchThread<'a> {
 
     pub fn revert_null_move(&mut self) {
         self.ply -= 1;
-        self.board.undo_move::<false>();
+        self.board.undo_null_move();
     }
 
     pub fn apply_move(&mut self, mv: Move) -> bool {


### PR DESCRIPTION
```
Elo   | 11.78 +- 5.91 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3512 W: 901 L: 782 D: 1829
Penta | [23, 317, 956, 438, 22]
```

No functional change