### PR TITLE
Update default network to v18-bf93ebe8.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v17-d6ece029.nnue";
+const NETWORK_NAME: &str = "v18-bf93ebe8.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed Node:
Elo   | 2.58 +- 2.07 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 54310 W: 18004 L: 17601 D: 18705
Penta | [1849, 5981, 11178, 6212, 1935]
https://rickdiculous.pythonanywhere.com/test/4293/

STC:
Elo   | 3.61 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19226 W: 4873 L: 4673 D: 9680
Penta | [86, 2289, 4700, 2415, 123]
https://rickdiculous.pythonanywhere.com/test/4294/

Bench: 4246609