### PR TITLE
Skip history updates for single quiet moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -531,7 +531,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         } else {
             td.stack[td.ply].killer = best_move;
 
-            td.quiet_history.update(&td.board, best_move, bonus);
+            if !quiet_moves.is_empty() || depth > 3 {
+                td.quiet_history.update(&td.board, best_move, bonus);
+                update_continuation_histories(td, td.board.moved_piece(best_move), best_move.to(), bonus);
+            }
 
             for &mv in quiet_moves.iter() {
                 td.quiet_history.update(&td.board, mv, -bonus);
@@ -540,8 +543,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             for &mv in noisy_moves.iter() {
                 td.noisy_history.update(&td.board, mv, -bonus);
             }
-
-            update_continuation_histories(td, td.board.moved_piece(best_move), best_move.to(), bonus);
 
             for &mv in quiet_moves.iter() {
                 update_continuation_histories(td, td.board.moved_piece(mv), mv.to(), -bonus);


### PR DESCRIPTION
```
Elo   | 1.98 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 58908 W: 14272 L: 13937 D: 30699
Penta | [318, 6965, 14591, 7224, 356]
```
Bench: 4421388