### PR TITLE
Decrease reduction for killer moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -470,6 +470,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 if td.stack[td.ply].cutoff_count > 3 {
                     reduction += 1024;
                 }
+
+                if td.stack[td.ply - 1].killer == mv {
+                    reduction -= 1024;
+                }
             }
 
             let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth);


### PR DESCRIPTION
```
Elo   | 7.64 +- 4.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 7054 W: 1756 L: 1601 D: 3697
Penta | [28, 781, 1757, 930, 31]
```
Bench: 3955137