### PR TITLE
Hindsight Reduction fix for NMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -327,7 +327,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         td.board.make_null_move();
 
+        td.stack[td.ply].reduction = 1024 * (r - 1);
         let mut score = -search::<false>(td, -beta, -beta + 1, depth - r, false);
+        td.stack[td.ply].reduction = 0;
 
         td.board.undo_null_move();
         td.ply -= 1;
@@ -346,7 +348,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             td.nmp_min_ply = td.ply as i32 + 3 * (depth - r) / 4;
+            td.stack[td.ply].reduction = 1024 * (r - 1);
             let verified_score = search::<false>(td, beta - 1, beta, depth - r, false);
+            td.stack[td.ply].reduction = 0;
             td.nmp_min_ply = 0;
 
             if td.stopped {


### PR DESCRIPTION
Again, prevents using garbage values for the reduction variable, mostly at verification

Elo   | 0.20 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 37120 W: 9008 L: 8987 D: 19125
Penta | [165, 4506, 9209, 4503, 177]
https://rickdiculous.pythonanywhere.com/test/4458/

bench: 8058987