### PR TITLE
Add null move pruning

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -112,7 +112,7 @@ impl Board {
     /// Returns `true` if the current side to move has non-pawn material.
     ///
     /// This method is used to minimize the risk of zugzwang when considering the Null Move Heuristic.
-    pub fn has_non_pawn_material(&self) -> bool {
+    pub fn has_non_pawns(&self) -> bool {
         self.our(PieceType::Pawn) | self.our(PieceType::King) != self.us()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     datagen(std::env::args());
 
     match std::env::args().nth(1).as_deref() {
-        Some("bench") => tools::bench::<false>(6),
+        Some("bench") => tools::bench::<false>(7),
         _ => uci::message_loop(),
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -90,7 +90,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         && td.stack[td.ply - 1].mv != Move::NULL
         && td.board.has_non_pawns()
     {
-        let r = 3;
+        let r = 3 + depth / 3 + ((eval - beta) / 256).min(3);
 
         td.stack[td.ply].mv = Move::NULL;
         td.board.make_null_move();


### PR DESCRIPTION
Basic null move pruning
```
Elo   | 24.17 +- 10.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2174 W: 801 L: 650 D: 723
Penta | [56, 193, 470, 280, 88]
```

Dynamic reduction
```
Elo   | 60.68 +- 16.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 908 W: 387 L: 230 D: 291
Penta | [15, 63, 186, 130, 60]
```