### PR TITLE
Add check extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -337,7 +337,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         }
 
         let initial_nodes = td.nodes;
-        let mut new_depth = depth + extension - 1;
 
         let history = td.quiet_history.get(&td.board, mv) + td.conthist(1, mv) + td.conthist(2, mv);
 
@@ -348,7 +347,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32, depth:
         td.board.make_move::<true, false>(mv);
         td.tt.prefetch(td.board.hash());
 
+        let mut new_depth = depth + extension - 1;
         let mut score = Score::ZERO;
+
+        if depth >= 8 && static_eval.abs() >= 128 && td.board.in_check() {
+            new_depth += 1;
+        }
 
         if depth >= 3 && move_count > 1 + is_root as i32 && is_quiet {
             let mut reduction = td.lmr.reduction(depth, move_count);


### PR DESCRIPTION
```
Elo   | 2.33 +- 1.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 38118 W: 8991 L: 8735 D: 20392
Penta | [236, 4513, 9338, 4703, 269]
```
Bench: 3881851