### PR TITLE
Remove a needless condition in QS FP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -575,7 +575,7 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
                 break;
             }
 
-            if !in_check && futility_score <= alpha && mv.is_noisy() && !td.board.see(mv, 1) {
+            if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {
                 best_score = best_score.max(futility_score);
                 continue;
             }


### PR DESCRIPTION
```
Elo   | 0.35 +- 2.34 (95%)
SPRT  | 7.0+0.07s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 21960 W: 5203 L: 5181 D: 11576
Penta | [141, 2284, 6090, 2342, 123]
```
Bench: 3498977