### PR TITLE
Fix averaging in RFP affecting mates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -231,7 +231,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && eval >= beta
         && eval >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32)
     {
-        return (eval + beta) / 2;
+        return ((eval + beta) / 2).clamp(-16384, 16384);
     }
 
     // Null Move Pruning (NMP)


### PR DESCRIPTION
Elo   | -0.19 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 33054 W: 7961 L: 7979 D: 17114
Penta | [173, 3509, 9159, 3535, 151]
https://rickdiculous.pythonanywhere.com/test/3514/

bench: 4288048