### PR TITLE
Add a constant offset to SEE pruning margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -380,7 +380,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             skip_quiets |= !in_check && is_quiet && lmr_depth < 10 && static_eval + 100 * lmr_depth + 150 <= alpha;
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
-            let threshold = if is_quiet { -30 * lmr_depth * lmr_depth } else { -95 * depth } - history / 32;
+            let threshold = if is_quiet { -30 * lmr_depth * lmr_depth } else { -95 * depth + 50 } - history / 32;
             if !td.board.see(mv, threshold) {
                 continue;
             }


### PR DESCRIPTION
```
Elo   | 2.16 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 4.50]
Games | N: 42936 W: 10307 L: 10040 D: 22589
Penta | [192, 5061, 10721, 5276, 218]
```
Bench: 4646962