### PR TITLE
Refine LMR reduction formula based on cutoff count

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -506,8 +506,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     reduction += 1024;
                 }
 
-                if td.stack[td.ply].cutoff_count > 3 {
-                    reduction += 1024;
+                if td.stack[td.ply].cutoff_count > 2 {
+                    reduction += 896 + 64 * td.stack[td.ply].cutoff_count.max(8);
                 }
 
                 if td.stack[td.ply - 1].killer == mv {


### PR DESCRIPTION
```
Elo   | 3.52 +- 2.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19856 W: 4816 L: 4615 D: 10425
Penta | [101, 2292, 4932, 2511, 92]
```
Bench: 4745474