### PR TITLE
Introduce pawn correction history

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -26,6 +26,7 @@ const PHASE_WEIGHTS: [i32; PieceType::NUM - 1] = [0, 3, 3, 5, 9];
 #[derive(Copy, Clone, Default)]
 struct InternalState {
     key: u64,
+    pawn_key: u64,
     en_passant: Square,
     castling: Castling,
     halfmove_clock: u8,
@@ -65,6 +66,10 @@ impl Board {
     /// Returns the Zobrist hash key for the current position.
     pub const fn hash(&self) -> u64 {
         self.state.key
+    }
+
+    pub const fn pawn_key(&self) -> u64 {
+        self.state.pawn_key
     }
 
     pub const fn pinners(&self) -> Bitboard {
@@ -153,6 +158,9 @@ impl Board {
 
     pub fn update_hash(&mut self, piece: Piece, square: Square) {
         self.state.key ^= ZOBRIST.pieces[piece][square];
+        if piece.piece_type() == PieceType::Pawn {
+            self.state.pawn_key ^= ZOBRIST.pieces[piece][square];
+        }
     }
 
     /// Calculates the score of the current position from the perspective of the side to move.
@@ -320,8 +328,13 @@ impl Board {
 
         for piece in 0..Piece::NUM {
             let piece = Piece::from_index(piece);
+
             for square in self.of(piece.piece_type(), piece.piece_color()) {
                 self.state.key ^= ZOBRIST.pieces[piece][square];
+
+                if piece.piece_type() == PieceType::Pawn {
+                    self.state.pawn_key ^= ZOBRIST.pieces[piece][square];
+                }
             }
         }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,6 +1,6 @@
 use crate::{
     board::Board,
-    types::{ArrayVec, Move},
+    types::{ArrayVec, Color, Move},
 };
 
 fn bonus(depth: i32) -> i32 {
@@ -78,5 +78,37 @@ impl NoisyHistory {
 impl Default for NoisyHistory {
     fn default() -> Self {
         Self { entries: Box::new([[[0; 7]; 64]; 12]) }
+    }
+}
+
+pub struct CorrectionHistory {
+    // [side_to_move][key]
+    entries: Box<[[i32; Self::SIZE]; 2]>,
+}
+
+impl CorrectionHistory {
+    const GRAIN: i32 = 256;
+    const LIMIT: i32 = Self::GRAIN * 64;
+
+    const SIZE: usize = 65536;
+    const MASK: usize = Self::SIZE - 1;
+
+    pub fn get(&self, stm: Color, key: u64) -> i32 {
+        self.entries[stm][key as usize & Self::MASK] / Self::GRAIN
+    }
+
+    pub fn update(&mut self, stm: Color, key: u64, depth: i32, diff: i32) {
+        let weight = (8 * depth + 8).min(96);
+
+        let entry = &mut self.entries[stm][key as usize & Self::MASK];
+        let weighted_average = (*entry * (1024 - weight) + diff * weight * Self::GRAIN) / 1024;
+
+        *entry = (weighted_average).clamp(-Self::LIMIT, Self::LIMIT);
+    }
+}
+
+impl Default for CorrectionHistory {
+    fn default() -> Self {
+        Self { entries: Box::new([[0; Self::SIZE]; 2]) }
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     board::Board,
-    history::{NoisyHistory, QuietHistory},
+    history::{CorrectionHistory, NoisyHistory, QuietHistory},
     time::{Limits, TimeManager},
     transposition::TranspositionTable,
     types::{is_loss, is_win, Move, Score, MAX_PLY},
@@ -56,6 +56,7 @@ pub struct ThreadData<'a> {
     pub pv: PrincipalVariationTable,
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
+    pub pawn_corrhist: CorrectionHistory,
     pub lmr: LmrTable,
     pub stopped: bool,
     pub nodes: u64,
@@ -74,6 +75,7 @@ impl<'a> ThreadData<'a> {
             pv: PrincipalVariationTable::default(),
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
+            pawn_corrhist: CorrectionHistory::default(),
             lmr: LmrTable::default(),
             stopped: false,
             nodes: 0,


### PR DESCRIPTION
```
Elo   | 9.18 +- 5.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5036 W: 1248 L: 1115 D: 2673
Penta | [30, 570, 1215, 643, 60]
```
Bench: 1979756