### PR TITLE
Fix assigning tt_move in a singular search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -131,7 +131,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
 
     let mut depth = depth.min(MAX_PLY as i32 - 1);
 
-    let entry = if excluded { None } else { td.tt.read(td.board.hash(), td.ply) };
+    let entry = td.tt.read(td.board.hash(), td.ply);
     let mut tt_move = Move::NULL;
     let mut tt_pv = PV;
 
@@ -140,6 +140,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         tt_pv |= entry.pv;
 
         if !PV
+            && !excluded
             && entry.depth >= depth
             && match entry.bound {
                 Bound::Upper => entry.score <= alpha,


### PR DESCRIPTION
Elo   | 0.90 +- 2.80 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=32MB
LLR   | 3.05 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 17742 W: 4306 L: 4260 D: 9176
Penta | [115, 2164, 4283, 2178, 131]
https://rickdiculous.pythonanywhere.com/test/3285/

bench: 3498977