### PR TITLE
Always penalize bad noisy

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -530,6 +530,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 td.quiet_history.update(&td.board, mv, -bonus);
             }
 
+            for &mv in noisy_moves.iter() {
+                td.noisy_history.update(&td.board, mv, -bonus);
+            }
+
             for index in [1, 2] {
                 if td.ply < index || td.stack[td.ply - index].mv == Move::NULL {
                     continue;


### PR DESCRIPTION
Whether the best-move is noisy or a quiet we need to penalize bad captures since we know supposedly good ones are sorted first and thus were searched before the best-move or otherwise no searched captures.

Elo   | 1.92 +- 1.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 63412 W: 15209 L: 14858 D: 33345
Penta | [326, 7511, 15686, 7852, 331]
https://rickdiculous.pythonanywhere.com/test/3498/

bench: 4288048