### PR TITLE
Simplify principal variation search

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,8 +1,5 @@
 pub const PIECE_VALUES: [i32; 7] = [100, 400, 400, 650, 1200, 0, 0];
 
-pub const LMR_MOVES_PLAYED: i32 = 3;
-pub const LMR_DEPTH: i32 = 3;
-
 pub const LMP_DEPTH: i32 = 4;
 pub const LMP_MARGIN: i32 = 3;
 

--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -148,16 +148,21 @@ impl super::SearchThread<'_> {
 
             let nodes_before = self.nodes.local();
 
-            let new_depth = depth - 1;
+            let mut new_depth = depth - 1;
             let mut score = 0;
 
             if depth >= 3 && moves_played >= 3 {
                 let r = self.calculate_reduction::<PV>(mv, depth, moves_played, improving, &entry);
+                let d = new_depth - r;
 
-                score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, new_depth - r);
+                score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, d);
 
                 if score > alpha && r > 0 {
-                    score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, new_depth);
+                    new_depth += i32::from(score > best_score + search_deeper_margin());
+
+                    if new_depth > d {
+                        score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, new_depth);
+                    }
                 }
             } else if !PV || moves_played > 0 {
                 score = -self.alpha_beta::<false, false>(-alpha - 1, -alpha, new_depth);


### PR DESCRIPTION
Refactor PVS implementation and remove the `score < beta` condition on full window searches.

```
Elo   | 1.80 +- 3.49 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 12362 W: 2988 L: 2924 D: 6450
Penta | [127, 1468, 2926, 1534, 126]
```

Bench: 1595229