### PR TITLE
Fix hindsight LMR being applied twice in SE

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -261,6 +261,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     if !in_check
+        && !excluded
         && td.ply >= 1
         && td.stack[td.ply - 1].reduction >= 2761
         && static_eval + td.stack[td.ply - 1].static_eval < 0
@@ -269,6 +270,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     if !in_check
+        && !excluded
         && depth >= 2
         && td.ply >= 1
         && td.stack[td.ply - 1].reduction >= 1053


### PR DESCRIPTION
```
Elo   | -0.03 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 47482 W: 11494 L: 11498 D: 24490
Penta | [210, 5754, 11839, 5706, 232]
```
Bench: 7776751