### PR TITLE
Use the results of partial searches

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -98,7 +98,7 @@ fn iterative_deepening(mut thread: SearchThread, silent: bool) -> SearchResult {
     }
 
     if !silent {
-        println!("bestmove {current_move}");
+        println!("bestmove {}", thread.pv_table.best_move());
     }
 
     SearchResult {

--- a/src/search.rs
+++ b/src/search.rs
@@ -70,7 +70,6 @@ pub fn start(options: Options, board: &mut Board, history: &mut History, tt: &Tr
 fn iterative_deepening(mut thread: SearchThread, silent: bool) -> SearchResult {
     let now = Instant::now();
 
-    let mut current_move = Move::NULL;
     let mut current_score = 0;
 
     for depth in 1.. {
@@ -84,14 +83,13 @@ fn iterative_deepening(mut thread: SearchThread, silent: bool) -> SearchResult {
             print_uci_info(&thread, depth, score, now);
         }
 
-        current_move = thread.pv_table.best_move();
         current_score = score;
 
         thread.sel_depth = 0;
         thread.finished_depth = depth;
-        thread.time_manager.update(depth, score, current_move);
+        thread.time_manager.update(depth, score, thread.pv_table.best_move());
 
-        let effort = thread.node_table.get(current_move) as f64 / thread.nodes.local() as f64;
+        let effort = thread.node_table.get(thread.pv_table.best_move()) as f64 / thread.nodes.local() as f64;
         if thread.time_manager.if_finished(depth, effort) {
             break;
         }
@@ -102,7 +100,7 @@ fn iterative_deepening(mut thread: SearchThread, silent: bool) -> SearchResult {
     }
 
     SearchResult {
-        best_move: current_move,
+        best_move: thread.pv_table.best_move(),
         score: current_score,
         nodes: thread.nodes.global(),
     }


### PR DESCRIPTION
This patch uses the best move from the PV table, even if the search is aborted mid-iteration.

Passed fixed nodes:
```
Elo   | 18.93 +- 8.10 (95%)
SPRT  | N=20000 Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2296 W: 770 L: 645 D: 881
Penta | [34, 145, 698, 204, 67]
```

Passed STC regression:
```
Elo   | 4.33 +- 4.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 6426 W: 1556 L: 1476 D: 3394
Penta | [36, 627, 1804, 713, 33]
```
