### PR TITLE
Split noisy moves based on SEE score

### DIFF
--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -20,7 +20,7 @@ impl super::Board {
         }
 
         // In the worst case, we lose a piece, but still end up with a non-negative balance
-        balance -= PIECE_VALUES[self.piece_on(mv.from())];
+        balance -= PIECE_VALUES[self.piece_on(mv.from()).piece_type()];
         if balance >= 0 {
             return true;
         }
@@ -78,7 +78,7 @@ impl super::Board {
             return PIECE_VALUES[PieceType::Pawn];
         }
 
-        let capture = self.piece_on(mv.to());
+        let capture = self.piece_on(mv.to()).piece_type();
         PIECE_VALUES[capture]
     }
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -53,7 +53,7 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>, tt_move: Move
         if mv.is_noisy() {
             let captured = td.board.piece_on(mv.to()).piece_type();
 
-            scores[i] = 1 << 20;
+            scores[i] = if td.board.see(mv, -110) { 1 << 20 } else { -(1 << 20) };
 
             scores[i] += PIECE_VALUES[captured as usize % 6] * 32;
 


### PR DESCRIPTION
```
Elo   | 14.08 +- 7.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3432 W: 940 L: 801 D: 1691
Penta | [46, 376, 751, 479, 64]
```

Bench: 2854114