### PR TITLE
Apply post-LMR bonus only after research

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -547,21 +547,21 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
                 if new_depth > reduced_depth {
                     score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
+
+                    let mut bonus = match score {
+                        s if s >= beta => (1 + 2 * (move_count > depth) as i32) * stat_bonus(depth),
+                        s if s <= alpha => -stat_bonus(depth),
+                        _ => 0,
+                    };
+
+                    if !is_quiet {
+                        bonus /= 5;
+                    }
+
+                    td.ply -= 1;
+                    update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
+                    td.ply += 1;
                 }
-
-                let mut bonus = match score {
-                    s if s >= beta => (1 + 2 * (move_count > depth) as i32) * stat_bonus(depth),
-                    s if s <= alpha => -stat_bonus(depth),
-                    _ => 0,
-                };
-
-                if !is_quiet {
-                    bonus /= 5;
-                }
-
-                td.ply -= 1;
-                update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
-                td.ply += 1;
             } else if score > alpha && score < best_score + 16 {
                 new_depth -= 1;
             }


### PR DESCRIPTION
```
Elo   | 3.17 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 21806 W: 5363 L: 5164 D: 11279
Penta | [93, 2531, 5461, 2720, 98]
```
Bench: 4353693