### PR TITLE
Reduce more when not improving

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -217,6 +217,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
                 reduction += 1;
             }
 
+            if !improving {
+                reduction += 1;
+            }
+
             let reduced_depth = (new_depth - reduction).max(1).min(new_depth);
 
             score = -search::<false>(td, -alpha - 1, -alpha, reduced_depth, true);


### PR DESCRIPTION
```
Elo   | 5.95 +- 4.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8930 W: 2226 L: 2073 D: 4631
Penta | [87, 1050, 2048, 1183, 97]
```
Bench: 1271484