### PR TITLE
Fix 50‑move rule in-check edge case

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -236,9 +236,8 @@ impl Board {
         }
     }
 
-    /// Returns `true` if the position is a draw by the fifty-move rule.
-    pub const fn draw_by_fifty_move_rule(&self) -> bool {
-        self.state.halfmove_clock >= 100
+    pub fn draw_by_fifty_move_rule(&self) -> bool {
+        self.state.halfmove_clock >= 100 && (!self.in_check() || self.has_legal_moves())
     }
 
     pub const fn halfmove_clock(&self) -> u8 {

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -7,6 +7,12 @@ const QUIET: u8 = 0;
 const NOISY: u8 = 1;
 
 impl super::Board {
+    pub fn has_legal_moves(&self) -> bool {
+        let mut list = MoveList::new();
+        self.append_all_moves(&mut list);
+        list.iter().any(|entry| self.is_legal(entry.mv))
+    }
+
     /// Generates all possible pseudo legal moves for the current position.
     pub fn generate_all_moves(&self) -> MoveList {
         let mut list = MoveList::new();


### PR DESCRIPTION
```
Elo   | 2.38 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 12682 W: 3075 L: 2988 D: 6619
Penta | [62, 1232, 3652, 1347, 48]
```
Bench: 4857960