### PR TITLE
Fix a bug in futility pruning

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -68,8 +68,8 @@ impl super::SearchThread<'_> {
         }
 
         let eval = match entry {
+            _ if in_check => -Score::INFINITY,
             Some(entry) => entry.score,
-            None if in_check => -Score::INFINITY,
             None => self.board.evaluate() + self.corrhist.get(self.board),
         };
 
@@ -114,7 +114,11 @@ impl super::SearchThread<'_> {
             if !ROOT && moves_played > 0 && best_score > -Score::MATE_BOUND {
                 // Futility Pruning. Leave the node since later moves with worse history
                 // are unlikely to recover a score so far below alpha in very few moves.
-                if !PV && mv.is_quiet() && depth <= fp_depth() && eval + fp_margin() * depth + fp_fixed_margin() < alpha
+                if !PV
+                    && !in_check
+                    && mv.is_quiet()
+                    && depth <= fp_depth()
+                    && eval + fp_margin() * depth + fp_fixed_margin() < alpha
                 {
                     break;
                 }


### PR DESCRIPTION
This fix addresses an issue where futility pruning used a `-Score::INFINITY` value, causing the pruning to trigger unintentionally.

```
Elo   | 0.32 +- 4.76 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 6432 W: 1569 L: 1563 D: 3300
Penta | [70, 731, 1603, 747, 65]
```