### PR TITLE
Skip LMP at root

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -141,7 +141,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         td.ply += 1;
         move_count += 1;
 
-        if !is_loss(best_score) {
+        if !is_root && !is_loss(best_score) {
             skip_quiets |= move_count >= lmp_threshold(depth);
         }
 


### PR DESCRIPTION
```
Elo   | -0.10 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 30060 W: 7645 L: 7654 D: 14761
Penta | [438, 3724, 6748, 3649, 471]
```

Bench: 1871562