### PR TITLE
 Scale maximum time based on move number

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -32,9 +32,10 @@ impl TimeManager {
             }
             Limits::Fischer(main, inc) => {
                 let soft_scale = 0.025 + 0.05 * (1.0 - (-0.017 * ply as f64).exp());
+                let hard_scale = 0.135 + 0.21 * (1.0 - (-0.015 * ply as f64).exp());
 
                 soft = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
-                hard = (0.135 * (main as f64 + 0.75 * inc as f64)) as u64;
+                hard = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;
             }
             Limits::Cyclic(main, inc, moves) => {
                 let base = (main as f64 / moves as f64) + 0.75 * inc as f64;


### PR DESCRIPTION
```
Elo   | 24.01 +- 8.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.16 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1870 W: 539 L: 410 D: 921
Penta | [8, 177, 449, 280, 21]
```
Bench: 3881851