### PR TITLE
Fix mates scores in ProbCut

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -263,6 +263,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
             if score >= probcut_beta {
                 td.tt.write(td.board.hash(), probcut_depth + 1, score, Bound::Lower, mv, td.ply, tt_pv);
 
+                if is_decisive(score) {
+                    return score;
+                }
+
                 return score - (probcut_beta - beta);
             }
         }


### PR DESCRIPTION
```
Elo   | 8.37 +- 8.89 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-10.00, 0.00]
Games | N: 1702 W: 430 L: 389 D: 883
Penta | [12, 178, 430, 219, 12]
```
Bench: 3997599