### PR TITLE
Make Pv search shallower in some cases

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -562,6 +562,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 td.ply -= 1;
                 update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
                 td.ply += 1;
+            } else if score > alpha && score < best_score + 16 {
+                new_depth -= 1;
             }
         }
         // Full Depth Search (FDS)


### PR DESCRIPTION

Conditions are the same as they are for doShallowerSearch, just that
they also apply for cases where LMR wasn't reducing anything - if result
is bad enough reduce search depth of PV search by 1.

Elo   | 2.72 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 27854 W: 6784 L: 6566 D: 14504
Penta | [120, 3290, 6908, 3470, 139]
https://rickdiculous.pythonanywhere.com/test/4204/

Credits to @Vizvezdenec

bench: 4272130