### PR TITLE
Simply to one reduction call per node

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -342,8 +342,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         move_count += 1;
 
+        let mut reduction = td.lmr.reduction(depth, move_count);
+
         if !is_root && !is_loss(best_score) {
-            let lmr_depth = (depth - td.lmr.reduction(depth, move_count) / 1024).max(0);
+            let lmr_depth = (depth - reduction / 1024).max(0);
 
             // Late Move Pruning (LMP)
             skip_quiets |= move_count >= lmp_threshold(depth, improving);
@@ -410,8 +412,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         // Late Move Reductions (LMR)
         if depth >= 3 && move_count > 1 + is_root as i32 && is_quiet {
-            let mut reduction = td.lmr.reduction(depth, move_count);
-
             reduction -= 4 * correction_value.abs();
 
             reduction -= (history - 512) / 16;


### PR DESCRIPTION
Elo   | 4.51 +- 6.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-10.00, 0.00]
Games | N: 2544 W: 647 L: 614 D: 1283
Penta | [18, 254, 690, 297, 13]
https://rickdiculous.pythonanywhere.com/test/3465/

bench: 4466384