### PR TITLE
Remove depth guard from NMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -272,7 +272,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     if cut_node
         && !in_check
         && !excluded
-        && depth >= 3
         && eval >= beta
         && eval >= static_eval
         && static_eval >= beta - 20 * depth + 128 * tt_pv as i32 + 180


### PR DESCRIPTION
Elo   | 0.65 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18664 W: 4444 L: 4409 D: 9811
Penta | [90, 2202, 4714, 2235, 91]
https://rickdiculous.pythonanywhere.com/test/3846/

bench: 5628055