### PR TITLE
Easier RFP for expected cut_nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -188,7 +188,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         return qsearch::<false>(td, alpha, beta);
     }
 
-    if !PV && !in_check && !excluded && depth <= 8 && eval >= beta + 80 * depth - (80 * improving as i32) {
+    if !PV
+        && !in_check
+        && !excluded
+        && depth <= 8
+        && eval >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32)
+    {
         return eval;
     }
 


### PR DESCRIPTION
Elo   | 4.27 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13494 W: 3273 L: 3107 D: 7114
Penta | [97, 1556, 3287, 1698, 109]
https://rickdiculous.pythonanywhere.com/test/3272/

bench: 3943112