### PR TITLE
Improve history formula

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -3,6 +3,10 @@ use crate::{
     types::{ArrayVec, Move},
 };
 
+fn bonus(depth: i32) -> i32 {
+    (128 * depth - 64).min(1280)
+}
+
 pub struct MainHistory {
     // [side_to_move][from_to]
     entries: Box<[[i32; 64 * 64]; 2]>,
@@ -16,7 +20,7 @@ impl MainHistory {
     }
 
     pub fn update(&mut self, board: &Board, best_move: Move, quiet_moves: ArrayVec<Move, 32>, depth: i32) {
-        let bonus = 32 * depth;
+        let bonus = bonus(depth);
 
         self.update_single(board, best_move, bonus);
 


### PR DESCRIPTION
```
Elo   | 6.66 +- 4.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9646 W: 2940 L: 2755 D: 3951
Penta | [253, 1051, 2064, 1168, 287]
```

Bench: 1662399