### PR TITLE
Allow LMR rules for captures

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -509,27 +509,25 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction += 1024;
             }
 
-            if is_quiet {
-                reduction -= 4 * correction_value.abs();
+            reduction -= 4 * correction_value.abs();
 
-                reduction -= (history - 512) / 16;
-
-                if td.board.in_check() {
-                    reduction -= 1024;
-                }
-
-                if !improving {
-                    reduction += 1024;
-                }
-
-                if td.stack[td.ply].cutoff_count > 2 {
-                    reduction += 896 + 64 * td.stack[td.ply].cutoff_count.max(8);
-                }
-
-                if td.stack[td.ply - 1].killer == mv {
-                    reduction -= 1024;
-                }
+            if td.board.in_check() {
+                reduction -= 1024;
             }
+
+            if !improving {
+                reduction += 1024;
+            }
+
+            if td.stack[td.ply].cutoff_count > 2 {
+                reduction += 896 + 64 * td.stack[td.ply].cutoff_count.max(8);
+            }
+
+            if td.stack[td.ply - 1].killer == mv {
+                reduction -= 1024;
+            }
+
+            reduction -= (history - 512) / 16;
 
             let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth);
 


### PR DESCRIPTION
Elo   | -0.15 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 52602 W: 12519 L: 12541 D: 27542
Penta | [219, 6325, 13255, 6263, 239]
https://rickdiculous.pythonanywhere.com/test/4042/

bench: 4486366