### PR TITLE
Mix more MVV and noisy history values

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -62,9 +62,7 @@ fn score_moves(
             let captured = td.board.piece_on(mv.to()).piece_type();
 
             scores[i] = if td.board.see(mv, threshold) { 1 << 20 } else { -(1 << 20) };
-
-            scores[i] += PIECE_VALUES[captured as usize % 6] * 32;
-
+            scores[i] += PIECE_VALUES[captured as usize % 6] * 24;
             scores[i] += td.noisy_history.get(&td.board, mv);
         } else {
             scores[i] = td.quiet_history.get(&td.board, mv);


### PR DESCRIPTION
```
Elo   | 2.86 +- 2.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 25610 W: 6246 L: 6035 D: 13329
Penta | [149, 3018, 6277, 3195, 166]
```
Bench: 4294175