### PR TITLE
Partially fix improving calculation after null move

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -249,7 +249,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), td.stack[td.ply - 1].mv, bonus);
     }
 
-    let improving = !in_check && td.ply >= 2 && static_eval > td.stack[td.ply - 2].static_eval;
+    let improving = !in_check
+        && td.ply >= 2
+        && td.stack[td.ply - 1].mv.is_valid()
+        && static_eval > td.stack[td.ply - 2].static_eval;
 
     if td.ply >= 1 && td.stack[td.ply - 1].reduction >= 3072 && static_eval + td.stack[td.ply - 1].static_eval < 0 {
         depth += 1;


### PR DESCRIPTION
```
Elo   | 1.44 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 18820 W: 4586 L: 4508 D: 9726
Penta | [100, 2205, 4702, 2323, 80]
```
Bench: 4521641