### PR TITLE
Time management based on evaluation stability

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -16,8 +16,11 @@ pub fn start(td: &mut ThreadData, silent: bool) {
     td.node_table.clear();
 
     let now = Instant::now();
-    let mut score = Score::NONE;
 
+    let mut score = Score::NONE;
+    let mut average = Score::NONE;
+
+    let mut eval_stability = 0;
     let mut pv_stability = 0;
     let mut last_move = Move::NULL;
 
@@ -55,6 +58,7 @@ pub fn start(td: &mut ThreadData, silent: bool) {
                 }
                 _ => {
                     score = current;
+                    average = if average == Score::NONE { current } else { (average + current) / 2 };
                     break;
                 }
             }
@@ -79,7 +83,13 @@ pub fn start(td: &mut ThreadData, silent: bool) {
             last_move = td.pv.best_move();
         }
 
-        if td.time_manager.soft_limit(td, pv_stability) {
+        if (score - eval_stability as i32).abs() < 12 {
+            eval_stability = (eval_stability + 1).min(8);
+        } else {
+            eval_stability = 0;
+        }
+
+        if td.time_manager.soft_limit(td, pv_stability, eval_stability) {
             break;
         }
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -54,7 +54,7 @@ impl TimeManager {
         }
     }
 
-    pub fn soft_limit(&self, td: &ThreadData, pv_stability: usize) -> bool {
+    pub fn soft_limit(&self, td: &ThreadData, pv_stability: usize, eval_stability: usize) -> bool {
         match self.limits {
             Limits::Infinite => false,
             Limits::Depth(maximum) => td.completed_depth >= maximum,
@@ -68,6 +68,8 @@ impl TimeManager {
                     limit *= 2.15 - 1.5 * fraction;
 
                     limit *= 1.25 - 0.05 * pv_stability as f32;
+
+                    limit *= 1.2 - 0.04 * eval_stability as f32;
                 }
 
                 self.start_time.elapsed() >= Duration::from_secs_f32(limit)


### PR DESCRIPTION
```
Elo   | 6.15 +- 4.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7744 W: 1870 L: 1733 D: 4141
Penta | [45, 841, 1972, 960, 54]
```
Bench: 1608725