### PR TITLE
Introduce fail-middle in RFP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -195,7 +195,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         && depth <= 8
         && eval >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32)
     {
-        return eval;
+        return (eval + beta) / 2;
     }
 
     if cut_node


### PR DESCRIPTION
```
Elo   | 9.71 +- 5.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4654 W: 1203 L: 1073 D: 2378
Penta | [24, 514, 1146, 594, 49]
```
Bench: 3556661