### PR TITLE
Reduce root depth on aspiration windows fail highs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -22,6 +22,7 @@ pub fn start(td: &mut ThreadData, silent: bool) {
         let mut beta = Score::INFINITE;
 
         let mut delta = 24;
+        let mut reduction = 0;
 
         if depth >= 4 {
             alpha = (score - delta).max(-Score::INFINITE);
@@ -29,7 +30,7 @@ pub fn start(td: &mut ThreadData, silent: bool) {
         }
 
         loop {
-            let current = search::<true>(td, alpha, beta, depth, false);
+            let current = search::<true>(td, alpha, beta, (depth - reduction).max(1), false);
 
             if td.stopped {
                 break;
@@ -39,9 +40,11 @@ pub fn start(td: &mut ThreadData, silent: bool) {
                 s if s <= alpha => {
                     beta = (alpha + beta) / 2;
                     alpha = (current - delta).max(-Score::INFINITE);
+                    reduction = 0;
                 }
                 s if s >= beta => {
                     beta = (current + delta).min(Score::INFINITE);
+                    reduction += 1;
                 }
                 _ => {
                     score = current;


### PR DESCRIPTION
```
Elo   | 4.64 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12964 W: 3209 L: 3036 D: 6719
Penta | [173, 1480, 2966, 1727, 136]
```
Bench: 2262602