### PR TITLE
Introduce principal variation search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -94,11 +94,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
         let mut score = Score::ZERO;
 
-        if move_count > 1 {
+        if !PV || move_count > 1 {
             score = -search::<false>(td, -alpha - 1, -alpha, depth - 1);
         }
 
-        if move_count == 1 || (alpha < score && score < beta) {
+        if PV && (move_count == 1 || score > alpha) {
             score = -search::<true>(td, -beta, -alpha, depth - 1);
         }
 


### PR DESCRIPTION
```
Elo   | 11.51 +- 8.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 10.00]
Games | N: 3230 W: 1291 L: 1184 D: 755
Penta | [139, 222, 809, 283, 162]
```

Bench: 2836157