### PR TITLE
Introduce singular extensions

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -163,11 +163,12 @@ impl Default for Stack {
 pub struct StackEntry {
     pub mv: Move,
     pub eval: i32,
+    pub excluded: Move,
 }
 
 impl Default for StackEntry {
     fn default() -> Self {
-        Self { mv: Move::NULL, eval: Score::NONE }
+        Self { mv: Move::NULL, eval: Score::NONE, excluded: Move::NULL }
     }
 }
 


### PR DESCRIPTION
8.0+0.08s
```
Elo   | 10.40 +- 5.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4276 W: 1052 L: 924 D: 2300
Penta | [37, 440, 1049, 582, 30]
```

20.0+0.2s
```
Elo   | 26.99 +- 9.50 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1522 W: 400 L: 282 D: 840
Penta | [8, 131, 373, 233, 16]
```

Bench: 2160550