### PR TITLE
Simplify aspiration window expansion

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -41,7 +41,7 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
     let mut eval_stability = 0;
     let mut pv_stability = 0;
 
-    let mut window_expansions = 0;
+    let mut window_expansion = 0;
 
     for depth in 1..MAX_PLY as i32 {
         td.sel_depth = 0;
@@ -50,12 +50,12 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
         let mut alpha = -Score::INFINITE;
         let mut beta = Score::INFINITE;
 
-        let mut delta = 12 + 6 * (window_expansions >= 4) as i32;
+        let mut delta = 12;
         let mut reduction = 0;
 
         // Aspiration Windows
         if depth >= 4 {
-            delta += average * average / asp_div();
+            delta += window_expansion + average * average / asp_div();
 
             alpha = (average - delta).max(-Score::INFINITE);
             beta = (average + delta).min(Score::INFINITE);
@@ -73,18 +73,18 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
 
             match current {
                 s if s <= alpha => {
-                    window_expansions += 1;
+                    window_expansion += 1;
                     beta = (alpha + beta) / 2;
                     alpha = (current - delta).max(-Score::INFINITE);
                     reduction = 0;
                 }
                 s if s >= beta => {
-                    window_expansions += 1;
+                    window_expansion += 1;
                     beta = (current + delta).min(Score::INFINITE);
                     reduction += 1;
                 }
                 _ => {
-                    window_expansions /= 2;
+                    window_expansion /= 2;
                     average = if average == Score::NONE { current } else { (average + current) / 2 };
                     break;
                 }


### PR DESCRIPTION
```
Elo   | 4.73 +- 3.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 8152 W: 2018 L: 1907 D: 4227
Penta | [35, 933, 2037, 1028, 43]
```
https://rickdiculous.pythonanywhere.com/test/4281/

Bench: 4452236