### PR TITLE
Update default network to v7-c95c1cf1.nnue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EXE    := reckless
-MODEL  := v6-eee46357.nnue
+MODEL  := v7-c95c1cf1.nnue
 REPO   := https://github.com/codedeliveryservice/RecklessNetworks/raw/main
 
 ifeq ($(OS),Windows_NT)

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -3,10 +3,10 @@ use crate::types::{Color, Piece, PieceType, Square, MAX_PLY};
 mod simd;
 
 const INPUT_SIZE: usize = 768;
-const HIDDEN_SIZE: usize = 384;
+const HIDDEN_SIZE: usize = 512;
 
 const EVAL_SCALE: i32 = 400;
-const L0_SCALE: i32 = 256;
+const L0_SCALE: i32 = 384;
 const L1_SCALE: i32 = 64;
 
 type FtIndex = (usize, usize);


### PR DESCRIPTION
Fixed nodes
```
Elo   | 27.14 +- 10.91 (95%)
SPRT  | N=25000 Threads=1 Hash=32MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2078 W: 749 L: 587 D: 742
Penta | [53, 208, 410, 260, 108]
```

STC
```
Elo   | 24.11 +- 9.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1804 W: 518 L: 393 D: 893
Penta | [7, 196, 387, 289, 23]
```
Bench: 4594966