### PR TITLE
Increase base NMP reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -200,7 +200,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         && td.stack[td.ply - 1].mv != Move::NULL
         && td.board.has_non_pawns()
     {
-        let r = 3 + depth / 3 + ((eval - beta) / 256).min(3) + tt_move.is_capture() as i32;
+        let r = 4 + depth / 3 + ((eval - beta) / 256).min(3) + tt_move.is_capture() as i32;
 
         td.stack[td.ply].piece = Piece::None;
         td.stack[td.ply].mv = Move::NULL;


### PR DESCRIPTION
```
Elo   | 6.74 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8920 W: 2186 L: 2013 D: 4721
Penta | [77, 1023, 2092, 1186, 82]
```
Bench: 3614788