### PR TITLE
Introduce corrplexity in LMR

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -227,7 +227,7 @@ impl Default for LmrTable {
 
         for depth in 1..64 {
             for move_count in 1..64 {
-                let reduction = 820.0 + 455.0 * (depth as f32).ln() * (move_count as f32).ln();
+                let reduction = 1000.0 + 455.0 * (depth as f32).ln() * (move_count as f32).ln();
                 table[depth][move_count] = reduction as i32;
             }
         }


### PR DESCRIPTION
```
Elo   | 9.17 +- 5.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4962 W: 1245 L: 1114 D: 2603
Penta | [26, 562, 1192, 657, 44]
```
Bench: 4065323