### PR TITLE
Introduce triple extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -272,7 +272,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
                 if score < singular_beta {
                     extension = 1;
-                    extension += (!PV && score <= singular_beta - 24) as i32;
+                    extension += (!PV && score < singular_beta - 24) as i32;
+                    extension += (!PV && is_quiet && score < singular_beta - 128) as i32;
 
                     td.stack[td.ply].multiple_extensions += (extension > 1) as i32;
                 } else if singular_beta >= beta {


### PR DESCRIPTION
```
Elo   | 4.62 +- 3.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11812 W: 2809 L: 2652 D: 6351
Penta | [68, 1369, 2902, 1472, 95]
```
Bench: 1624159