### PR TITLE
Tweak NMP conditions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -247,6 +247,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && depth >= 3
         && eval >= beta
+        && eval >= static_eval
         && static_eval >= beta - 20 * depth + 128 * tt_pv as i32 + 180
         && td.board.has_non_pawns()
     {


### PR DESCRIPTION
```
Elo   | 1.62 +- 1.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 4.50]
Games | N: 98646 W: 23697 L: 23237 D: 51712
Penta | [499, 11625, 24594, 12127, 478]
```
Bench: 4126230