### PR TITLE
Make use of correction history in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -127,7 +127,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
     let eval;
 
     if in_check {
-        raw = Score::NONE;
         eval = Score::NONE;
     } else if excluded {
         raw = td.stack[td.ply].eval;
@@ -370,9 +369,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         && !(bound == Bound::Lower && best_score <= eval)
         && (best_move == Move::NULL || !best_move.is_noisy())
     {
-        td.pawn_corrhist.update(td.board.side_to_move(), td.board.pawn_key(), depth, best_score - raw);
-        td.minor_corrhist.update(td.board.side_to_move(), td.board.minor_key(), depth, best_score - raw);
-        td.major_corrhist.update(td.board.side_to_move(), td.board.major_key(), depth, best_score - raw);
+        td.pawn_corrhist.update(td.board.side_to_move(), td.board.pawn_key(), depth, best_score - eval);
+        td.minor_corrhist.update(td.board.side_to_move(), td.board.minor_key(), depth, best_score - eval);
+        td.major_corrhist.update(td.board.side_to_move(), td.board.major_key(), depth, best_score - eval);
     }
 
     best_score
@@ -406,7 +405,7 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
         }
     }
 
-    let mut best_score = td.board.evaluate();
+    let mut best_score = td.board.evaluate() + correction_value(td);
 
     if best_score >= beta {
         return best_score;


### PR DESCRIPTION
```
Elo   | 13.85 +- 6.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3062 W: 792 L: 670 D: 1600
Penta | [18, 312, 763, 406, 32]
```
Bench: 1678694