### PR TITLE
Introduce LMR extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -558,7 +558,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 978;
             }
 
-            let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth);
+            let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth + (PV || cut_node) as i32);
 
             td.stack[td.ply - 1].reduction = reduction;
 


### PR DESCRIPTION
```
Elo   | 2.75 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 28046 W: 6891 L: 6669 D: 14486
Penta | [120, 3371, 6835, 3561, 136]
```
https://recklesschess.space/test/4728/

Bench: 6420403