### PR TITLE
Increase aspiration window if previous searches expanded heavily

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -39,6 +39,5 @@ macro_rules! define {
 }
 
 define! {
-    i32 asp_delta: 12;
     i32 asp_div:   32768;
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -41,6 +41,8 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
     let mut eval_stability = 0;
     let mut pv_stability = 0;
 
+    let mut window_expansions = 0;
+
     for depth in 1..MAX_PLY as i32 {
         td.sel_depth = 0;
         td.root_depth = depth;
@@ -48,7 +50,7 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
         let mut alpha = -Score::INFINITE;
         let mut beta = Score::INFINITE;
 
-        let mut delta = asp_delta();
+        let mut delta = 12 + 6 * (window_expansions >= 4) as i32;
         let mut reduction = 0;
 
         // Aspiration Windows
@@ -71,15 +73,18 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
 
             match current {
                 s if s <= alpha => {
+                    window_expansions += 1;
                     beta = (alpha + beta) / 2;
                     alpha = (current - delta).max(-Score::INFINITE);
                     reduction = 0;
                 }
                 s if s >= beta => {
+                    window_expansions += 1;
                     beta = (current + delta).min(Score::INFINITE);
                     reduction += 1;
                 }
                 _ => {
+                    window_expansions /= 2;
                     average = if average == Score::NONE { current } else { (average + current) / 2 };
                     break;
                 }


### PR DESCRIPTION
```
Elo   | 4.73 +- 3.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11962 W: 2987 L: 2824 D: 6151
Penta | [36, 1301, 3154, 1444, 46]
```
https://rickdiculous.pythonanywhere.com/test/4275/

Bench: 4267336