### PR TITLE
Decrease LMR reduction in hindsight

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -226,6 +226,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
     let improving = !in_check && td.ply >= 2 && static_eval > td.stack[td.ply - 2].static_eval;
 
+    if td.ply >= 1 && td.stack[td.ply - 1].reduction >= 3072 && static_eval + td.stack[td.ply - 1].static_eval < 0 {
+        depth += 1;
+    }
+
     td.stack[td.ply].static_eval = static_eval;
     td.stack[td.ply].tt_pv = tt_pv;
 
@@ -466,7 +470,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth);
 
+            td.stack[td.ply - 1].reduction = reduction;
+
             score = -search::<false>(td, -alpha - 1, -alpha, reduced_depth, true);
+
+            td.stack[td.ply - 1].reduction = 0;
 
             if score > alpha && new_depth > reduced_depth {
                 new_depth += (score > best_score + 64) as i32;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -21,6 +21,7 @@ pub struct StackEntry {
     pub killer: Move,
     pub tt_pv: bool,
     pub cutoff_count: i32,
+    pub reduction: i32,
 }
 
 impl Default for StackEntry {
@@ -33,6 +34,7 @@ impl Default for StackEntry {
             killer: Move::NULL,
             tt_pv: false,
             cutoff_count: 0,
+            reduction: 0,
         }
     }
 }


### PR DESCRIPTION

```
Elo   | 6.03 +- 3.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.50]
Games | N: 8590 W: 2106 L: 1957 D: 4527
Penta | [40, 957, 2163, 1084, 51]
```
Bench: 3926338