### PR TITLE
Simplify pessimistic forward pruning

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,5 +1,4 @@
 pub const SEE_PIECE_VALUES: [i32; 7] = [100, 400, 400, 650, 1200, 0, 0];
-pub const OPT_PIECE_VALUES: [i32; 7] = [400, 750, 800, 1200, 1900, 0, 0];
 
 pub const LMR_MOVES_PLAYED: i32 = 3;
 pub const LMR_DEPTH: i32 = 3;


### PR DESCRIPTION
```
Elo   | 1.88 +- 3.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 11846 W: 2863 L: 2799 D: 6184
Penta | [98, 1352, 2961, 1412, 100]
```