### PR TITLE
Properly account for full move number in time management

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -48,7 +48,7 @@ pub struct Board {
     mailbox: [Piece; Square::NUM],
     state: InternalState,
     state_stack: Vec<InternalState>,
-    game_ply: usize,
+    fullmove_number: usize,
 }
 
 impl Board {
@@ -66,8 +66,8 @@ impl Board {
         self.side_to_move
     }
 
-    pub const fn game_ply(&self) -> usize {
-        self.game_ply
+    pub const fn fullmove_number(&self) -> usize {
+        self.fullmove_number
     }
 
     /// Returns the Zobrist hash key for the current position.
@@ -160,7 +160,9 @@ impl Board {
     }
 
     pub fn increment_game_ply(&mut self) {
-        self.game_ply += 1;
+        if self.side_to_move == Color::Black {
+            self.fullmove_number += 1;
+        }
     }
 
     /// Places a piece of the specified type and color on the square.
@@ -502,7 +504,7 @@ impl Default for Board {
             colors: [Bitboard::default(); Color::NUM],
             mailbox: [Piece::None; Square::NUM],
             state_stack: Vec::default(),
-            game_ply: 0,
+            fullmove_number: 0,
         }
     }
 }

--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -54,6 +54,7 @@ impl FromStr for Board {
         board.state.castling = parts.next().unwrap_or_default().into();
         board.state.en_passant = parts.next().unwrap_or_default().try_into().unwrap_or_default();
         board.state.halfmove_clock = parts.next().unwrap_or_default().parse().unwrap_or_default();
+        board.fullmove_number = parts.next().unwrap_or_default().parse().unwrap_or_default();
 
         board.update_threats();
         board.update_king_threats();

--- a/src/time.rs
+++ b/src/time.rs
@@ -22,7 +22,7 @@ pub struct TimeManager {
 }
 
 impl TimeManager {
-    pub fn new(limits: Limits, ply: usize) -> Self {
+    pub fn new(limits: Limits, fullmove_number: usize) -> Self {
         let soft;
         let hard;
 
@@ -32,8 +32,8 @@ impl TimeManager {
                 hard = ms;
             }
             Limits::Fischer(main, inc) => {
-                let soft_scale = 0.025 + 0.05 * (1.0 - (-0.017 * ply as f64).exp());
-                let hard_scale = 0.135 + 0.21 * (1.0 - (-0.015 * ply as f64).exp());
+                let soft_scale = 0.025 + 0.05 * (1.0 - (-0.034 * fullmove_number as f64).exp());
+                let hard_scale = 0.135 + 0.21 * (1.0 - (-0.030 * fullmove_number as f64).exp());
 
                 soft = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
                 hard = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -70,7 +70,7 @@ fn reset(threads: &mut ThreadPool, tt: &TranspositionTable) {
 fn go(threads: &mut ThreadPool, report: Report, tokens: &[&str]) {
     let board = &threads.main_thread().board;
     let limits = parse_limits(board.side_to_move(), tokens);
-    threads.main_thread().time_manager = TimeManager::new(limits, board.game_ply());
+    threads.main_thread().time_manager = TimeManager::new(limits, board.fullmove_number());
     threads.main_thread().set_stop(false);
 
     std::thread::scope(|scope| {


### PR DESCRIPTION
```
Elo   | -0.50 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.50, 0.00]
Games | N: 61584 W: 14556 L: 14645 D: 32383
Penta | [267, 6974, 16368, 6947, 236]
```
Bench: 3926338