### PR TITLE
Add quiet butterfly history

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,22 @@
+use crate::{board::Board, types::Move};
+
+pub struct MainHistory {
+    // [side_to_move][from_to]
+    entries: Box<[[i32; 64 * 64]; 2]>,
+}
+
+impl MainHistory {
+    pub fn get(&self, board: &Board, mv: Move) -> i32 {
+        self.entries[board.side_to_move()][mv.from_to()]
+    }
+
+    pub fn update(&mut self, board: &Board, mv: Move, depth: i32) {
+        self.entries[board.side_to_move()][mv.from_to()] += depth;
+    }
+}
+
+impl Default for MainHistory {
+    fn default() -> Self {
+        MainHistory { entries: Box::new([[0; 64 * 64]; 2]) }
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,16 +9,25 @@ pub struct MainHistory {
 }
 
 impl MainHistory {
+    const MAX_HISTORY: i32 = 8192;
+
     pub fn get(&self, board: &Board, mv: Move) -> i32 {
         self.entries[board.side_to_move()][mv.from_to()]
     }
 
     pub fn update(&mut self, board: &Board, best_move: Move, quiet_moves: ArrayVec<Move, 32>, depth: i32) {
-        self.entries[board.side_to_move()][best_move.from_to()] += depth;
+        let bonus = 32 * depth;
 
-        for mv in quiet_moves.iter() {
-            self.entries[board.side_to_move()][mv.from_to()] -= depth;
+        self.update_single(board, best_move, bonus);
+
+        for &mv in quiet_moves.iter() {
+            self.update_single(board, mv, -bonus);
         }
+    }
+
+    fn update_single(&mut self, board: &Board, mv: Move, bonus: i32) {
+        let entry = &mut self.entries[board.side_to_move()][mv.from_to()];
+        *entry += bonus - bonus.abs() * (*entry) / Self::MAX_HISTORY;
     }
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,4 +1,7 @@
-use crate::{board::Board, types::Move};
+use crate::{
+    board::Board,
+    types::{ArrayVec, Move},
+};
 
 pub struct MainHistory {
     // [side_to_move][from_to]
@@ -10,8 +13,12 @@ impl MainHistory {
         self.entries[board.side_to_move()][mv.from_to()]
     }
 
-    pub fn update(&mut self, board: &Board, mv: Move, depth: i32) {
-        self.entries[board.side_to_move()][mv.from_to()] += depth;
+    pub fn update(&mut self, board: &Board, best_move: Move, quiet_moves: ArrayVec<Move, 32>, depth: i32) {
+        self.entries[board.side_to_move()][best_move.from_to()] += depth;
+
+        for mv in quiet_moves.iter() {
+            self.entries[board.side_to_move()][mv.from_to()] -= depth;
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code, unused_variables)]
 
 mod board;
+mod history;
 mod lookup;
 mod misc;
 mod movepick;
@@ -19,7 +20,7 @@ fn main() {
     datagen(std::env::args());
 
     match std::env::args().nth(1).as_deref() {
-        Some("bench") => tools::bench::<false>(5),
+        Some("bench") => tools::bench::<false>(6),
         _ => uci::message_loop(),
     }
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -58,7 +58,7 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>, tt_move: Move
             scores[i] += captured as i32 * 16384;
             scores[i] -= moving as i32;
         } else {
-            scores[i] = 0;
+            scores[i] = td.main_history.get(&td.board, mv);
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,7 +4,7 @@ use crate::{
     movepick::MovePicker,
     tables::Bound,
     thread::ThreadData,
-    types::{mated_in, Move, Score, MAX_PLY},
+    types::{mated_in, ArrayVec, Move, Score, MAX_PLY},
 };
 
 pub fn start(td: &mut ThreadData, silent: bool) {
@@ -86,6 +86,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
     let mut best_score = -Score::INFINITE;
     let mut best_move = Move::NULL;
 
+    let mut quiet_moves = ArrayVec::<Move, 32>::new();
+
     let mut move_count = 0;
     let mut move_picker = MovePicker::new(td, tt_move);
 
@@ -126,12 +128,16 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
                 }
 
                 if score >= beta {
-                    update_histories(td, mv, depth);
+                    update_histories(td, best_move, quiet_moves, depth);
                     break;
                 }
 
                 alpha = score;
             }
+        }
+
+        if mv != best_move && move_count < 32 && !mv.is_noisy() {
+            quiet_moves.push(mv);
         }
     }
 
@@ -211,10 +217,10 @@ fn qsearch(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i32 {
     best_score
 }
 
-fn update_histories(td: &mut ThreadData, mv: Move, depth: i32) {
-    if mv.is_noisy() {
+fn update_histories(td: &mut ThreadData, best_move: Move, quiet_moves: ArrayVec<Move, 32>, depth: i32) {
+    if best_move.is_noisy() {
         return;
     }
 
-    td.main_history.update(&td.board, mv, depth);
+    td.main_history.update(&td.board, best_move, quiet_moves, depth);
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -126,6 +126,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
                 }
 
                 if score >= beta {
+                    update_histories(td, mv, depth);
                     break;
                 }
 
@@ -208,4 +209,12 @@ fn qsearch(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i32 {
     }
 
     best_score
+}
+
+fn update_histories(td: &mut ThreadData, mv: Move, depth: i32) {
+    if mv.is_noisy() {
+        return;
+    }
+
+    td.main_history.update(&td.board, mv, depth);
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     board::Board,
+    history::MainHistory,
     tables::{PrincipalVariationTable, TranspositionTable},
     time::{Limits, TimeManager},
     types::{is_loss, is_win, Score},
@@ -51,6 +52,7 @@ pub struct ThreadData<'a> {
     pub board: Board,
     pub time_manager: TimeManager,
     pub pv: PrincipalVariationTable,
+    pub main_history: MainHistory,
     pub stopped: bool,
     pub nodes: u64,
     pub completed_depth: i32,
@@ -65,6 +67,7 @@ impl<'a> ThreadData<'a> {
             board: Board::starting_position(),
             time_manager: TimeManager::new(Limits::Infinite),
             pv: PrincipalVariationTable::default(),
+            main_history: MainHistory::default(),
             stopped: false,
             nodes: 0,
             completed_depth: 0,

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -48,6 +48,10 @@ impl Move {
         unsafe { mem::transmute(((self.0 & 0b0000_1111_1100_0000) >> 6) as u8) }
     }
 
+    pub const fn from_to(self) -> usize {
+        (self.0 & 0b0000_1111_1111_1111) as usize
+    }
+
     pub const fn kind(self) -> MoveKind {
         unsafe { mem::transmute((self.0 >> 12) as u8) }
     }


### PR DESCRIPTION
Butterfly history
```
Elo   | 104.03 +- 21.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 564 W: 273 L: 109 D: 182
Penta | [3, 28, 104, 96, 51]
```

History malus
```
Elo   | 36.13 +- 12.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1496 W: 548 L: 393 D: 555
Penta | [38, 124, 299, 219, 68]
```

Gravity formula
```
Elo   | 23.47 +- 9.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2224 W: 752 L: 602 D: 870
Penta | [48, 203, 487, 299, 75]
```