### PR TITLE
Reduce TTPV nodes less

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -66,9 +66,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
     let entry = td.tt.read(td.board.hash(), td.ply);
     let mut tt_move = Move::NULL;
+    let mut tt_pv = PV;
 
     if let Some(entry) = entry {
         tt_move = entry.mv;
+        tt_pv |= entry.pv;
 
         if !PV
             && entry.depth >= depth
@@ -167,6 +169,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
                 reduction -= 1;
             }
 
+            if tt_pv {
+                reduction -= 1;
+            }
+
             if cut_node {
                 reduction += 1;
             }
@@ -237,7 +243,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         Bound::Exact
     };
 
-    td.tt.write(td.board.hash(), depth, best_score, bound, best_move, td.ply);
+    td.tt.write(td.board.hash(), depth, best_score, bound, best_move, td.ply, tt_pv);
 
     best_score
 }


### PR DESCRIPTION
```
Elo   | 8.98 +- 5.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5262 W: 1320 L: 1184 D: 2758
Penta | [42, 591, 1249, 687, 62]
```

Bench: 2642586