### PR TITLE
Refine definition of noisy in NMP

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -46,7 +46,7 @@ impl Board {
 
         self.state.captured = None;
 
-        if mv.is_capture() || pt == PieceType::Pawn {
+        if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
             self.state.halfmove_clock = 0;
         } else {
             self.state.halfmove_clock += 1;

--- a/src/search.rs
+++ b/src/search.rs
@@ -200,7 +200,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         && td.stack[td.ply - 1].mv != Move::NULL
         && td.board.has_non_pawns()
     {
-        let r = 4 + depth / 3 + ((eval - beta) / 256).min(3) + tt_move.is_capture() as i32;
+        let r = 4 + depth / 3 + ((eval - beta) / 256).min(3) + tt_move.is_noisy() as i32;
 
         td.stack[td.ply].piece = Piece::None;
         td.stack[td.ply].mv = Move::NULL;

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -57,15 +57,10 @@ impl Move {
     }
 
     pub fn is_noisy(self) -> bool {
-        (self.is_capture() && !self.is_promotion()) || self.promotion_piece() == Some(PieceType::Queen)
-    }
-
-    pub const fn is_capture(self) -> bool {
-        (self.0 >> 14) & 1 != 0
-    }
-
-    pub const fn is_quiet(self) -> bool {
-        !self.is_capture()
+        matches!(
+            self.kind(),
+            MoveKind::Capture | MoveKind::EnPassant | MoveKind::PromotionCaptureQ | MoveKind::PromotionQ
+        )
     }
 
     pub const fn is_promotion(self) -> bool {


### PR DESCRIPTION
Hopefully it's neutral, but it's a logical fix to the intended behavior anyway...
```
Elo   | -1.16 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.52 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 53454 W: 12609 L: 12788 D: 28057
Penta | [337, 5818, 14564, 5703, 305]
```
Bench: 4172056