### PR TITLE
Less aggressive RFP for cut nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -283,7 +283,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && depth <= 8
         && eval >= beta
         && eval
-            >= beta + 80 * depth - (80 * improving as i32) - (60 * cut_node as i32) + correction_value.abs() / 2 + 25
+            >= beta + 80 * depth - (80 * improving as i32) - (30 * cut_node as i32) + correction_value.abs() / 2 + 25
     {
         return ((eval + beta) / 2).clamp(-16384, 16384);
     }


### PR DESCRIPTION
```
Elo   | 1.73 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 69458 W: 17043 L: 16697 D: 35718
Penta | [333, 8291, 17151, 8605, 349]
```
Bench: 5229599