### PR TITLE
Simplify away null move history

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -162,29 +162,6 @@ impl Default for ContinuationHistory {
     }
 }
 
-pub struct NullMoveHistory {
-    entries: Box<[FromToHistory<i16>; 2]>,
-}
-
-impl NullMoveHistory {
-    const MAX_HISTORY: i32 = 1024;
-
-    pub fn get(&self, stm: Color, mv: Move) -> i32 {
-        self.entries[stm][mv.from()][mv.to()] as i32
-    }
-
-    pub fn update(&mut self, stm: Color, mv: Move, bonus: i32) {
-        let entry = &mut self.entries[stm][mv.from()][mv.to()];
-        *entry += (bonus - bonus.abs() * (*entry) as i32 / Self::MAX_HISTORY) as i16;
-    }
-}
-
-impl Default for NullMoveHistory {
-    fn default() -> Self {
-        Self { entries: zeroed_box() }
-    }
-}
-
 fn zeroed_box<T>() -> Box<T> {
     unsafe {
         let layout = std::alloc::Layout::new::<T>();

--- a/src/search.rs
+++ b/src/search.rs
@@ -304,9 +304,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && eval >= beta
         && eval >= static_eval
-        && static_eval
-            >= beta - 20 * depth + 128 * tt_pv as i32 + 180
-                - td.nmp_history.get(td.board.side_to_move(), td.stack[td.ply - 1].mv) / 16
+        && static_eval >= beta - 20 * depth + 128 * tt_pv as i32 + 180
         && td.ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
     {
@@ -326,9 +324,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         if td.stopped {
             return Score::ZERO;
         }
-
-        let bonus = if score >= beta { stat_bonus(depth) / 2 } else { -stat_bonus(depth) };
-        td.nmp_history.update(td.board.side_to_move(), td.stack[td.ply - 1].mv, bonus);
 
         if score >= beta {
             if is_win(score) {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     board::Board,
-    history::{ContinuationHistory, CorrectionHistory, NoisyHistory, NullMoveHistory, QuietHistory},
+    history::{ContinuationHistory, CorrectionHistory, NoisyHistory, QuietHistory},
     nnue::Network,
     stack::Stack,
     time::{Limits, TimeManager},
@@ -65,7 +65,6 @@ pub struct ThreadData<'a> {
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
     pub continuation_history: ContinuationHistory,
-    pub nmp_history: NullMoveHistory,
     pub pawn_corrhist: CorrectionHistory,
     pub minor_corrhist: CorrectionHistory,
     pub major_corrhist: CorrectionHistory,
@@ -97,7 +96,6 @@ impl<'a> ThreadData<'a> {
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
             continuation_history: ContinuationHistory::default(),
-            nmp_history: NullMoveHistory::default(),
             pawn_corrhist: CorrectionHistory::default(),
             minor_corrhist: CorrectionHistory::default(),
             major_corrhist: CorrectionHistory::default(),


### PR DESCRIPTION
```
Elo   | 1.97 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 15310 W: 3737 L: 3650 D: 7923
Penta | [61, 1847, 3771, 1896, 80]
```
Bench: 4589131