### PR TITLE
Perform TT cutoffs only in non-PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -65,7 +65,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
     let tt_move = entry.map(|entry| entry.mv).unwrap_or(Move::NULL);
 
     if let Some(entry) = entry {
-        if !is_root
+        if !PV
             && entry.depth >= depth
             && match entry.bound {
                 Bound::Upper => entry.score <= alpha,


### PR DESCRIPTION
```
Elo   | 69.70 +- 17.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 788 W: 342 L: 186 D: 260
Penta | [8, 66, 139, 124, 57]
```

Bench: 1582508