### PR TITLE
Prevent dropping into qsearch when in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -40,7 +40,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
     td.pv.clear(td.ply);
 
-    if depth <= 0 {
+    if depth <= 0 && !in_check {
         return qsearch(td, alpha, beta);
     }
 
@@ -60,6 +60,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
             return if in_check { Score::DRAW } else { td.board.evaluate() };
         }
     }
+
+    let depth = depth.max(1);
 
     let entry = td.tt.read(td.board.hash(), td.ply);
     let tt_move = entry.map(|entry| entry.mv).unwrap_or(Move::NULL);


### PR DESCRIPTION
```
Elo   | 31.22 +- 11.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1618 W: 589 L: 444 D: 585
Penta | [31, 141, 357, 212, 68]
```

Bench: 2838295