### PR TITLE
Less aggressive LMP

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,7 +1,7 @@
 pub const PIECE_VALUES: [i32; 7] = [100, 375, 400, 625, 1200, 0, 0];
 
 pub fn lmp_threshold(depth: i32, improving: bool) -> i32 {
-    (3 + depth * depth) / (2 - improving as i32)
+    (4 + depth * depth) / (2 - improving as i32)
 }
 
 #[cfg(not(feature = "spsa"))]


### PR DESCRIPTION
```
Elo   | 2.13 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 48516 W: 11808 L: 11511 D: 25197
Penta | [285, 5728, 11961, 5973, 311]
```
Bench: 4822920