### PR TITLE
Use TT depth to adjust TT PV reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -491,7 +491,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         // Late Move Reductions (LMR)
         if depth >= 3 && move_count > 1 + is_root as i32 && (is_quiet || !tt_pv) {
             if tt_pv {
-                reduction -= 768 + entry.is_some_and(|entry| entry.score > alpha) as i32 * 768;
+                reduction -= 768;
+                reduction -= 768 * entry.is_some_and(|entry| entry.score > alpha) as i32;
+                reduction -= 768 * entry.is_some_and(|entry| entry.depth >= depth) as i32;
             }
 
             if PV {


### PR DESCRIPTION
```
Elo   | 2.35 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 35428 W: 8452 L: 8212 D: 18764
Penta | [124, 4242, 8759, 4448, 141]
```
Bench: 5437012