### PR TITLE
Scale do deeper margin based on depth

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -559,7 +559,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             td.stack[td.ply - 1].reduction = 0;
 
             if score > alpha && new_depth > reduced_depth {
-                new_depth += (score > best_score + 68) as i32;
+                new_depth += (score > best_score + 48 + 4 * depth) as i32;
                 new_depth -= (score < best_score + new_depth) as i32;
 
                 if new_depth > reduced_depth {


### PR DESCRIPTION
```
Elo   | 1.64 +- 1.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 80324 W: 19707 L: 19327 D: 41290
Penta | [368, 9501, 20092, 9785, 416]
```
Bench: 7667854