### PR TITLE
Introduce basic prior-counter-move (pcm) history updates

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -103,6 +103,10 @@ impl Board {
         self.state.threats
     }
 
+    pub fn prior_threats(&self) -> Bitboard {
+        self.state_stack.last().unwrap().threats
+    }
+
     /// Returns a `Bitboard` for the specified `Color`.
     pub fn colors(&self, color: Color) -> Bitboard {
         self.colors[color]

--- a/src/search.rs
+++ b/src/search.rs
@@ -594,8 +594,18 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
     }
 
-    if bound == Bound::Upper {
-        tt_pv |= td.ply >= 1 && td.stack[td.ply - 1].tt_pv;
+    if bound == Bound::Upper && td.ply >= 1 && depth > 3 {
+        td.ply -= 1;
+        tt_pv |= td.stack[td.ply].tt_pv;
+
+        let factor = 2;
+        let scaled_bonus = factor * bonus(depth);
+
+        let pcm_move = td.stack[td.ply].mv;
+        if pcm_move != Move::NULL && pcm_move.is_quiet() {
+            td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
+        }
+        td.ply += 1;
     }
 
     if !excluded {


### PR DESCRIPTION
The idea is that a move that make us try many moves and eventually make us fail low is probably good so boost its stats with hindsight.

the reasoning of a scaled bonus vs the normal update bonus can probably be related to the fact that the current depth of this ply is already decremented compared to the previous depth of the prior-counter-move it gets normally updated with.

Elo   | 3.87 +- 2.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 16414 W: 3957 L: 3774 D: 8683
Penta | [68, 1888, 4134, 2027, 90]
https://rickdiculous.pythonanywhere.com/test/3773/

bench: 5099312