### PR TITLE
Skip nodes time management at low depth

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -61,10 +61,12 @@ impl TimeManager {
             Limits::Nodes(maximum) => td.nodes >= maximum,
             Limits::Time(maximum) => self.start_time.elapsed() >= Duration::from_millis(maximum),
             _ => {
-                let fraction = td.node_table.get(td.pv.best_move()) as f32 / td.nodes as f32;
-                let effort = 2.15 - 1.5 * fraction;
+                let mut limit = self.soft_bound.as_secs_f32();
 
-                let limit = self.soft_bound.as_secs_f32() * effort;
+                if td.completed_depth >= 7 {
+                    let fraction = td.node_table.get(td.pv.best_move()) as f32 / td.nodes as f32;
+                    limit *= 2.15 - 1.5 * fraction;
+                }
 
                 self.start_time.elapsed() >= Duration::from_secs_f32(limit)
             }


### PR DESCRIPTION
```
Elo   | 5.09 +- 3.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8528 W: 2016 L: 1891 D: 4621
Penta | [31, 757, 2577, 854, 45]
```
Bench: 1608725