### PR TITLE
Keep refining hindsight concept

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -276,7 +276,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth += 1;
     }
 
-    if !in_check
+    if !tt_pv
+        && !in_check
         && !excluded
         && depth >= 2
         && td.ply >= 1


### PR DESCRIPTION
Guard old PVs from doing a static eval difference based hindsight reduction, as the static eval is not relevant anymore for such entry that made it to the PV, suggesting it's likely incorrect anyways. Generally we also mitigate tt_pv from reductions.

Elo   | 1.81 +- 1.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 61390 W: 15059 L: 14739 D: 31592
Penta | [263, 7343, 15211, 7567, 311]
https://recklesschess.space/test/4577/

bench: 8153057