### PR TITLE
Time management based on distribution of nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -13,6 +13,7 @@ pub fn start(td: &mut ThreadData, silent: bool) {
     td.completed_depth = 0;
     td.stopped = false;
     td.pv.clear(0);
+    td.node_table.clear();
 
     let now = Instant::now();
     let mut score = Score::NONE;
@@ -67,7 +68,7 @@ pub fn start(td: &mut ThreadData, silent: bool) {
 
         td.completed_depth = depth;
 
-        if td.time_manager.soft_limit(depth, td.nodes) {
+        if td.time_manager.soft_limit(td) {
             break;
         }
     }
@@ -257,6 +258,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
             }
         }
 
+        let initial_nodes = td.nodes;
         let mut new_depth = depth + extension - 1;
 
         td.stack[td.ply].piece = td.board.piece_on(mv.from());
@@ -316,6 +318,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
         if td.stopped {
             return Score::ZERO;
+        }
+
+        if is_root {
+            td.node_table.add(mv, td.nodes - initial_nodes);
         }
 
         if score > best_score {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -60,6 +60,7 @@ pub struct ThreadData<'a> {
     pub pawn_corrhist: CorrectionHistory,
     pub minor_corrhist: CorrectionHistory,
     pub major_corrhist: CorrectionHistory,
+    pub node_table: NodeTable,
     pub lmr: LmrTable,
     pub stopped: bool,
     pub nodes: u64,
@@ -82,6 +83,7 @@ impl<'a> ThreadData<'a> {
             pawn_corrhist: CorrectionHistory::default(),
             minor_corrhist: CorrectionHistory::default(),
             major_corrhist: CorrectionHistory::default(),
+            node_table: NodeTable::default(),
             lmr: LmrTable::default(),
             stopped: false,
             nodes: 0,
@@ -229,5 +231,29 @@ impl Default for LmrTable {
         }
 
         Self { table }
+    }
+}
+
+pub struct NodeTable {
+    table: [[u64; 64]; 64],
+}
+
+impl NodeTable {
+    pub fn add(&mut self, mv: Move, nodes: u64) {
+        self.table[mv.from()][mv.to()] += nodes;
+    }
+
+    pub fn get(&self, mv: Move) -> u64 {
+        self.table[mv.from()][mv.to()]
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+}
+
+impl Default for NodeTable {
+    fn default() -> Self {
+        Self { table: [[0; 64]; 64] }
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -62,7 +62,7 @@ impl TimeManager {
             Limits::Time(maximum) => self.start_time.elapsed() >= Duration::from_millis(maximum),
             _ => {
                 let fraction = td.node_table.get(td.pv.best_move()) as f32 / td.nodes as f32;
-                let effort = 2.3 - 1.5 * fraction;
+                let effort = 2.15 - 1.5 * fraction;
 
                 let limit = self.soft_bound.as_secs_f32() * effort;
 


### PR DESCRIPTION
```
Elo   | 17.59 +- 7.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2352 W: 602 L: 483 D: 1267
Penta | [12, 224, 592, 329, 19]
```
Bench: 1608725