### PR TITLE
Preserve existing TT moves when applicable

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -120,9 +120,12 @@ impl TranspositionTable {
         }
 
         let key = verification_key(hash);
-        let entry = InternalEntry { key, depth: depth as u8, score: score as i16, bound, mv };
+        let entry = self.entry(hash);
+        let stored = entry.load();
 
-        self.entry(hash).write(entry);
+        let mv = if stored.key == key && mv == Move::NULL { stored.mv } else { mv };
+
+        entry.write(InternalEntry { key, depth: depth as u8, score: score as i16, bound, mv });
     }
 
     pub fn prefetch(&self, hash: u64) {


### PR DESCRIPTION
```
Elo   | 38.88 +- 12.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1310 W: 485 L: 339 D: 486
Penta | [24, 112, 267, 198, 54]
```

Bench: 2747704