### PR TITLE
Push expected cutting late moves up in the move ordering.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -546,7 +546,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 }
 
                 let bonus = match score {
-                    s if s >= beta => stat_bonus(depth),
+                    s if s >= beta => (1 + 2 * (move_count > depth) as i32) * stat_bonus(depth),
                     s if s <= alpha => -stat_bonus(depth),
                     _ => 0,
                 };


### PR DESCRIPTION
since the passing of the LMR verification is coming from a relatively late move this means we have wasted some time trying/picking other moves, and it would make sense to push it up in the move ordering for future positions not to be as late.

bench: 5062688