### PR TITLE
Add constant offset in RFP margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -276,7 +276,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && depth <= 8
         && eval >= beta
-        && eval >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32) + correction_value.abs() / 2
+        && eval
+            >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32) + correction_value.abs() / 2 + 25
     {
         return ((eval + beta) / 2).clamp(-16384, 16384);
     }


### PR DESCRIPTION
```
Elo   | 2.61 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 29794 W: 7292 L: 7068 D: 15434
Penta | [127, 3543, 7356, 3721, 150]
```
Bench: 4665569