### PR TITLE
Introduce quiet history updates based on static evaluation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -224,6 +224,19 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
     }
 
+    if !in_check
+        && !excluded
+        && td.ply >= 1
+        && td.stack[td.ply - 1].mv.is_valid()
+        && td.stack[td.ply - 1].mv.is_quiet()
+        && td.stack[td.ply - 1].static_eval != Score::NONE
+    {
+        let value = 6 * -(static_eval + td.stack[td.ply - 1].static_eval);
+        let bonus = value.clamp(-64, 128);
+
+        td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), td.stack[td.ply - 1].mv, bonus);
+    }
+
     let improving = !in_check && td.ply >= 2 && static_eval > td.stack[td.ply - 2].static_eval;
 
     if td.ply >= 1 && td.stack[td.ply - 1].reduction >= 3072 && static_eval + td.stack[td.ply - 1].static_eval < 0 {


### PR DESCRIPTION
The idea is to update the history of a move based on how the static evaluation
changes after making the move. If it improves the evaluation, it's more likely to
be a good move, so the history is increased. The opposite also applies.

```
Elo   | 3.64 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 4.00]
Games | N: 18126 W: 4339 L: 4149 D: 9638
Penta | [67, 2136, 4482, 2296, 82]
```
Bench: 4054662