### PR TITLE
Update network to v6-eee46357.nnue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE    := reckless
-MODEL  := v5-0aa6d222.nnue
+MODEL  := v6-eee46357.nnue
 REPO   := https://github.com/codedeliveryservice/RecklessNetworks/raw/main
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
After running several training experiments, the new network has finally been trained using a two-staged process, with the WDL doubled from `0.25` to `0.5` in the second stage. Additionally, the weight initialization now follows a normal distribution, and the weight decay has been reduced from `0.1` to `0.01`.

Passed fixed nodes:
```
Elo   | 5.14 +- 3.91 (95%)
SPRT  | N=25000 Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 14810 W: 4556 L: 4337 D: 5917
Penta | [453, 1665, 2982, 1820, 485]
```

Passed STC:
```
Elo   | 8.10 +- 5.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6092 W: 1625 L: 1483 D: 2984
Penta | [64, 685, 1417, 805, 75]
```