### PR TITLE
Scale optimal time based on move number

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -48,6 +48,7 @@ pub struct Board {
     mailbox: [Piece; Square::NUM],
     state: InternalState,
     state_stack: Vec<InternalState>,
+    game_ply: usize,
     nnue: Network,
 }
 
@@ -64,6 +65,10 @@ impl Board {
 
     pub const fn side_to_move(&self) -> Color {
         self.side_to_move
+    }
+
+    pub const fn game_ply(&self) -> usize {
+        self.game_ply
     }
 
     /// Returns the Zobrist hash key for the current position.
@@ -145,6 +150,10 @@ impl Board {
     /// This method is used to minimize the risk of zugzwang when considering the Null Move Heuristic.
     pub fn has_non_pawns(&self) -> bool {
         self.our(PieceType::Pawn) | self.our(PieceType::King) != self.us()
+    }
+
+    pub fn increment_game_ply(&mut self) {
+        self.game_ply += 1;
     }
 
     /// Places a piece of the specified type and color on the square.
@@ -400,6 +409,7 @@ impl Default for Board {
             mailbox: [Piece::None; Square::NUM],
             state_stack: Vec::default(),
             nnue: Network::default(),
+            game_ply: 0,
         }
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -77,7 +77,7 @@ impl<'a> ThreadData<'a> {
             tt,
             stop,
             board: Board::starting_position(),
-            time_manager: TimeManager::new(Limits::Infinite),
+            time_manager: TimeManager::new(Limits::Infinite, 0),
             stack: Stack::default(),
             pv: PrincipalVariationTable::default(),
             noisy_history: NoisyHistory::default(),

--- a/src/time.rs
+++ b/src/time.rs
@@ -21,7 +21,7 @@ pub struct TimeManager {
 }
 
 impl TimeManager {
-    pub fn new(limits: Limits) -> Self {
+    pub fn new(limits: Limits, ply: usize) -> Self {
         let soft;
         let hard;
 
@@ -31,7 +31,9 @@ impl TimeManager {
                 hard = ms;
             }
             Limits::Fischer(main, inc) => {
-                soft = (0.035 * (main as f64 + 0.75 * inc as f64)) as u64;
+                let soft_scale = 0.025 + 0.05 * (1.0 - (-0.017 * ply as f64).exp());
+
+                soft = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
                 hard = (0.135 * (main as f64 + 0.75 * inc as f64)) as u64;
             }
             Limits::Cyclic(main, inc, moves) => {

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -85,7 +85,7 @@ pub fn bench<const PRETTY: bool>(depth: i32) {
 
         let mut td = ThreadData::new(&tt, &stop);
         td.board = Board::new(position).unwrap();
-        td.time_manager = TimeManager::new(Limits::Depth(depth));
+        td.time_manager = TimeManager::new(Limits::Depth(depth), 0);
 
         search::start(&mut td, true);
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -61,9 +61,9 @@ fn reset(threads: &mut ThreadPool, tt: &TranspositionTable) {
 }
 
 fn go(threads: &mut ThreadPool, tokens: &[&str]) {
-    let stm = threads.main_thread().board.side_to_move();
-    let limits = parse_limits(stm, tokens);
-    threads.main_thread().time_manager = TimeManager::new(limits);
+    let board = &threads.main_thread().board;
+    let limits = parse_limits(board.side_to_move(), tokens);
+    threads.main_thread().time_manager = TimeManager::new(limits, board.game_ply());
     threads.main_thread().set_stop(false);
 
     std::thread::scope(|scope| {
@@ -124,6 +124,7 @@ fn make_uci_move(board: &mut Board, uci_move: &str) {
     let moves = board.generate_all_moves();
     if let Some(&mv) = moves.iter().find(|mv| mv.to_string() == uci_move) {
         board.make_move::<true, true>(mv);
+        board.increment_game_ply();
     }
 }
 


### PR DESCRIPTION
```
Elo   | 5.24 +- 3.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9548 W: 2398 L: 2254 D: 4896
Penta | [58, 1027, 2482, 1127, 80]
```
Bench: 3881851