### PR TITLE
Introduce non-pawn correction history

### DIFF
--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -61,6 +61,7 @@ impl FromStr for Board {
         board.state.pawn_key = board.generate_pawn_key();
         board.state.minor_key = board.generate_minor_key();
         board.state.major_key = board.generate_major_key();
+        board.state.non_pawn_keys = board.generate_non_pawn_keys();
 
         Ok(board)
     }

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -1,3 +1,5 @@
+use crate::types::Color;
+
 use super::Board;
 
 macro_rules! assert_perft {
@@ -24,6 +26,11 @@ fn perft(board: &mut Board, depth: usize) -> u32 {
         assert_eq!(board.generate_pawn_key(), board.pawn_key());
         assert_eq!(board.generate_minor_key(), board.minor_key());
         assert_eq!(board.generate_major_key(), board.major_key());
+
+        assert_eq!(
+            board.generate_non_pawn_keys(),
+            [board.non_pawn_key(Color::White), board.non_pawn_key(Color::Black)]
+        );
 
         nodes += if depth > 1 { perft(board, depth - 1) } else { 1 };
         board.undo_move::<false>();

--- a/src/tables/correction.rs
+++ b/src/tables/correction.rs
@@ -9,13 +9,17 @@ pub struct CorrectionHistory {
     pawn: CorrectionTable,
     minor: CorrectionTable,
     major: CorrectionTable,
+    non_pawn_white: CorrectionTable,
+    non_pawn_black: CorrectionTable,
 }
 
 impl CorrectionHistory {
     pub fn get(&self, board: &Board) -> i32 {
         let correction = self.pawn.get(board, board.pawn_key())
             + self.minor.get(board, board.minor_key())
-            + self.major.get(board, board.major_key());
+            + self.major.get(board, board.major_key())
+            + self.non_pawn_white.get(board, board.non_pawn_key(Color::White))
+            + self.non_pawn_black.get(board, board.non_pawn_key(Color::Black));
 
         correction / GRAIN
     }
@@ -24,6 +28,8 @@ impl CorrectionHistory {
         update_entry(self.pawn.get_mut(board, board.pawn_key()), depth, delta);
         update_entry(self.minor.get_mut(board, board.minor_key()), depth, delta);
         update_entry(self.major.get_mut(board, board.major_key()), depth, delta);
+        update_entry(self.non_pawn_white.get_mut(board, board.non_pawn_key(Color::White)), depth, delta);
+        update_entry(self.non_pawn_black.get_mut(board, board.non_pawn_key(Color::Black)), depth, delta);
     }
 }
 


### PR DESCRIPTION
Yet another correction history, now combining minor and major corrections, separated by color.

```
Elo   | 8.04 +- 4.95 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5792 W: 1429 L: 1295 D: 3068
Penta | [31, 668, 1391, 748, 58]
```