### PR TITLE
Introduce cutoff count

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -150,12 +150,12 @@ impl Default for PrincipalVariationTable {
 }
 
 pub struct Stack {
-    data: [StackEntry; MAX_PLY],
+    data: [StackEntry; MAX_PLY + 8],
 }
 
 impl Default for Stack {
     fn default() -> Self {
-        Self { data: [Default::default(); MAX_PLY] }
+        Self { data: [Default::default(); MAX_PLY + 8] }
     }
 }
 
@@ -166,6 +166,7 @@ pub struct StackEntry {
     pub excluded: Move,
     pub tt_pv: bool,
     pub multiple_extensions: i32,
+    pub cutoff_count: i32,
 }
 
 impl Default for StackEntry {
@@ -176,6 +177,7 @@ impl Default for StackEntry {
             excluded: Move::NULL,
             tt_pv: false,
             multiple_extensions: 0,
+            cutoff_count: 0,
         }
     }
 }


### PR DESCRIPTION
```
Elo   | 6.00 +- 4.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8688 W: 2084 L: 1934 D: 4670
Penta | [80, 985, 2078, 1107, 94]
```
Bench: 1843812