### PR TITLE
Do accumulator updates only on legal moves

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -85,12 +85,17 @@ impl Board {
         self.state.hash_key ^= ZOBRIST.castling[self.state.castling];
         self.side_to_move = !self.side_to_move;
 
+        let king = self.their(PieceType::King).lsb();
+        if self.is_square_attacked_by(king, self.side_to_move) {
+            self.nnue.clear_buffers();
+            return false;
+        }
+
         if NNUE {
             self.nnue.commit();
         }
 
-        let king = self.their(PieceType::King).lsb();
-        !self.is_square_attacked_by(king, self.side_to_move)
+        true
     }
 
     pub fn undo_move<const NNUE: bool>(&mut self) {

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -59,6 +59,10 @@ impl Network {
             _ => panic!(),
         }
 
+        self.clear_buffers();
+    }
+
+    pub fn clear_buffers(&mut self) {
         self.adds.clear();
         self.subs.clear();
     }


### PR DESCRIPTION
```
Elo   | 6.19 +- 4.30 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9378 W: 3015 L: 2848 D: 3515
Penta | [205, 818, 2511, 915, 240]
```

Bench: 1662399