### PR TITLE
Simplify NMP reduction formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -277,11 +277,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && static_eval >= beta - 20 * depth + 128 * tt_pv as i32 + 180
         && td.board.has_non_pawns()
     {
-        let r = 4
-            + depth / 3
-            + ((eval - beta) / 256).min(3)
-            + tt_move.is_noisy() as i32
-            + (tt_move.is_null() && depth >= 4) as i32;
+        let r = 4 + depth / 3 + ((eval - beta) / 256).min(3) + (tt_move.is_null() || tt_move.is_noisy()) as i32;
 
         td.stack[td.ply].piece = Piece::None;
         td.stack[td.ply].mv = Move::NULL;


### PR DESCRIPTION
```
Elo   | 2.15 +- 3.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.50, 0.00]
Games | N: 11966 W: 2889 L: 2815 D: 6262
Penta | [50, 1291, 3231, 1357, 54]
```
Bench: 5628055