### PR TITLE
Decouple noisy history updates from board

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -159,7 +159,13 @@ impl MovePicker {
                 if entry.mv.is_en_passant() { PieceType::Pawn } else { td.board.piece_on(entry.mv.to()).piece_type() };
 
             entry.score = PIECE_VALUES[captured] * 16;
-            entry.score += td.noisy_history.get(&td.board, entry.mv);
+
+            entry.score += td.noisy_history.get(
+                td.board.threats(),
+                td.board.moved_piece(entry.mv),
+                entry.mv.to(),
+                td.board.piece_on(entry.mv.to()).piece_type(),
+            );
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -424,7 +424,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 + td.conthist(1, mv)
                 + td.conthist(2, mv)
         } else {
-            td.noisy_history.get(&td.board, mv)
+            let captured = td.board.piece_on(mv.to()).piece_type();
+            td.noisy_history.get(td.board.threats(), td.board.moved_piece(mv), mv.to(), captured)
         };
 
         let mut reduction = td.lmr.reduction(depth, move_count);
@@ -625,10 +626,17 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let bonus = stat_bonus(depth);
 
         if best_move.is_noisy() {
-            td.noisy_history.update(&td.board, best_move, bonus);
+            td.noisy_history.update(
+                td.board.threats(),
+                td.board.moved_piece(best_move),
+                best_move.to(),
+                td.board.piece_on(best_move.to()).piece_type(),
+                bonus,
+            );
 
             for &mv in noisy_moves.iter() {
-                td.noisy_history.update(&td.board, mv, -bonus);
+                let captured = td.board.piece_on(mv.to()).piece_type();
+                td.noisy_history.update(td.board.threats(), td.board.moved_piece(mv), mv.to(), captured, -bonus);
             }
         } else {
             td.stack[td.ply].killer = best_move;
@@ -643,7 +651,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             for &mv in noisy_moves.iter() {
-                td.noisy_history.update(&td.board, mv, -bonus);
+                let captured = td.board.piece_on(mv.to()).piece_type();
+                td.noisy_history.update(td.board.threats(), td.board.moved_piece(mv), mv.to(), captured, -bonus);
             }
 
             for &mv in quiet_moves.iter() {


### PR DESCRIPTION
```
Elo   | -0.02 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 4.00]
Games | N: 33318 W: 8037 L: 8039 D: 17242
Penta | [167, 3995, 8335, 3997, 165]
```
Bench: 4621188