### PR TITLE
Reduce depth after alpha raises at PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -626,6 +626,10 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     td.stack[td.ply].cutoff_count += 1;
                     break;
                 }
+
+                if depth > 2 && depth < 16 && !is_decisive(score) {
+                    depth -= 1;
+                }
             }
         }
 


### PR DESCRIPTION
```
Elo   | 2.50 +- 2.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 32502 W: 8004 L: 7770 D: 16728
Penta | [149, 3878, 7987, 4064, 173]
```
https://recklesschess.space/test/4702/

Bench: 5422304