### PR TITLE
Introduce 1-ply continuation history

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -61,6 +61,13 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>, tt_move: Move
             scores[i] += td.noisy_history.get(&td.board, mv);
         } else {
             scores[i] = td.quiet_history.get(&td.board, mv);
+
+            if td.ply >= 1 && td.stack[td.ply - 1].mv != Move::NULL {
+                let prev_mv = td.stack[td.ply - 1].mv;
+                let prev_piece = td.stack[td.ply - 1].piece;
+
+                scores[i] += td.continuation_history.get(&td.board, prev_piece, prev_mv, mv);
+            }
         }
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -6,10 +6,10 @@ use std::{
 
 use crate::{
     board::Board,
-    history::{CorrectionHistory, NoisyHistory, QuietHistory},
+    history::{ContinuationHistory, CorrectionHistory, NoisyHistory, QuietHistory},
     time::{Limits, TimeManager},
     transposition::TranspositionTable,
-    types::{is_loss, is_win, Move, Score, MAX_PLY},
+    types::{is_loss, is_win, Move, Piece, Score, MAX_PLY},
 };
 
 pub struct ThreadPool<'a> {
@@ -56,6 +56,7 @@ pub struct ThreadData<'a> {
     pub pv: PrincipalVariationTable,
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
+    pub continuation_history: ContinuationHistory,
     pub pawn_corrhist: CorrectionHistory,
     pub minor_corrhist: CorrectionHistory,
     pub major_corrhist: CorrectionHistory,
@@ -77,6 +78,7 @@ impl<'a> ThreadData<'a> {
             pv: PrincipalVariationTable::default(),
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
+            continuation_history: ContinuationHistory::default(),
             pawn_corrhist: CorrectionHistory::default(),
             minor_corrhist: CorrectionHistory::default(),
             major_corrhist: CorrectionHistory::default(),
@@ -168,6 +170,7 @@ impl Default for Stack {
 #[derive(Copy, Clone)]
 pub struct StackEntry {
     pub mv: Move,
+    pub piece: Piece,
     pub eval: i32,
     pub excluded: Move,
     pub tt_pv: bool,
@@ -179,6 +182,7 @@ impl Default for StackEntry {
     fn default() -> Self {
         Self {
             mv: Move::NULL,
+            piece: Piece::None,
             eval: Score::NONE,
             excluded: Move::NULL,
             tt_pv: false,


### PR DESCRIPTION
```
Elo   | 6.93 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7266 W: 1846 L: 1701 D: 3719
Penta | [63, 843, 1694, 952, 81]
```
Bench: 1832013