### PR TITLE
Simplify away constant offset in RFP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -273,8 +273,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && depth <= 8
         && eval >= beta
-        && eval
-            >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32) + correction_value.abs() / 2 - 20
+        && eval >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32) + correction_value.abs() / 2
     {
         return ((eval + beta) / 2).clamp(-16384, 16384);
     }


### PR DESCRIPTION
```
Elo   | 1.08 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 15422 W: 3698 L: 3650 D: 8074
Penta | [72, 1851, 3808, 1917, 63]
```
Bench: 5031365