### PR TITLE
Add `improving` heuristic to LMP

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,7 +1,7 @@
 pub const PIECE_VALUES: [i32; 7] = [100, 375, 400, 625, 1200, 0, 0];
 
-pub fn lmp_threshold(depth: i32) -> i32 {
-    3 + depth * depth
+pub fn lmp_threshold(depth: i32, improving: bool) -> i32 {
+    (3 + depth * depth) / (2 - improving as i32)
 }
 
 #[cfg(not(feature = "spsa"))]

--- a/src/search.rs
+++ b/src/search.rs
@@ -247,7 +247,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         if !is_root && !is_loss(best_score) {
             let lmr_depth = (depth - td.lmr.reduction(depth, move_count) / 1024).max(0);
 
-            skip_quiets |= move_count >= lmp_threshold(depth);
+            skip_quiets |= move_count >= lmp_threshold(depth, improving);
 
             skip_quiets |= is_quiet && lmr_depth < 10 && static_eval + 100 * lmr_depth + 150 <= alpha;
 


### PR DESCRIPTION
```
Elo   | 4.18 +- 3.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13648 W: 3263 L: 3099 D: 7286
Penta | [90, 1570, 3345, 1724, 95]
```
Bench: 1295031