### PR TITLE
Blend lmr_depth for quiet moves with history in pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -496,7 +496,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut reduction = td.lmr.reduction(depth, move_count);
 
         if !is_root && !is_loss(best_score) {
-            let lmr_depth = (depth - reduction / 1024).max(0);
+            let lmr_depth = (depth - reduction / 1024 + is_quiet as i32 * history / 7777).max(0);
 
             // Late Move Pruning (LMP)
             skip_quiets |= move_count >= lmp_threshold(depth, improving);


### PR DESCRIPTION
Elo   | 4.55 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 4.00]
Games | N: 13738 W: 3445 L: 3265 D: 7028
Penta | [59, 1614, 3358, 1764, 74]
https://recklesschess.space/test/4785/

Bench: 6810339