### PR TITLE
Calculate SEE threshold based on move score in qsearch

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -37,12 +37,24 @@ impl MovePicker {
         }
     }
 
-    pub const fn new_noisy(threshold: i32) -> Self {
+    pub const fn new_probcut(threshold: i32) -> Self {
         Self {
             list: MoveList::new(),
             tt_move: Move::NULL,
             killer: Move::NULL,
             threshold: Some(threshold),
+            stage: Stage::GenerateNoisy,
+            bad_noisy: ArrayVec::new(),
+            bad_noisy_idx: 0,
+        }
+    }
+
+    pub const fn new_qsearch() -> Self {
+        Self {
+            list: MoveList::new(),
+            tt_move: Move::NULL,
+            killer: Move::NULL,
+            threshold: None,
             stage: Stage::GenerateNoisy,
             bad_noisy: ArrayVec::new(),
             bad_noisy_idx: 0,

--- a/src/search.rs
+++ b/src/search.rs
@@ -278,7 +278,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     let probcut_beta = beta + 256 - 64 * improving as i32;
 
     if depth >= 3 && !is_decisive(beta) && entry.is_none_or(|entry| entry.score >= probcut_beta) {
-        let mut move_picker = MovePicker::new_noisy(probcut_beta - static_eval);
+        let mut move_picker = MovePicker::new_probcut(probcut_beta - static_eval);
 
         let probcut_depth = 0.max(depth - 4);
 
@@ -625,7 +625,7 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
     let mut best_move = Move::NULL;
 
     let mut move_count = 0;
-    let mut move_picker = MovePicker::new_noisy(-110);
+    let mut move_picker = MovePicker::new_qsearch();
 
     let previous_square = match td.stack[td.ply - 1].mv {
         Move::NULL => Square::None,


### PR DESCRIPTION
```
Elo   | 2.15 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.50]
Games | N: 43854 W: 10756 L: 10485 D: 22613
Penta | [194, 5289, 10747, 5446, 251]
```
Bench: 4479962