### PR TITLE
Introduce correction history

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -7,11 +7,11 @@ impl Board {
         self.move_stack.push(FullMove::NULL);
         self.state_stack.push(self.state);
 
-        self.state.hash ^= ZOBRIST.side;
-        self.state.hash ^= ZOBRIST.castling[self.state.castling];
+        self.state.hash_key ^= ZOBRIST.side;
+        self.state.hash_key ^= ZOBRIST.castling[self.state.castling];
 
         if self.state.en_passant != Square::None {
-            self.state.hash ^= ZOBRIST.en_passant[self.state.en_passant];
+            self.state.hash_key ^= ZOBRIST.en_passant[self.state.en_passant];
             self.state.en_passant = Square::None;
         }
     }
@@ -34,11 +34,11 @@ impl Board {
             self.nnue.push();
         }
 
-        self.state.hash ^= ZOBRIST.side;
-        self.state.hash ^= ZOBRIST.castling[self.state.castling];
+        self.state.hash_key ^= ZOBRIST.side;
+        self.state.hash_key ^= ZOBRIST.castling[self.state.castling];
 
         if self.state.en_passant != Square::None {
-            self.state.hash ^= ZOBRIST.en_passant[self.state.en_passant];
+            self.state.hash_key ^= ZOBRIST.en_passant[self.state.en_passant];
             self.state.en_passant = Square::None;
         }
 
@@ -62,7 +62,7 @@ impl Board {
         match mv.kind() {
             MoveKind::DoublePush => {
                 self.state.en_passant = Square::new((start as u8 + target as u8) / 2);
-                self.state.hash ^= ZOBRIST.en_passant[self.state.en_passant];
+                self.state.hash_key ^= ZOBRIST.en_passant[self.state.en_passant];
             }
             MoveKind::EnPassant => {
                 self.remove_piece::<NNUE>(!self.side_to_move, Piece::Pawn, target ^ 8);
@@ -80,7 +80,7 @@ impl Board {
         }
 
         self.state.castling.update(start, target);
-        self.state.hash ^= ZOBRIST.castling[self.state.castling];
+        self.state.hash_key ^= ZOBRIST.castling[self.state.castling];
         self.side_to_move = !self.side_to_move;
 
         if NNUE {

--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -56,7 +56,9 @@ impl FromStr for Board {
         board.state.castling = parts.next().unwrap_or_default().into();
         board.state.en_passant = parts.next().unwrap_or_default().try_into().unwrap_or_default();
         board.state.halfmove_clock = parts.next().unwrap_or_default().parse().unwrap_or_default();
-        board.state.hash = board.generate_hash_key();
+
+        board.state.hash_key = board.generate_hash_key();
+        board.state.pawn_key = board.generate_pawn_key();
 
         Ok(board)
     }

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -21,6 +21,8 @@ fn perft(board: &mut Board, depth: usize) -> u32 {
         }
 
         assert_eq!(board.generate_hash_key(), board.hash());
+        assert_eq!(board.generate_pawn_key(), board.pawn_key());
+
         nodes += if depth > 1 { perft(board, depth - 1) } else { 1 };
         board.undo_move::<false>();
     }

--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -22,7 +22,7 @@ impl super::SearchThread<'_> {
         let eval = match entry {
             Some(entry) if should_cutoff(entry, alpha, beta) => return entry.score,
             Some(entry) => entry.score,
-            None => self.board.evaluate(),
+            None => self.board.evaluate() + self.corrhist.get(self.board),
         };
 
         if eval > alpha {

--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -2,7 +2,7 @@ use super::{counter::AtomicCounter, ABORT_SIGNAL, NODES_GLOBAL};
 use crate::{
     board::Board,
     parameters::Parameters,
-    tables::{History, NodeTable, PrincipalVariationTable, TranspositionTable},
+    tables::{CorrectionHistory, History, NodeTable, PrincipalVariationTable, TranspositionTable},
     time::{Limits, TimeManager},
     types::{Move, MAX_PLY},
 };
@@ -19,6 +19,7 @@ pub struct SearchThread<'a> {
     pub board: &'a mut Board,
     /// Persistent between searches history table for move ordering.
     pub history: &'a mut History,
+    pub corrhist: &'a mut CorrectionHistory,
     /// Hash table with interior mutability for shared memory parallelism.
     pub tt: &'a TranspositionTable,
 
@@ -44,12 +45,19 @@ pub struct SearchThread<'a> {
 
 impl<'a> SearchThread<'a> {
     /// Creates a new search thread instance.
-    pub fn new(limits: Limits, board: &'a mut Board, history: &'a mut History, tt: &'a TranspositionTable) -> Self {
+    pub fn new(
+        limits: Limits,
+        board: &'a mut Board,
+        history: &'a mut History,
+        corrhist: &'a mut CorrectionHistory,
+        tt: &'a TranspositionTable,
+    ) -> Self {
         Self {
             time_manager: TimeManager::new(&ABORT_SIGNAL, limits),
             stopped: false,
             board,
             history,
+            corrhist,
             tt,
             killers: [Move::NULL; MAX_PLY],
             eval_stack: [0; MAX_PLY],

--- a/src/tables/correction.rs
+++ b/src/tables/correction.rs
@@ -1,0 +1,55 @@
+use crate::{board::Board, types::Color};
+
+const SCALE: i32 = 2000;
+const GRAIN: i32 = 250;
+const LIMIT: i32 = 32;
+
+#[derive(Clone, Default)]
+pub struct CorrectionHistory {
+    pawn: CorrectionTable,
+}
+
+impl CorrectionHistory {
+    pub fn get(&self, board: &Board) -> i32 {
+        self.pawn.get(board) / GRAIN
+    }
+
+    pub fn update(&mut self, board: &mut Board, depth: i32, delta: i32) {
+        update_entry(self.pawn.get_mut(board), depth, delta);
+    }
+}
+
+fn update_entry(entry: &mut i32, depth: i32, delta: i32) {
+    let weight = weight(depth);
+    let value = (*entry * (SCALE - weight) + delta * weight * GRAIN) / SCALE;
+
+    *entry = value.clamp(-LIMIT * GRAIN, LIMIT * GRAIN);
+}
+
+fn weight(depth: i32) -> i32 {
+    (3 * depth * depth + 6 * depth + 3).min(350)
+}
+
+#[derive(Clone)]
+struct CorrectionTable {
+    table: Box<[[i32; Self::SIZE]; Color::NUM]>,
+}
+
+impl CorrectionTable {
+    // The size has to be a power of two.
+    const SIZE: usize = 16384;
+
+    pub fn get(&self, board: &Board) -> i32 {
+        self.table[board.side_to_move()][board.pawn_key() as usize & (Self::SIZE - 1)]
+    }
+
+    pub fn get_mut(&mut self, board: &Board) -> &mut i32 {
+        &mut self.table[board.side_to_move()][board.pawn_key() as usize & (Self::SIZE - 1)]
+    }
+}
+
+impl Default for CorrectionTable {
+    fn default() -> Self {
+        Self { table: Box::new([[0; Self::SIZE]; Color::NUM]) }
+    }
+}

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -1,8 +1,10 @@
+pub mod correction;
 pub mod history;
 pub mod nodes;
 pub mod pv;
 pub mod transposition;
 
+pub use correction::*;
 pub use history::*;
 pub use nodes::*;
 pub use pv::*;

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use crate::{
     board::Board,
     search::{self, Options},
-    tables::{History, TranspositionTable},
+    tables::{CorrectionHistory, History, TranspositionTable},
     time::Limits,
 };
 
@@ -84,9 +84,10 @@ pub fn bench<const PRETTY: bool>(depth: i32) {
 
         let mut board = Board::new(position).unwrap();
         let mut history = History::default();
+        let mut corrhist = CorrectionHistory::default();
         let tt = TranspositionTable::default();
 
-        let result = search::start(options, &mut board, &mut history, &tt);
+        let result = search::start(options, &mut board, &mut history, &mut corrhist, &tt);
 
         nodes += result.nodes;
         index += 1;

--- a/src/tools/datagen.rs
+++ b/src/tools/datagen.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     board::Board,
     search::{self, Options, SearchResult},
-    tables::{History, TranspositionTable},
+    tables::{CorrectionHistory, History, TranspositionTable},
     time::Limits,
     tools::datagen::random::Random,
     types::{Color, Move},
@@ -144,11 +144,12 @@ fn generate_data(mut buf: BufWriter<File>, book: &[String]) {
 fn play_game(mut board: Board) -> (Vec<SearchResult>, f32) {
     let tt = TranspositionTable::default();
     let mut history = History::default();
+    let mut corrhist = CorrectionHistory::default();
     let mut entries = Vec::new();
     let mut draw_counter = 0;
 
     loop {
-        let entry = search::start(GENERATION_OPTIONS, &mut board, &mut history, &tt);
+        let entry = search::start(GENERATION_OPTIONS, &mut board, &mut history, &mut corrhist, &tt);
         let SearchResult { best_move, score, .. } = entry;
 
         draw_counter = if score.abs() <= DRAW_SCORE { draw_counter + 1 } else { 0 };
@@ -213,7 +214,8 @@ fn generate_random_opening(random: &mut Random, book: &[String]) -> Board {
 fn validation_score(board: &mut Board) -> i32 {
     let tt = TranspositionTable::default();
     let mut history = History::default();
-    search::start(VALIDATION_OPTIONS, board, &mut history, &tt).score
+    let mut corrhist = CorrectionHistory::default();
+    search::start(VALIDATION_OPTIONS, board, &mut history, &mut corrhist, &tt).score
 }
 
 /// Generates all legal moves for the given board.


### PR DESCRIPTION
Introduces a correction history table based on the pawn structure (using the Zobrist hash key of pawns) that tracks differences between static evaluations and search scores.

```
Elo   | 6.86 +- 4.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7244 W: 1837 L: 1694 D: 3713
Penta | [58, 815, 1743, 938, 68]
```