### PR TITLE
Order noisy moves by MVV-LVA

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     datagen(std::env::args());
 
     match std::env::args().nth(1).as_deref() {
-        Some("bench") => tools::bench::<false>(2),
+        Some("bench") => tools::bench::<false>(4),
         _ => uci::message_loop(),
     }
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -44,7 +44,17 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>) -> [i32; MAX_
     let mut scores = [0; MAX_MOVES];
 
     for (i, &mv) in moves.iter().enumerate() {
-        scores[i] = 0;
+        if mv.is_noisy() {
+            let moving = td.board.piece_on(mv.from()).piece_type();
+            let captured = td.board.piece_on(mv.to()).piece_type();
+
+            scores[i] = 1 << 20;
+
+            scores[i] += captured as i32 * 16384;
+            scores[i] -= moving as i32;
+        } else {
+            scores[i] = 0;
+        }
     }
 
     scores

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,1 +1,1 @@
-pub const PIECE_VALUES: [i32; 7] = [100, 400, 400, 650, 1200, 0, 0];
+pub const PIECE_VALUES: [i32; 7] = [100, 400, 400, 650, 1250, 0, 0];

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -52,6 +52,10 @@ impl Move {
         unsafe { mem::transmute((self.0 >> 12) as u8) }
     }
 
+    pub fn is_noisy(self) -> bool {
+        (self.is_capture() && !self.is_promotion()) || self.promotion_piece() == Some(PieceType::Queen)
+    }
+
     pub const fn is_capture(self) -> bool {
         (self.0 >> 14) & 1 != 0
     }


### PR DESCRIPTION
```
Elo   | 615.41 +- 379.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.10 (-2.25, 2.89) [0.00, 10.00]
Games | N: 160 W: 155 L: 4 D: 1
Penta | [0, 0, 4, 1, 75]
```

Bench: 1894317