### PR TITLE
Use unadjusted depth in malus calculations

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -420,6 +420,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth -= 1;
     }
 
+    let initial_depth = depth;
+
     let mut best_score = -Score::INFINITE;
     let mut best_move = Move::NULL;
     let mut bound = Bound::Upper;
@@ -657,13 +659,13 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
     if best_move.is_some() {
         let bonus_noisy = (133 * depth - 65).min(1270);
-        let malus_noisy = (143 * depth - 75).min(1270) - 15 * (move_count - 1);
+        let malus_noisy = (143 * initial_depth - 75).min(1270) - 15 * (move_count - 1);
 
         let bonus_quiet = (126 * depth - 75).min(1325);
-        let malus_quiet = (119 * depth - 59).min(1180) - 18 * (move_count - 1);
+        let malus_quiet = (119 * initial_depth - 59).min(1180) - 18 * (move_count - 1);
 
         let bonus_cont = (139 * depth - 61).min(1433);
-        let malus_cont = (171 * depth - 67).min(1047) - 16 * (move_count - 1);
+        let malus_cont = (171 * initial_depth - 67).min(1047) - 16 * (move_count - 1);
 
         if best_move.is_noisy() {
             td.noisy_history.update(


### PR DESCRIPTION
```
Elo   | 1.80 +- 1.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 62382 W: 15508 L: 15184 D: 31690
Penta | [278, 7462, 15405, 7750, 296]
```
https://recklesschess.space/test/4709/

Bench: 6044868