### PR TITLE
Mitigate transposition GHI

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -73,8 +73,8 @@ impl Board {
     }
 
     /// Returns the Zobrist hash key for the current position.
-    pub const fn hash(&self) -> u64 {
-        self.state.key
+    pub fn hash(&self) -> u64 {
+        self.state.key ^ ZOBRIST.halfmove_clock[(self.state.halfmove_clock.saturating_sub(8) as usize / 8).min(15)]
     }
 
     pub const fn pawn_key(&self) -> u64 {

--- a/src/types/zobrist.rs
+++ b/src/types/zobrist.rs
@@ -5,11 +5,12 @@ pub struct Zobrist {
     pub en_passant: [u64; 64],
     pub castling: [u64; 16],
     pub side: u64,
+    pub halfmove_clock: [u64; 16],
 }
 
 pub const ZOBRIST: Zobrist = {
     let mut seed = 0xFFAA_B58C_5833_FE89u64;
-    let mut zobrist = [0; 849];
+    let mut zobrist = [0; 865];
 
     let mut i = 0;
     while i < zobrist.len() {


### PR DESCRIPTION
Passed STC on fortress positions
```
Elo   | 9.74 +- 4.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 3496 W: 728 L: 630 D: 2138
Penta | [5, 150, 1339, 250, 4]
```

Passed non-regression STC
```
Elo   | 4.60 +- 3.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 0.00]
Games | N: 8312 W: 2035 L: 1925 D: 4352
Penta | [32, 946, 2097, 1042, 39]
```

Bench: 7479913