### PR TITLE
Use static evaluation in correction history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -376,13 +376,13 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
     if !excluded
         && !in_check
         && !is_decisive(best_score)
-        && !(bound == Bound::Upper && best_score >= eval)
-        && !(bound == Bound::Lower && best_score <= eval)
+        && !(bound == Bound::Upper && best_score >= static_eval)
+        && !(bound == Bound::Lower && best_score <= static_eval)
         && (best_move == Move::NULL || !best_move.is_noisy())
     {
-        td.pawn_corrhist.update(td.board.side_to_move(), td.board.pawn_key(), depth, best_score - eval);
-        td.minor_corrhist.update(td.board.side_to_move(), td.board.minor_key(), depth, best_score - eval);
-        td.major_corrhist.update(td.board.side_to_move(), td.board.major_key(), depth, best_score - eval);
+        td.pawn_corrhist.update(td.board.side_to_move(), td.board.pawn_key(), depth, best_score - static_eval);
+        td.minor_corrhist.update(td.board.side_to_move(), td.board.minor_key(), depth, best_score - static_eval);
+        td.major_corrhist.update(td.board.side_to_move(), td.board.major_key(), depth, best_score - static_eval);
     }
 
     best_score


### PR DESCRIPTION
```
Elo   | 6.15 +- 4.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8308 W: 2091 L: 1944 D: 4273
Penta | [63, 949, 1996, 1070, 76]
```
Bench: 1763502