### PR TITLE
Use i16 instead of i32 for history tables

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -8,7 +8,7 @@ type PieceToHistory<T> = [[T; 64]; 12];
 
 pub struct QuietHistory {
     // [side_to_move][from_threated][to_threated][from][to]
-    entries: Box<[[[FromToHistory<i32>; 2]; 2]; 2]>,
+    entries: Box<[[[FromToHistory<i16>; 2]; 2]; 2]>,
 }
 
 impl QuietHistory {
@@ -18,7 +18,7 @@ impl QuietHistory {
         let from_threated = board.is_threatened(mv.from()) as usize;
         let to_threated = board.is_threatened(mv.to()) as usize;
 
-        self.entries[board.side_to_move()][from_threated][to_threated][mv.from()][mv.to()]
+        self.entries[board.side_to_move()][from_threated][to_threated][mv.from()][mv.to()] as i32
     }
 
     pub fn update(&mut self, board: &Board, mv: Move, bonus: i32) {
@@ -26,7 +26,7 @@ impl QuietHistory {
         let to_threated = board.is_threatened(mv.to()) as usize;
 
         let entry = &mut self.entries[board.side_to_move()][from_threated][to_threated][mv.from()][mv.to()];
-        *entry += bonus - bonus.abs() * (*entry) / Self::MAX_HISTORY;
+        *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_HISTORY) as i16;
     }
 }
 
@@ -38,19 +38,19 @@ impl Default for QuietHistory {
 
 pub struct NoisyHistory {
     // [piece][to][captured_piece_type]
-    entries: Box<PieceToHistory<[i32; 7]>>,
+    entries: Box<PieceToHistory<[i16; 7]>>,
 }
 
 impl NoisyHistory {
     const MAX_HISTORY: i32 = 12288;
 
     pub fn get(&self, board: &Board, mv: Move) -> i32 {
-        self.entries[board.piece_on(mv.from())][mv.to()][board.piece_on(mv.to()).piece_type()]
+        self.entries[board.piece_on(mv.from())][mv.to()][board.piece_on(mv.to()).piece_type()] as i32
     }
 
     pub fn update(&mut self, board: &Board, mv: Move, bonus: i32) {
         let entry = &mut self.entries[board.piece_on(mv.from())][mv.to()][board.piece_on(mv.to()).piece_type()];
-        *entry += bonus - bonus.abs() * (*entry) / Self::MAX_HISTORY;
+        *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_HISTORY) as i16;
     }
 }
 
@@ -62,7 +62,7 @@ impl Default for NoisyHistory {
 
 pub struct CorrectionHistory {
     // [side_to_move][key]
-    entries: Box<[[i32; Self::SIZE]; 2]>,
+    entries: Box<[[i16; Self::SIZE]; 2]>,
 }
 
 impl CorrectionHistory {
@@ -72,14 +72,14 @@ impl CorrectionHistory {
     const MASK: usize = Self::SIZE - 1;
 
     pub fn get(&self, stm: Color, key: u64) -> i32 {
-        self.entries[stm][key as usize & Self::MASK] / 96
+        (self.entries[stm][key as usize & Self::MASK] / 96) as i32
     }
 
     pub fn update(&mut self, stm: Color, key: u64, depth: i32, diff: i32) {
         let entry = &mut self.entries[stm][key as usize & Self::MASK];
         let bonus = (diff * depth).clamp(-Self::MAX_HISTORY / 4, Self::MAX_HISTORY / 4);
 
-        *entry += bonus - bonus.abs() * (*entry) / Self::MAX_HISTORY;
+        *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_HISTORY) as i16;
     }
 }
 
@@ -91,19 +91,19 @@ impl Default for CorrectionHistory {
 
 pub struct ContinuationHistory {
     // [piece][to][continuation_piece][continuation_to]
-    entries: Box<[[PieceToHistory<i32>; 64]; 13]>,
+    entries: Box<[[PieceToHistory<i16>; 64]; 13]>,
 }
 
 impl ContinuationHistory {
     const MAX_HISTORY: i32 = 16384;
 
     pub fn get(&self, piece: Piece, sq: Square, cont_piece: Piece, cont_sq: Square) -> i32 {
-        self.entries[piece][sq][cont_piece][cont_sq]
+        self.entries[piece][sq][cont_piece][cont_sq] as i32
     }
 
     pub fn update(&mut self, piece: Piece, sq: Square, cont_piece: Piece, cont_sq: Square, bonus: i32) {
         let entry = &mut self.entries[piece][sq][cont_piece][cont_sq];
-        *entry += bonus - bonus.abs() * (*entry) / Self::MAX_HISTORY;
+        *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_HISTORY) as i16;
     }
 }
 


### PR DESCRIPTION
```
Elo   | 2.78 +- 4.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-7.00, 0.00]
Games | N: 5620 W: 1362 L: 1317 D: 2941
Penta | [32, 584, 1520, 655, 19]
```
Bench: 3823249