### PR TITLE
Perform razoring before NMP

### DIFF
--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -84,14 +84,14 @@ impl super::SearchThread<'_> {
                 return eval;
             }
 
-            // Null Move Pruning
-            if let Some(score) = self.null_move_pruning::<PV>(depth, beta, eval) {
-                return score;
-            }
-
             // Razoring
             if depth <= razoring_depth() && eval + razoring_margin() * depth + razoring_fixed_margin() < alpha {
                 return self.quiescence_search(alpha, beta);
+            }
+
+            // Null Move Pruning
+            if let Some(score) = self.null_move_pruning::<PV>(depth, beta, eval) {
+                return score;
             }
         }
 


### PR DESCRIPTION
Perform razoring before null move pruning, as it is much cheaper.

```
Elo   | 4.17 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12152 W: 2989 L: 2843 D: 6320
Penta | [72, 1166, 3471, 1278, 89]
```