### PR TITLE
Update default netowrk to v17-d6ece029.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v16-4dd4d325.nnue";
+const NETWORK_NAME: &str = "v17-d6ece029.nnue";
 
 fn main() {
     generate_model_env();

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -18,7 +18,7 @@ mod avx2;
 mod ssse3;
 
 const INPUT_SIZE: usize = 768;
-const HIDDEN_SIZE: usize = 640;
+const HIDDEN_SIZE: usize = 768;
 
 const NETWORK_SCALE: i32 = 400;
 const NETWORK_QA: i32 = 384;


### PR DESCRIPTION
Update default net work to v17. First net with L1=768

Fixed Node:
Elo   | 13.26 +- 6.63 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 4.00]
Games | N: 5506 W: 1930 L: 1720 D: 1856
Penta | [170, 580, 1117, 642, 244]
https://rickdiculous.pythonanywhere.com/test/4260/

STC:
Elo   | 6.89 +- 4.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8118 W: 2115 L: 1954 D: 4049
Penta | [38, 931, 1971, 1070, 49]
https://rickdiculous.pythonanywhere.com/test/4261/

Bench: 4118955