### PR TITLE
Introduce minor correction history

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -25,6 +25,7 @@ const PHASE_WEIGHTS: [i32; Piece::NUM - 1] = [0, 3, 3, 5, 9];
 struct InternalState {
     hash_key: u64,
     pawn_key: u64,
+    minor_key: u64,
     en_passant: Square,
     castling: Castling,
     halfmove_clock: u8,
@@ -66,6 +67,10 @@ impl Board {
 
     pub const fn pawn_key(&self) -> u64 {
         self.state.pawn_key
+    }
+
+    pub const fn minor_key(&self) -> u64 {
+        self.state.minor_key
     }
 
     /// Returns a `Bitboard` for the specified `Color`.
@@ -147,6 +152,8 @@ impl Board {
 
         if piece == Piece::Pawn {
             self.state.pawn_key ^= ZOBRIST.pieces[color][piece][square];
+        } else if piece == Piece::Knight || piece == Piece::Bishop {
+            self.state.minor_key ^= ZOBRIST.pieces[color][piece][square];
         }
     }
 
@@ -302,6 +309,18 @@ impl Board {
         for color in [Color::White, Color::Black] {
             for square in self.of(Piece::Pawn, color) {
                 hash ^= ZOBRIST.pieces[color][Piece::Pawn][square];
+            }
+        }
+        hash
+    }
+
+    pub fn generate_minor_key(&self) -> u64 {
+        let mut hash = 0;
+        for color in [Color::White, Color::Black] {
+            for piece in [Piece::Knight, Piece::Bishop] {
+                for square in self.of(piece, color) {
+                    hash ^= ZOBRIST.pieces[color][piece][square];
+                }
             }
         }
         hash

--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -59,6 +59,7 @@ impl FromStr for Board {
 
         board.state.hash_key = board.generate_hash_key();
         board.state.pawn_key = board.generate_pawn_key();
+        board.state.minor_key = board.generate_minor_key();
 
         Ok(board)
     }

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -22,6 +22,7 @@ fn perft(board: &mut Board, depth: usize) -> u32 {
 
         assert_eq!(board.generate_hash_key(), board.hash());
         assert_eq!(board.generate_pawn_key(), board.pawn_key());
+        assert_eq!(board.generate_minor_key(), board.minor_key());
 
         nodes += if depth > 1 { perft(board, depth - 1) } else { 1 };
         board.undo_move::<false>();

--- a/src/tables/correction.rs
+++ b/src/tables/correction.rs
@@ -7,15 +7,17 @@ const LIMIT: i32 = 32;
 #[derive(Clone, Default)]
 pub struct CorrectionHistory {
     pawn: CorrectionTable,
+    minor: CorrectionTable,
 }
 
 impl CorrectionHistory {
     pub fn get(&self, board: &Board) -> i32 {
-        self.pawn.get(board) / GRAIN
+        (self.pawn.get(board, board.pawn_key()) + self.minor.get(board, board.minor_key())) / GRAIN
     }
 
     pub fn update(&mut self, board: &mut Board, depth: i32, delta: i32) {
-        update_entry(self.pawn.get_mut(board), depth, delta);
+        update_entry(self.pawn.get_mut(board, board.pawn_key()), depth, delta);
+        update_entry(self.minor.get_mut(board, board.minor_key()), depth, delta);
     }
 }
 
@@ -39,12 +41,12 @@ impl CorrectionTable {
     // The size has to be a power of two.
     const SIZE: usize = 16384;
 
-    pub fn get(&self, board: &Board) -> i32 {
-        self.table[board.side_to_move()][board.pawn_key() as usize & (Self::SIZE - 1)]
+    pub fn get(&self, board: &Board, key: u64) -> i32 {
+        self.table[board.side_to_move()][key as usize & (Self::SIZE - 1)]
     }
 
-    pub fn get_mut(&mut self, board: &Board) -> &mut i32 {
-        &mut self.table[board.side_to_move()][board.pawn_key() as usize & (Self::SIZE - 1)]
+    pub fn get_mut(&mut self, board: &Board, key: u64) -> &mut i32 {
+        &mut self.table[board.side_to_move()][key as usize & (Self::SIZE - 1)]
     }
 }
 


### PR DESCRIPTION
Introduces a minor correction history table based for minor pieces (knights and bishops), similar to the pawn structure-based correction introduced in #75.

```
Elo   | 8.21 +- 4.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5628 W: 1403 L: 1270 D: 2955
Penta | [45, 585, 1440, 680, 64]
```