### PR TITLE
Add reverse futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -77,6 +77,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         }
     }
 
+    let eval = if in_check { Score::NONE } else { td.board.evaluate() };
+
+    if !PV && !in_check && depth <= 8 && eval - 80 * depth >= beta {
+        return eval;
+    }
+
     let mut best_score = -Score::INFINITE;
     let mut best_move = Move::NULL;
 


### PR DESCRIPTION
```
Elo   | 72.88 +- 27.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 10.00]
Games | N: 474 W: 231 L: 133 D: 110
Penta | [18, 27, 81, 61, 50]
```

Bench: 1104301