### PR TITLE
Fix hindsight LMR in Probcut

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -381,7 +381,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             let mut score = -qsearch::<false>(td, -probcut_beta, -probcut_beta + 1);
 
             if score >= probcut_beta && probcut_depth > 0 {
+                td.stack[td.ply].reduction = 1024 * (depth - 1 - probcut_depth);
                 score = -search::<false>(td, -probcut_beta, -probcut_beta + 1, probcut_depth, !cut_node);
+                td.stack[td.ply].reduction = 0;
             }
 
             undo_move(td, mv);


### PR DESCRIPTION
it was using garbage values from previous searches.
`depth - 1` is the `new_depth`
so `reduction` is `depth - 1 - probcut_depth`

Elo   | 1.81 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 60510 W: 14833 L: 14518 D: 31159
Penta | [245, 7164, 15169, 7385, 292]
https://rickdiculous.pythonanywhere.com/test/4449/

bench: 7683056