### PR TITLE
Add 2-ply continuation history

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -62,9 +62,13 @@ fn score_moves(td: &ThreadData, moves: &ArrayVec<Move, MAX_MOVES>, tt_move: Move
         } else {
             scores[i] = td.quiet_history.get(&td.board, mv);
 
-            if td.ply >= 1 {
-                let prev_piece = td.stack[td.ply - 1].piece;
-                let prev_mv = td.stack[td.ply - 1].mv;
+            for index in [1, 2] {
+                if td.ply < index {
+                    continue;
+                }
+
+                let prev_piece = td.stack[td.ply - index].piece;
+                let prev_mv = td.stack[td.ply - index].mv;
 
                 scores[i] += td.continuation_history.get(&td.board, prev_piece, prev_mv, mv);
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -400,9 +400,13 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
                 td.quiet_history.update(&td.board, mv, -bonus);
             }
 
-            if td.ply >= 1 && td.stack[td.ply - 1].mv != Move::NULL {
-                let prev_mv = td.stack[td.ply - 1].mv;
-                let prev_piece = td.stack[td.ply - 1].piece;
+            for index in [1, 2] {
+                if td.ply < index || td.stack[td.ply - index].mv == Move::NULL {
+                    continue;
+                }
+
+                let prev_mv = td.stack[td.ply - index].mv;
+                let prev_piece = td.stack[td.ply - index].piece;
 
                 td.continuation_history.update(&td.board, prev_mv, prev_piece, best_move, bonus);
 


### PR DESCRIPTION
```
Elo   | 5.12 +- 3.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10046 W: 2440 L: 2292 D: 5314
Penta | [61, 1144, 2472, 1278, 68]
```
Bench: 1542939