### PR TITLE
Use TT value as a better position evaluation in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -708,18 +708,28 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
     let mut futility_score = Score::NONE;
 
     if !in_check {
-        let eval = evaluate(td) + correction_value(td);
+        let static_eval = evaluate(td) + correction_value(td);
+        best_score = static_eval;
 
-        if eval >= beta {
-            return eval;
+        if let Some(entry) = entry {
+            if match entry.bound {
+                Bound::Upper => entry.score < static_eval,
+                Bound::Lower => entry.score > static_eval,
+                _ => true,
+            } {
+                best_score = entry.score;
+            }
         }
 
-        if eval > alpha {
-            alpha = eval;
+        if best_score >= beta {
+            return best_score;
         }
 
-        best_score = eval;
-        futility_score = eval + 128;
+        if best_score > alpha {
+            alpha = best_score;
+        }
+
+        futility_score = static_eval + 128;
     }
 
     let mut best_move = Move::NULL;


### PR DESCRIPTION
```
Elo   | 2.00 +- 1.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 4.00]
Games | N: 49236 W: 11799 L: 11516 D: 25921
Penta | [199, 5824, 12293, 6099, 203]
```
Bench: 5094032