### PR TITLE
Linear formula for correction history

### DIFF
--- a/src/tables/correction.rs
+++ b/src/tables/correction.rs
@@ -27,7 +27,7 @@ fn update_entry(entry: &mut i32, depth: i32, delta: i32) {
 }
 
 fn weight(depth: i32) -> i32 {
-    (3 * depth * depth + 6 * depth + 3).min(350)
+    (20 * depth + 10).min(250)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
```
Elo   | 3.38 +- 2.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20054 W: 4995 L: 4800 D: 10259
Penta | [176, 2352, 4786, 2527, 186]
```