### PR TITLE
Downgrade continuation histories' bonus of captures

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -547,11 +547,15 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
                 }
 
-                let bonus = match score {
+                let mut bonus = match score {
                     s if s >= beta => (1 + 2 * (move_count > depth) as i32) * stat_bonus(depth),
                     s if s <= alpha => -stat_bonus(depth),
                     _ => 0,
                 };
+
+                if !is_quiet {
+                    bonus /= 5;
+                }
 
                 td.ply -= 1;
                 update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);


### PR DESCRIPTION
Credits to @vizvezdenec back in the day

Elo   | 1.65 +- 1.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [0.00, 4.00]
Games | N: 81470 W: 19690 L: 19302 D: 42478
Penta | [344, 9728, 20298, 9926, 439]
https://rickdiculous.pythonanywhere.com/test/4044/

Bench: 4848798