### PR TITLE
LMR reduction offset

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -499,6 +499,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         if depth >= 3 && move_count > 1 + is_root as i32 && (is_quiet || !tt_pv) {
             reduction -= (history - 512) / 16;
             reduction -= 4 * correction_value.abs();
+            reduction -= move_count * 64;
+            reduction += 256;
 
             if tt_pv {
                 reduction -= 768;


### PR DESCRIPTION
Elo   | 1.64 +- 1.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 79640 W: 19446 L: 19071 D: 41123
Penta | [311, 9521, 19851, 9756, 381]
https://rickdiculous.pythonanywhere.com/test/4348/

Bench: 5107311