### PR TITLE
Introduce late move reductions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     datagen(std::env::args());
 
     match std::env::args().nth(1).as_deref() {
-        Some("bench") => tools::bench::<false>(7),
+        Some("bench") => tools::bench::<false>(10),
         _ => uci::message_loop(),
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -56,6 +56,7 @@ pub struct ThreadData<'a> {
     pub pv: PrincipalVariationTable,
     pub quiet_history: QuietHistory,
     pub noisy_history: NoisyHistory,
+    pub lmr: LmrTable,
     pub stopped: bool,
     pub nodes: u64,
     pub completed_depth: i32,
@@ -73,6 +74,7 @@ impl<'a> ThreadData<'a> {
             pv: PrincipalVariationTable::default(),
             quiet_history: QuietHistory::default(),
             noisy_history: NoisyHistory::default(),
+            lmr: LmrTable::default(),
             stopped: false,
             nodes: 0,
             completed_depth: 0,
@@ -179,5 +181,30 @@ impl Index<usize> for Stack {
 impl IndexMut<usize> for Stack {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.data[index]
+    }
+}
+
+pub struct LmrTable {
+    table: [[i32; 64]; 64],
+}
+
+impl LmrTable {
+    pub fn reduction(&self, depth: i32, move_count: i32) -> i32 {
+        self.table[depth.min(63) as usize][move_count.min(63) as usize]
+    }
+}
+
+impl Default for LmrTable {
+    fn default() -> Self {
+        let mut table = [[0; 64]; 64];
+
+        for depth in 1..64 {
+            for move_count in 1..64 {
+                let reduction = 820.0 + 455.0 * (depth as f32).ln() * (move_count as f32).ln();
+                table[depth][move_count] = reduction as i32;
+            }
+        }
+
+        Self { table }
     }
 }


### PR DESCRIPTION
```
Elo   | 127.73 +- 20.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 520 W: 259 L: 76 D: 185
Penta | [4, 13, 80, 122, 41]
```

Bench: 2933603