### PR TITLE
Introduce major correction history

### DIFF
--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -60,6 +60,7 @@ impl FromStr for Board {
         board.state.hash_key = board.generate_hash_key();
         board.state.pawn_key = board.generate_pawn_key();
         board.state.minor_key = board.generate_minor_key();
+        board.state.major_key = board.generate_major_key();
 
         Ok(board)
     }

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -23,6 +23,7 @@ fn perft(board: &mut Board, depth: usize) -> u32 {
         assert_eq!(board.generate_hash_key(), board.hash());
         assert_eq!(board.generate_pawn_key(), board.pawn_key());
         assert_eq!(board.generate_minor_key(), board.minor_key());
+        assert_eq!(board.generate_major_key(), board.major_key());
 
         nodes += if depth > 1 { perft(board, depth - 1) } else { 1 };
         board.undo_move::<false>();

--- a/src/tables/correction.rs
+++ b/src/tables/correction.rs
@@ -8,16 +8,22 @@ const LIMIT: i32 = 32;
 pub struct CorrectionHistory {
     pawn: CorrectionTable,
     minor: CorrectionTable,
+    major: CorrectionTable,
 }
 
 impl CorrectionHistory {
     pub fn get(&self, board: &Board) -> i32 {
-        (self.pawn.get(board, board.pawn_key()) + self.minor.get(board, board.minor_key())) / GRAIN
+        let correction = self.pawn.get(board, board.pawn_key())
+            + self.minor.get(board, board.minor_key())
+            + self.major.get(board, board.major_key());
+
+        correction / GRAIN
     }
 
     pub fn update(&mut self, board: &mut Board, depth: i32, delta: i32) {
         update_entry(self.pawn.get_mut(board, board.pawn_key()), depth, delta);
         update_entry(self.minor.get_mut(board, board.minor_key()), depth, delta);
+        update_entry(self.major.get_mut(board, board.major_key()), depth, delta);
     }
 }
 


### PR DESCRIPTION
Introduces a correction history table based on major pieces (rooks and queens), following the ideas of #75 and #80.

```
Elo   | 6.87 +- 4.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7132 W: 1759 L: 1618 D: 3755
Penta | [46, 815, 1740, 882, 83]
```