### PR TITLE
Prefetch TT entries

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -137,6 +137,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
             continue;
         }
 
+        td.tt.prefetch(td.board.hash());
+
         td.stack[td.ply].mv = mv;
         td.ply += 1;
         move_count += 1;


### PR DESCRIPTION
```
Elo   | 2.26 +- 1.74 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 53454 W: 14141 L: 13794 D: 25519
Penta | [783, 5956, 12966, 6175, 847]
```
Bench: 1691960