### PR TITLE
Extract killer moves into its own stage

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -9,6 +9,7 @@ pub enum Stage {
     HashMove,
     GenerateNoisy,
     GoodNoisy,
+    Killer,
     GenerateQuiet,
     Quiet,
     BadNoisy,
@@ -103,7 +104,18 @@ impl MovePicker {
                 return Some(entry.mv);
             }
 
-            self.stage = Stage::GenerateQuiet;
+            self.stage = Stage::Killer;
+        }
+
+        if self.stage == Stage::Killer {
+            if !skip_quiets {
+                self.stage = Stage::GenerateQuiet;
+                if self.killer != self.tt_move && td.board.is_pseudo_legal(self.killer) {
+                    return Some(self.killer);
+                }
+            } else {
+                self.stage = Stage::BadNoisy;
+            }
         }
 
         if self.stage == Stage::GenerateQuiet {
@@ -127,7 +139,7 @@ impl MovePicker {
                     }
 
                     let entry = self.list.remove(index);
-                    if entry.mv == self.tt_move {
+                    if entry.mv == self.tt_move || entry.mv == self.killer {
                         continue;
                     }
 
@@ -172,8 +184,6 @@ impl MovePicker {
     fn score_quiet(&mut self, td: &ThreadData) {
         for entry in self.list.iter_mut() {
             let mv = entry.mv;
-
-            entry.score = (1 << 18) * (mv == self.killer) as i32;
 
             entry.score += 1247 * td.quiet_history.get(td.board.threats(), td.board.side_to_move(), mv) / 1024
                 + 1011 * td.conthist(1, mv) / 1024


### PR DESCRIPTION
```
Elo   | 2.50 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 30934 W: 7547 L: 7324 D: 16063
Penta | [125, 3640, 7715, 3861, 126]
```
Bench: 8308505