### PR TITLE
Bulk simplification

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -73,14 +73,13 @@ define!(
 
     i32 search_deeper_margin: 80, 0, 160;
 
-    i32 see_depth: 6, 1, 112;
-    i32 see_noisy_margin: 100, 50, 150;
-    i32 see_quiet_margin: 70, 50, 150;
+    i32 see_noisy: 100, 50, 150;
+    i32 see_quiet: 70, 50, 150;
 
     i32 iir_depth: 4, 1, 10;
 
     i32 aspiration_depth: 6, 1, 12;
-    i32 aspiration_delta: 30, 15, 45;
+    i32 aspiration_delta: 15, 5, 25;
 
     f64 lmr_base: 0.73, 0.5, 1.5;
     f64 lmr_divisor: 2.22, 1.5, 3.5;

--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -127,9 +127,7 @@ impl super::SearchThread<'_> {
                 }
 
                 // Static Exchange Evaluation Pruning. Skip moves that are losing material.
-                if depth < see_depth()
-                    && !self.board.see(mv, -[see_quiet_margin(), see_noisy_margin()][mv.is_capture() as usize] * depth)
-                {
+                if !self.board.see(mv, -[see_quiet(), see_noisy()][mv.is_capture() as usize] * depth) {
                     continue;
                 }
             }

--- a/src/search/aspiration.rs
+++ b/src/search/aspiration.rs
@@ -8,7 +8,7 @@ impl SearchThread<'_> {
             return self.search::<true, true>(-Score::INFINITY, Score::INFINITY, depth);
         }
 
-        let mut delta = (aspiration_delta() - depth).max(10);
+        let mut delta = aspiration_delta();
         let mut alpha = (score - delta).max(-Score::INFINITY);
         let mut beta = (score + delta).min(Score::INFINITY);
         let mut fail_high_count = 0;


### PR DESCRIPTION
- Remove depth based aspiration delta adjustment
- Remove SEE pruning depth margin

```
Elo   | 8.30 +- 6.07 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 4146 W: 1047 L: 948 D: 2151
Penta | [41, 463, 973, 548, 48]
```

Bench: 1475393