### PR TITLE
Replace game phase scaling with material scaling

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,7 +1,6 @@
 use crate::{board::Board, thread::ThreadData, types::PieceType};
 
-const MAX_PHASE: i32 = 62;
-const PHASE_WEIGHTS: [i32; PieceType::NUM - 1] = [0, 3, 3, 5, 9];
+const MATERIAL_VALUES: [i32; 6] = [128, 384, 416, 640, 1280, 0];
 
 /// Calculates the score of the current position from the perspective of the side to move.
 pub fn evaluate(td: &mut ThreadData) -> i32 {
@@ -9,16 +8,15 @@ pub fn evaluate(td: &mut ThreadData) -> i32 {
 
     #[cfg(not(feature = "datagen"))]
     {
-        eval -= eval * (MAX_PHASE - game_phase(&td.board)) / (5 * MAX_PHASE);
+        eval = eval * (22400 + material(&td.board)) / 32768;
     }
 
     eval.clamp(-16384, 16384)
 }
 
-fn game_phase(board: &Board) -> i32 {
-    [PieceType::Knight, PieceType::Bishop, PieceType::Rook, PieceType::Queen]
+fn material(board: &Board) -> i32 {
+    [PieceType::Pawn, PieceType::Knight, PieceType::Bishop, PieceType::Rook, PieceType::Queen]
         .iter()
-        .map(|&piece| board.pieces(piece).len() as i32 * PHASE_WEIGHTS[piece])
+        .map(|&pt| board.pieces(pt).len() as i32 * MATERIAL_VALUES[pt])
         .sum::<i32>()
-        .min(MAX_PHASE)
 }


### PR DESCRIPTION
```
Elo   | 2.52 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.50]
Games | N: 31680 W: 7663 L: 7433 D: 16584
Penta | [150, 3768, 7783, 3980, 159]
```
Bench: 4187589