### PR TITLE
Use proper MVV values

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -50,11 +50,13 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>, tt_move: Move
         }
 
         if mv.is_noisy() {
+            const MVV_VALUES: [i32; 7] = [0, 1, 1, 2, 3, 0, 0];
+
             let captured = td.board.piece_on(mv.to()).piece_type();
 
             scores[i] = 1 << 20;
 
-            scores[i] += captured as i32 * 16384;
+            scores[i] += MVV_VALUES[captured] * 16384;
 
             scores[i] += td.noisy_history.get(&td.board, mv);
         } else {


### PR DESCRIPTION
```
Elo   | 0.33 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.97 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 23322 W: 7323 L: 7301 D: 8698
Penta | [509, 2248, 6141, 2238, 525]
```

Passes [-5, 0] with 2.93 LLR

Bench: 2819315