### PR TITLE
Fix time management based on evaluation stability

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -99,7 +99,7 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
             last_move = td.pv.best_move();
         }
 
-        if (score - eval_stability as i32).abs() < 12 {
+        if (score - average as i32).abs() < 12 {
             eval_stability = (eval_stability + 1).min(8);
         } else {
             eval_stability = 0;

--- a/src/search.rs
+++ b/src/search.rs
@@ -99,7 +99,7 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
             last_move = td.pv.best_move();
         }
 
-        if (score - average as i32).abs() < 12 {
+        if (score - average).abs() < 12 {
             eval_stability = (eval_stability + 1).min(8);
         } else {
             eval_stability = 0;


### PR DESCRIPTION
```
Elo   | 5.47 +- 4.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-4.00, 1.00]
Games | N: 5846 W: 1419 L: 1327 D: 3100
Penta | [21, 632, 1537, 700, 33]
```
Bench: 3955137