### PR TITLE
Late move pruning in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -712,6 +712,10 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
                 break;
             }
 
+            if move_count >= 3 {
+                break;
+            }
+
             if mv.is_quiet() {
                 continue;
             }


### PR DESCRIPTION
```
Elo   | 5.52 +- 3.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 10770 W: 2661 L: 2490 D: 5619
Penta | [52, 1246, 2625, 1403, 59]
```
Bench: 5530346