### PR TITLE
Use LMR depth in futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -142,9 +142,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         move_count += 1;
 
         if !is_root && !is_loss(best_score) {
+            let lmr_depth = (depth - td.lmr.reduction(depth, move_count) / 1024).max(0);
+
             skip_quiets |= move_count >= lmp_threshold(depth);
 
-            skip_quiets |= depth < 10 && eval + 100 * depth + 150 <= alpha;
+            skip_quiets |= depth < 10 && eval + 100 * lmr_depth + 150 <= alpha;
         }
 
         let new_depth = depth - 1;


### PR DESCRIPTION
```
Elo   | 1.26 +- 3.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 15110 W: 3796 L: 3741 D: 7573
Penta | [224, 1780, 3477, 1865, 209]
```

Bench: 1691960