### PR TITLE
Adjust LMR research depth based on reduced search results

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -255,7 +255,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
             score = -search::<false>(td, -alpha - 1, -alpha, reduced_depth, true);
 
             if score > alpha && new_depth > reduced_depth {
-                score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
+                new_depth += (score > best_score + 64) as i32;
+                new_depth -= (score < best_score + new_depth) as i32;
+
+                if new_depth > reduced_depth {
+                    score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
+                }
             }
         } else if !PV || move_count > 1 {
             score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);


### PR DESCRIPTION
```
Elo   | 6.03 +- 4.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8696 W: 2142 L: 1991 D: 4563
Penta | [82, 998, 2053, 1117, 98]
```

Bench: 2289344