### PR TITLE
Sometimes mix MVV values with noisy history

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -1,4 +1,5 @@
 use crate::{
+    parameters::PIECE_VALUES,
     thread::ThreadData,
     types::{ArrayVec, Move, MAX_MOVES},
 };
@@ -50,13 +51,11 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>, tt_move: Move
         }
 
         if mv.is_noisy() {
-            const MVV_VALUES: [i32; 7] = [0, 1, 1, 2, 3, 0, 0];
-
             let captured = td.board.piece_on(mv.to()).piece_type();
 
             scores[i] = 1 << 20;
 
-            scores[i] += MVV_VALUES[captured] * 16384;
+            scores[i] += PIECE_VALUES[captured as usize % 6] * 32;
 
             scores[i] += td.noisy_history.get(&td.board, mv);
         } else {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,1 +1,1 @@
-pub const PIECE_VALUES: [i32; 7] = [100, 400, 400, 650, 1250, 0, 0];
+pub const PIECE_VALUES: [i32; 7] = [100, 375, 400, 625, 1200, 0, 0];


### PR DESCRIPTION
```
Elo   | -0.31 +- 1.74 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 58492 W: 18484 L: 18536 D: 21472
Penta | [1374, 5617, 15361, 5475, 1419]
```

Bench: 2936783