### PR TITLE
Allow correction history updates in singular extension search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -430,8 +430,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         td.tt.write(td.board.hash(), depth, best_score, bound, best_move, td.ply, tt_pv);
     }
 
-    if !(excluded
-        || in_check
+    if !(in_check
         || best_move.is_noisy()
         || is_decisive(best_score)
         || (bound == Bound::Upper && best_score >= static_eval)


### PR DESCRIPTION
```
Elo   | 2.74 +- 3.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 9376 W: 2227 L: 2153 D: 4996
Penta | [69, 1101, 2275, 1173, 70]
```
Bench: 1564853