### PR TITLE
Add a missing rule for pseudo-legal checks

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -307,6 +307,10 @@ impl Board {
             return false;
         }
 
+        if self.checkers().multiple() {
+            return !mv.is_capture() && piece == PieceType::King && king_attacks(from).contains(to);
+        }
+
         if piece == PieceType::Pawn {
             let offset = match self.side_to_move {
                 Color::White => 8,

--- a/src/board.rs
+++ b/src/board.rs
@@ -299,16 +299,16 @@ impl Board {
             return false;
         }
 
+        if self.piece_on(to).piece_type() == PieceType::King {
+            return false;
+        }
+
         if (mv.is_double_push() || mv.is_promotion() || mv.is_en_passant()) && piece != PieceType::Pawn {
             return false;
         }
 
         if mv.is_castling() && piece != PieceType::King {
             return false;
-        }
-
-        if self.checkers().multiple() {
-            return !mv.is_capture() && piece == PieceType::King && king_attacks(from).contains(to);
         }
 
         if piece == PieceType::Pawn {


### PR DESCRIPTION
Fix rare occurrences where a king could be captured, that led an illegal position, causing a crash. Apart from this edge case, there should be no functional changes. Merging as it passes non-regression tests and resolves a reproducible crash.

Fixed nodes
```
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14030 W: 4133 L: 4133 D: 5764
Penta | [0, 0, 7015, 0, 0]
```
STC
```
Elo   | -0.21 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.89, 2.89) [-5.00, 0.00]
Games | N: 33674 W: 8086 L: 8106 D: 17482
Penta | [149, 3670, 9223, 3642, 153]
```

Bench: 4420041