### PR TITLE
Increase NMP reduction when no TT move

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -263,7 +263,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && static_eval >= beta - 20 * depth + 128 * tt_pv as i32 + 180
         && td.board.has_non_pawns()
     {
-        let r = 4 + depth / 3 + ((eval - beta) / 256).min(3) + tt_move.is_noisy() as i32;
+        let r = 4
+            + depth / 3
+            + ((eval - beta) / 256).min(3)
+            + tt_move.is_noisy() as i32
+            + (tt_move.is_null() && depth >= 4) as i32;
 
         td.stack[td.ply].piece = Piece::None;
         td.stack[td.ply].mv = Move::NULL;


### PR DESCRIPTION
```
Elo   | 2.00 +- 1.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 4.00]
Games | N: 50170 W: 11957 L: 11668 D: 26545
Penta | [211, 5950, 12500, 6187, 237]
```
Bench: 4914457