### PR TITLE
Less reduction for ttpv

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -464,7 +464,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         // Late Move Reductions (LMR)
         if depth >= 3 && move_count > 1 + is_root as i32 && (is_quiet || !tt_pv) {
             if tt_pv {
-                reduction -= 768;
+                reduction -= 768 + entry.is_some_and(|entry| entry.score > alpha) as i32 * 768;
             }
 
             if PV {


### PR DESCRIPTION
if entry score is higher than alpha

Elo   | 1.51 +- 1.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 105460 W: 25237 L: 24780 D: 55443
Penta | [499, 12566, 26163, 12983, 519]
https://rickdiculous.pythonanywhere.com/test/3838/

bench: 5731846