### PR TITLE
Simplify away check extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -486,11 +486,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut new_depth = depth + extension - 1;
         let mut score = Score::ZERO;
 
-        // Check Extensions
-        if depth >= 8 && static_eval.abs() >= 128 && td.board.in_check() {
-            new_depth += 1;
-        }
-
         // Late Move Reductions (LMR)
         if depth >= 3 && move_count > 1 + is_root as i32 && (is_quiet || !tt_pv) {
             if tt_pv {


### PR DESCRIPTION
```
Elo   | -0.26 +- 1.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 58032 W: 13776 L: 13819 D: 30437
Penta | [267, 7037, 14481, 6934, 297]
```
Bench: 4108317