### PR TITLE
Nmp verification search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -6,7 +6,7 @@ use crate::{
     parameters::*,
     thread::ThreadData,
     transposition::Bound,
-    types::{is_decisive, is_loss, mate_in, mated_in, ArrayVec, Color, Move, Piece, Score, Square, MAX_PLY},
+    types::{is_decisive, is_loss, is_win, mate_in, mated_in, ArrayVec, Color, Move, Piece, Score, Square, MAX_PLY},
 };
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -286,7 +286,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         td.board.make_null_move();
 
-        let score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
+        let mut score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
         td.board.undo_null_move();
 
         td.ply -= 1;
@@ -295,7 +295,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             return Score::ZERO;
         }
 
-        if score >= beta && !is_decisive(score) {
+        if score >= beta {
+            if is_win(score) {
+                score = beta;
+            }
             if td.nmp_min_ply > 0 || depth < 16 {
                 return score;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -288,12 +288,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         let score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
         td.board.undo_null_move();
-
-  	td.ply -= 1;
-
-        if td.stopped {
-            return Score::ZERO;
-        }
 	
 	if td.nmp_min_ply > 0 || depth < 16 {
                         return score;
@@ -302,6 +296,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 	td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
         let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
 	td.nmp_min_ply = 0;
+
+	td.ply -= 1;
+
+        if td.stopped {
+            return Score::ZERO;
+        }
 
         match verified_score {
             s if is_decisive(s) => return beta,

--- a/src/search.rs
+++ b/src/search.rs
@@ -302,9 +302,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
             let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
             td.nmp_min_ply = 0;
+            
             if td.stopped {
                 return Score::ZERO;
             }
+            
             if verified_score >= beta {
                 return score;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -287,8 +287,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         td.board.make_null_move();
 
         let mut score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
-        td.board.undo_null_move();
 
+        td.board.undo_null_move();
         td.ply -= 1;
 
         if td.stopped {
@@ -299,17 +299,19 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             if is_win(score) {
                 score = beta;
             }
+
             if td.nmp_min_ply > 0 || depth < 16 {
                 return score;
             }
+
             td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
             let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
             td.nmp_min_ply = 0;
-            
+
             if td.stopped {
                 return Score::ZERO;
             }
-            
+
             if verified_score >= beta {
                 return score;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -288,15 +288,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         let score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
         td.board.undo_null_move();
-	
-	if td.nmp_min_ply > 0 || depth < 16 {
-			td.ply -= 1;
-                        return score;
-	}
-
-	td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
-        let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
-	td.nmp_min_ply = 0;
 
 	td.ply -= 1;
 
@@ -304,12 +295,24 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             return Score::ZERO;
         }
 
-        match verified_score {
-            s if is_decisive(s) => return beta,
-            s if s >= beta => return score,
-            _ => (),
+        if score >= beta {
+		    	if td.nmp_min_ply > 0 || depth < 16 {
+                        	return score;
+			}
+			if score >= beta {
+			td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
+        		let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
+			td.nmp_min_ply = 0;
+			if td.stopped {
+            			return Score::ZERO;
+        			}
+			if verified_score >= beta {
+				return score
+				}
+
+			}
+	    }
         }
-    }
 
     // ProbCut
     let probcut_beta = beta + 256 - 64 * improving as i32;

--- a/src/search.rs
+++ b/src/search.rs
@@ -295,7 +295,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             return Score::ZERO;
         }
 
-        if score >= beta {
+        if score >= beta && !is_decisive(score) {
             if td.nmp_min_ply > 0 || depth < 16 {
                 return score;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -289,27 +289,27 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
         td.board.undo_null_move();
 
-	td.ply -= 1;
+        td.ply -= 1;
 
         if td.stopped {
             return Score::ZERO;
         }
 
         if score >= beta {
-		    	if td.nmp_min_ply > 0 || depth < 16 {
-                        	return score;
-			}
-			td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
-        		let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
-			td.nmp_min_ply = 0;
-			if td.stopped {
-            			return Score::ZERO;
-        			}
-			if verified_score >= beta {
-				return score
-				}
-	    }
+            if td.nmp_min_ply > 0 || depth < 16 {
+                return score;
+            }
+            td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
+            let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
+            td.nmp_min_ply = 0;
+            if td.stopped {
+                return Score::ZERO;
+            }
+            if verified_score >= beta {
+                return score;
+            }
         }
+    }
 
     // ProbCut
     let probcut_beta = beta + 256 - 64 * improving as i32;

--- a/src/search.rs
+++ b/src/search.rs
@@ -290,6 +290,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         td.board.undo_null_move();
 	
 	if td.nmp_min_ply > 0 || depth < 16 {
+			td.ply -= 1;
                         return score;
 	}
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -299,7 +299,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 		    	if td.nmp_min_ply > 0 || depth < 16 {
                         	return score;
 			}
-			if score >= beta {
 			td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
         		let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
 			td.nmp_min_ply = 0;
@@ -309,8 +308,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 			if verified_score >= beta {
 				return score
 				}
-
-			}
 	    }
         }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -73,6 +73,7 @@ pub struct ThreadData<'a> {
     pub sel_depth: i32,
     pub completed_depth: i32,
     pub ply: usize,
+    pub nmp_min_ply: i32,
 }
 
 impl<'a> ThreadData<'a> {
@@ -101,6 +102,7 @@ impl<'a> ThreadData<'a> {
             sel_depth: 0,
             completed_depth: 0,
             ply: 0,
+            nmp_min_ply=0,
         }
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -102,7 +102,7 @@ impl<'a> ThreadData<'a> {
             sel_depth: 0,
             completed_depth: 0,
             ply: 0,
-            nmp_min_ply=0,
+            nmp_min_ply: 0,
         }
     }
 


### PR DESCRIPTION
Elo   | 2.71 +- 3.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.24 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 10258 W: 2467 L: 2387 D: 5404
Penta | [41, 1230, 2510, 1304, 44]
https://rickdiculous.pythonanywhere.com/test/3889/

Bench: 5266801