### PR TITLE
Update network to v5-0aa6d222.nnue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE    := reckless
-MODEL  := v4-ae46ed54.nnue
+MODEL  := v5-0aa6d222.nnue
 REPO   := https://github.com/codedeliveryservice/RecklessNetworks/raw/main
 
 ifeq ($(OS),Windows_NT)

--- a/src/board.rs
+++ b/src/board.rs
@@ -138,7 +138,7 @@ impl Board {
 
     /// Calculates the score of the current position from the perspective of the side to move.
     pub fn evaluate(&self) -> i32 {
-        let mut eval = self.nnue.evaluate(self.side_to_move, self.occupancies().len());
+        let mut eval = self.nnue.evaluate(self.side_to_move);
 
         #[cfg(not(feature = "datagen"))]
         {


### PR DESCRIPTION
Following the data generation changes introduced in PR #72, the entire training dataset has been regenerated. The new dataset was produced using engine version a3f3afabd571fa866666d4c993a3f3c9317f6397 following a fixed nodes SPSA tuning session.

The architecture has been simplified by removing output buckets: `(768 -> 384)x2 -> 1`

Passed fixed nodes:
```
Elo   | 13.66 +- 7.33 (95%)
SPRT  | N=25000 Threads=1 Hash=32MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4352 W: 1420 L: 1249 D: 1683
Penta | [129, 461, 860, 562, 164]
```

Passed 20+0.2s:
```
Elo   | 13.93 +- 6.73 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3070 W: 827 L: 704 D: 1539
Penta | [21, 316, 740, 435, 23]
```