### PR TITLE
Increase NMP reduction if TT move is a capture

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -198,7 +198,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         && td.stack[td.ply - 1].mv != Move::NULL
         && td.board.has_non_pawns()
     {
-        let r = 3 + depth / 3 + ((eval - beta) / 256).min(3);
+        let r = 3 + depth / 3 + ((eval - beta) / 256).min(3) + tt_move.is_capture() as i32;
 
         td.stack[td.ply].piece = Piece::None;
         td.stack[td.ply].mv = Move::NULL;


### PR DESCRIPTION
```
Elo   | 5.34 +- 3.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9694 W: 2375 L: 2226 D: 5093
Penta | [65, 1122, 2336, 1247, 77]
```
Bench: 4214958