### PR TITLE
Introduce big brain reductions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -583,7 +583,9 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
         // Full Depth Search (FDS)
         else if !PV || move_count > 1 {
+            td.stack[td.ply - 1].reduction = 1024 * ((depth - 1) - new_depth);
             score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
+            td.stack[td.ply - 1].reduction = 0;
         }
 
         // Principal Variation Search (PVS)


### PR DESCRIPTION
This is a follow-up on series of refining this concept this is to avoid garbage values and to mitigate negative extended moves and overly extended ones
note that here ply - 1 refers to current ply because do_move increase it

Elo   | 2.60 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 29814 W: 7353 L: 7130 D: 15331
Penta | [112, 3508, 7470, 3679, 138]
https://recklesschess.space/test/4528/

bench: 7681893