### PR TITLE
Adjust fail high score in quiescence search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -836,6 +836,10 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
         return mated_in(td.ply);
     }
 
+    if best_score >= beta && !is_decisive(best_score) && !is_decisive(beta) {
+        best_score = (3 * best_score + beta) / 4;
+    }
+
     let bound = if best_score >= beta { Bound::Lower } else { Bound::Upper };
 
     td.tt.write(td.board.hash(), 0, raw_eval, best_score, bound, best_move, td.ply, tt_pv);


### PR DESCRIPTION
```
Elo   | 1.58 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 88204 W: 21606 L: 21205 D: 45393
Penta | [396, 10500, 21916, 10887, 403]
```

Bench: 4868865