### PR TITLE
Update quiet history on TT hit

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,7 +1,7 @@
 use crate::types::{Bitboard, Color, Move, Piece, PieceType, Square};
 
 type FromToHistory<T> = [[T; 64]; 64];
-type PieceToHistory<T> = [[T; 64]; 12];
+type PieceToHistory<T> = [[T; 64]; 13];
 
 fn apply_bonus<const MAX: i32>(entry: &mut i16, bonus: i32) {
     let bonus = bonus.clamp(-MAX, MAX);

--- a/src/search.rs
+++ b/src/search.rs
@@ -210,6 +210,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 _ => true,
             }
         {
+            if tt_move.is_some() && tt_move.is_quiet() && entry.score >= beta {
+                let bonus = (133 * depth - 65).min(1270);
+                td.quiet_history.update(td.board.threats(), td.board.side_to_move(), tt_move, bonus);
+            }
+
             return entry.score;
         }
     }


### PR DESCRIPTION
```
Elo   | 3.51 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 18786 W: 4645 L: 4455 D: 9686
Penta | [81, 2187, 4680, 2351, 94]
```
https://recklesschess.space/test/4707/

Bench: 6428452