### PR TITLE
Introduce negative extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -388,10 +388,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     extension = 1;
                     extension += (!PV && score < singular_beta - 24) as i32;
                     extension += (!PV && is_quiet && score < singular_beta - 128) as i32;
-                }
-                // Multi-Cut Pruning
-                else if score >= beta {
+                } else if score >= beta {
                     return score;
+                } else if entry.score >= beta {
+                    extension -= 2;
+                } else if cut_node {
+                    extension = -2;
                 }
             }
         }


### PR DESCRIPTION
```
Elo   | 1.85 +- 1.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 70894 W: 17078 L: 16700 D: 37116
Penta | [346, 8412, 17586, 8724, 379]
```

Bench: 4607597