### PR TITLE
Allow LMR reduction into qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -441,7 +441,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction += 1024;
             }
 
-            let reduced_depth = (new_depth - reduction / 1024).max(1).min(new_depth);
+            let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth);
 
             score = -search::<false>(td, -alpha - 1, -alpha, reduced_depth, true);
 


### PR DESCRIPTION
```
Elo   | 2.58 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 29864 W: 7228 L: 7006 D: 15630
Penta | [145, 3526, 7381, 3722, 158]
```
Bench: 4318199