### PR TITLE
Introduce post LMR conthist updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -475,6 +475,16 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 if new_depth > reduced_depth {
                     score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
                 }
+
+                let bonus = match score {
+                    s if s >= beta => bonus(depth),
+                    s if s <= alpha => -bonus(depth),
+                    _ => 0,
+                };
+
+                td.ply -= 1;
+                update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
+                td.ply += 1;
             }
         }
         // Principal Variation Search (PVS)


### PR DESCRIPTION
The idea is common, since LMR is very common it is sometimes best to order moves such that the faster LMR cutting moves are ordered first.

Elo   | 3.67 +- 2.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.50]
Games | N: 16584 W: 3937 L: 3762 D: 8885
Penta | [73, 1925, 4135, 2072, 87]
https://rickdiculous.pythonanywhere.com/test/3673/

Bench: 4163448