### PR TITLE
Fix correction history key updates

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -344,6 +344,9 @@ impl Board {
 
     pub fn update_hash_keys(&mut self) {
         self.state.key = 0;
+        self.state.pawn_key = 0;
+        self.state.minor_key = 0;
+        self.state.major_key = 0;
 
         for piece in 0..Piece::NUM {
             let piece = Piece::from_index(piece);

--- a/src/history.rs
+++ b/src/history.rs
@@ -69,7 +69,7 @@ impl CorrectionHistory {
     const GRAIN: i32 = 256;
     const LIMIT: i32 = Self::GRAIN * 64;
 
-    const SIZE: usize = 65536;
+    const SIZE: usize = 16384;
     const MASK: usize = Self::SIZE - 1;
 
     pub fn get(&self, stm: Color, key: u64) -> i32 {


### PR DESCRIPTION
```
Elo   | 4.47 +- 4.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 6534 W: 1575 L: 1491 D: 3468
Penta | [37, 770, 1583, 826, 51]
```
Bench: 3685489