### PR TITLE
Introduce null move history

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -168,6 +168,29 @@ impl Default for ContinuationHistory {
     }
 }
 
+pub struct NullMoveHistory {
+    entries: Box<[FromToHistory<i16>; 2]>,
+}
+
+impl NullMoveHistory {
+    const MAX_HISTORY: i32 = 1024;
+
+    pub fn get(&self, stm: Color, mv: Move) -> i32 {
+        self.entries[stm][mv.from()][mv.to()] as i32
+    }
+
+    pub fn update(&mut self, stm: Color, mv: Move, bonus: i32) {
+        let entry = &mut self.entries[stm][mv.from()][mv.to()];
+        *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_HISTORY) as i16;
+    }
+}
+
+impl Default for NullMoveHistory {
+    fn default() -> Self {
+        Self { entries: zeroed_box() }
+    }
+}
+
 fn zeroed_box<T>() -> Box<T> {
     unsafe {
         let layout = std::alloc::Layout::new::<T>();

--- a/src/search.rs
+++ b/src/search.rs
@@ -275,7 +275,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && eval >= beta
         && eval >= static_eval
-        && static_eval >= beta - 20 * depth + 128 * tt_pv as i32 + 180
+        && static_eval
+            >= beta - 20 * depth + 128 * tt_pv as i32 + 180
+                - td.nmp_history.get(td.board.side_to_move(), td.stack[td.ply - 1].mv) / 16
         && td.ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
     {
@@ -295,6 +297,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         if td.stopped {
             return Score::ZERO;
         }
+
+        let bonus = if score >= beta { bonus(depth) / 2 } else { -bonus(depth) };
+        td.nmp_history.update(td.board.side_to_move(), td.stack[td.ply - 1].mv, bonus);
 
         if score >= beta {
             if is_win(score) {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     board::Board,
-    history::{ContinuationHistory, CorrectionHistory, NoisyHistory, QuietHistory},
+    history::{ContinuationHistory, CorrectionHistory, NoisyHistory, NullMoveHistory, QuietHistory},
     nnue::Network,
     stack::Stack,
     time::{Limits, TimeManager},
@@ -61,6 +61,7 @@ pub struct ThreadData<'a> {
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
     pub continuation_history: ContinuationHistory,
+    pub nmp_history: NullMoveHistory,
     pub pawn_corrhist: CorrectionHistory,
     pub minor_corrhist: CorrectionHistory,
     pub major_corrhist: CorrectionHistory,
@@ -91,6 +92,7 @@ impl<'a> ThreadData<'a> {
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
             continuation_history: ContinuationHistory::default(),
+            nmp_history: NullMoveHistory::default(),
             pawn_corrhist: CorrectionHistory::default(),
             minor_corrhist: CorrectionHistory::default(),
             major_corrhist: CorrectionHistory::default(),


### PR DESCRIPTION
The idea is to adjust the NMP static evaluation margin based on the history
of past results when using NMP in response to the opponent's last move.

```
Elo   | 1.96 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 52018 W: 12534 L: 12241 D: 27243
Penta | [244, 6121, 12991, 6404, 249]
```

Bench: 6151917