### PR TITLE
Reduce less for moves that give check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -156,7 +156,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         let mut score = Score::ZERO;
 
         if depth >= 3 && move_count > 1 + is_root as i32 && is_quiet {
-            let reduction = td.lmr.reduction(depth, move_count) / 1024;
+            let mut reduction = td.lmr.reduction(depth, move_count) / 1024;
+
+            if td.board.in_check() {
+                reduction -= 1;
+            }
 
             let reduced_depth = (new_depth - reduction).max(1).min(new_depth);
 


### PR DESCRIPTION
```
Elo   | 10.91 +- 6.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4396 W: 1166 L: 1028 D: 2202
Penta | [43, 497, 1006, 583, 69]
```

Bench: 1092294