### PR TITLE
Use LMR depth in futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -142,7 +142,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
             skip_quiets |= move_count >= lmp_threshold(depth);
 
-            skip_quiets |= depth < 10 && eval + 100 * lmr_depth + 150 <= alpha;
+            skip_quiets |= lmr_depth < 10 && eval + 100 * lmr_depth + 150 <= alpha;
 
             let threshold = if is_quiet { -30 * lmr_depth * lmr_depth } else { -95 * depth };
             if !td.board.see(mv, threshold) {


### PR DESCRIPTION
```
Elo   | 0.85 +- 2.96 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 17534 W: 4393 L: 4350 D: 8791
Penta | [217, 2013, 4266, 2052, 219]
```

Bench: 1683724