### PR TITLE
Improve fail high score adjustment in quiescence search 

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -837,7 +837,7 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
     }
 
     if best_score >= beta && !is_decisive(best_score) && !is_decisive(beta) {
-        best_score = (3 * best_score + beta) / 4;
+        best_score = (best_score + beta) / 2;
     }
 
     let bound = if best_score >= beta { Bound::Lower } else { Bound::Upper };


### PR DESCRIPTION
```
Elo   | 2.53 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 31524 W: 7791 L: 7561 D: 16172
Penta | [137, 3712, 7850, 3910, 153]
```
Bench: 5233220