### PR TITLE
Extend all moves at low depth if extensions greater than 1

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -408,6 +408,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     extension = 1;
                     extension += (!PV && score < singular_beta - 24) as i32;
                     extension += (!PV && is_quiet && score < singular_beta - 128) as i32;
+                    if extension > 1 && depth < 12 {
+                        depth += 1;
+                    }
                 } else if score >= beta {
                     return score;
                 } else if entry.score >= beta {


### PR DESCRIPTION
Elo   | 1.43 +- 1.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 97254 W: 23233 L: 22832 D: 51189
Penta | [473, 11491, 24288, 11912, 463]
https://rickdiculous.pythonanywhere.com/test/3682/

bench: 4909548