### PR TITLE
Adjust aspiration windows delta based on previous score

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -21,10 +21,12 @@ pub fn start(td: &mut ThreadData, silent: bool) {
         let mut alpha = -Score::INFINITE;
         let mut beta = Score::INFINITE;
 
-        let mut delta = 24;
+        let mut delta = 12;
         let mut reduction = 0;
 
         if depth >= 4 {
+            delta += score * score / 32768;
+
             alpha = (score - delta).max(-Score::INFINITE);
             beta = (score + delta).min(Score::INFINITE);
         }


### PR DESCRIPTION
```
Elo   | 4.59 +- 3.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12108 W: 2879 L: 2719 D: 6510
Penta | [103, 1372, 2947, 1526, 106]
```
Bench: 2015421