### PR TITLE
Increase LMR reduction in hindsight

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -246,6 +246,16 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth += 1;
     }
 
+    if !in_check
+        && depth >= 2
+        && td.ply >= 1
+        && td.stack[td.ply - 1].reduction >= 1024
+        && td.stack[td.ply - 1].static_eval != Score::NONE
+        && static_eval + td.stack[td.ply - 1].static_eval > 96
+    {
+        depth -= 1;
+    }
+
     td.stack[td.ply].static_eval = static_eval;
     td.stack[td.ply].tt_pv = tt_pv;
 


### PR DESCRIPTION
Increase the applied LMR reduction retroactively (decrease current node depth)
if the static evaluation gets worse.
```
Elo   | 2.89 +- 2.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 4.00]
Games | N: 26350 W: 6332 L: 6113 D: 13905
Penta | [111, 3092, 6554, 3303, 115]
```
Bench: 6404406