### PR TITLE
Fix overflow in histories

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -21,6 +21,7 @@ impl QuietHistoryEntry {
 
     pub fn update_factorizer(&mut self, bonus: i32) {
         let entry = &mut self.factorizer;
+        let bonus = bonus.clamp(-Self::MAX_FACTORIZER, Self::MAX_FACTORIZER);
         *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_FACTORIZER) as i16;
     }
 


### PR DESCRIPTION
Elo   | -0.63 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.34 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 12754 W: 3041 L: 3064 D: 6649
Penta | [70, 1526, 3186, 1547, 48]
https://rickdiculous.pythonanywhere.com/test/4324/

need to merge before CCC update
Bench: 4363227