### PR TITLE
Fix missing ply updates in NMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -96,8 +96,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
         td.stack[td.ply].mv = Move::NULL;
         td.board.make_null_move();
+        td.ply += 1;
+
         let score = -search::<false>(td, -beta, -beta + 1, depth - r);
+
         td.board.undo_null_move();
+        td.ply -= 1;
 
         if td.stopped {
             return Score::ZERO;


### PR DESCRIPTION
```
Elo   | 2.26 +- 3.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 11242 W: 2910 L: 2837 D: 5495
Penta | [179, 1282, 2624, 1359, 177]
```

Bench: 2854060