### PR TITLE
Clear stack before starting root search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -60,6 +60,8 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
         }
 
         loop {
+            td.stack = Default::default();
+
             let current = search::<true>(td, alpha, beta, (depth - reduction).max(1), false);
 
             if td.stopped {


### PR DESCRIPTION
```
Elo   | 1.65 +- 3.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 12662 W: 3078 L: 3018 D: 6566
Penta | [54, 1506, 3156, 1556, 59]
```
Bench: 4416366