### PR TITLE
Fix bug in MVV scoring

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -1,7 +1,7 @@
 use crate::{
     parameters::PIECE_VALUES,
     thread::ThreadData,
-    types::{ArrayVec, Move, MoveList, MAX_MOVES},
+    types::{ArrayVec, Move, MoveList, PieceType, MAX_MOVES},
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd)]
@@ -155,9 +155,10 @@ impl MovePicker {
 
     fn score_noisy(&mut self, td: &ThreadData) {
         for entry in self.list.iter_mut() {
-            let captured = td.board.piece_on(entry.mv.to()).piece_type();
+            let captured =
+                if entry.mv.is_en_passant() { PieceType::Pawn } else { td.board.piece_on(entry.mv.to()).piece_type() };
 
-            entry.score = PIECE_VALUES[captured as usize % 6] * 16;
+            entry.score = PIECE_VALUES[captured] * 16;
             entry.score += td.noisy_history.get(&td.board, entry.mv);
         }
     }


### PR DESCRIPTION
Previously, a hack used the pawn value as the captured piece when the target
square was empty - this was meant to handle en passant, where the target square
is empty, but it's a pawn capture.
However, this also affects non-capture queen promotions, where the target square
is actually empty and should be treated as such.
```
Elo   | 1.07 +- 2.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 15214 W: 3552 L: 3505 D: 8157
Penta | [51, 1637, 4209, 1634, 76]
```
Bench: 4174377