### PR TITLE
Reduce PV nodes less

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -312,7 +312,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
             }
 
             if tt_pv {
-                reduction -= 1024;
+                reduction -= 768;
+            }
+
+            if PV {
+                reduction -= 768;
             }
 
             if cut_node {


### PR DESCRIPTION
Passes non-regression [-3, 0] LLR: 3.5359.
```
Elo   | 1.75 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.19 (-2.25, 2.89) [0.00, 4.00]
Games | N: 30418 W: 7331 L: 7178 D: 15909
Penta | [216, 3623, 7411, 3710, 249]
```
Bench: 4474468