### PR TITLE
Implement SEE pruning in quiescence search

### DIFF
--- a/src/search/quiescence.rs
+++ b/src/search/quiescence.rs
@@ -42,7 +42,7 @@ impl super::SearchThread<'_> {
         let mut ordering = self.build_ordering(&moves, None, 1);
 
         while let Some(mv) = moves.next(&mut ordering) {
-            if !mv.is_capture() {
+            if !self.board.see(mv, 0) {
                 continue;
             }
 


### PR DESCRIPTION
```
Elo   | 12.74 +- 6.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3602 W: 951 L: 819 D: 1832
Penta | [37, 378, 842, 504, 40]
```