### PR TITLE
Update continuation history on TT hit

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -213,6 +213,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             if tt_move.is_some() && tt_move.is_quiet() && entry.score >= beta {
                 let bonus = (133 * depth - 65).min(1270);
                 td.quiet_history.update(td.board.threats(), td.board.side_to_move(), tt_move, bonus);
+                update_continuation_histories(td, td.board.moved_piece(tt_move), tt_move.to(), bonus);
             }
 
             return entry.score;


### PR DESCRIPTION
```
Elo   | 2.56 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 31240 W: 7692 L: 7462 D: 16086
Penta | [144, 3620, 7886, 3802, 168]
```
https://recklesschess.space/test/4708/

Bench: 5492017