### PR TITLE
Time management based on PV stability

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -18,6 +18,9 @@ pub fn start(td: &mut ThreadData, silent: bool) {
     let now = Instant::now();
     let mut score = Score::NONE;
 
+    let mut pv_stability = 0;
+    let mut last_move = Move::NULL;
+
     for depth in 1..MAX_PLY as i32 {
         let mut alpha = -Score::INFINITE;
         let mut beta = Score::INFINITE;
@@ -68,7 +71,14 @@ pub fn start(td: &mut ThreadData, silent: bool) {
 
         td.completed_depth = depth;
 
-        if td.time_manager.soft_limit(td) {
+        if last_move == td.pv.best_move() {
+            pv_stability = (pv_stability + 1).min(8);
+        } else {
+            pv_stability = 0;
+            last_move = td.pv.best_move();
+        }
+
+        if td.time_manager.soft_limit(td, pv_stability) {
             break;
         }
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -54,7 +54,7 @@ impl TimeManager {
         }
     }
 
-    pub fn soft_limit(&self, td: &ThreadData) -> bool {
+    pub fn soft_limit(&self, td: &ThreadData, pv_stability: usize) -> bool {
         match self.limits {
             Limits::Infinite => false,
             Limits::Depth(maximum) => td.completed_depth >= maximum,
@@ -66,6 +66,10 @@ impl TimeManager {
                 if td.completed_depth >= 7 {
                     let fraction = td.node_table.get(td.pv.best_move()) as f32 / td.nodes as f32;
                     limit *= 2.15 - 1.5 * fraction;
+                }
+
+                if td.completed_depth >= 2 {
+                    limit *= 1.25 - 0.05 * pv_stability as f32;
                 }
 
                 self.start_time.elapsed() >= Duration::from_secs_f32(limit)

--- a/src/time.rs
+++ b/src/time.rs
@@ -66,9 +66,7 @@ impl TimeManager {
                 if td.completed_depth >= 7 {
                     let fraction = td.node_table.get(td.pv.best_move()) as f32 / td.nodes as f32;
                     limit *= 2.15 - 1.5 * fraction;
-                }
 
-                if td.completed_depth >= 2 {
                     limit *= 1.25 - 0.05 * pv_stability as f32;
                 }
 


### PR DESCRIPTION
```
Elo   | 3.75 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15462 W: 3664 L: 3497 D: 8301
Penta | [81, 1774, 3883, 1883, 110]
```
Bench: 1608725