### PR TITLE
Prevent diving into qsearch for other moves with LMR at PV nodes afte…

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -599,7 +599,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 978;
             }
 
-            let reduced_depth = (new_depth - reduction / 1024).clamp(0, new_depth + (PV || cut_node) as i32);
+            let reduced_depth = (new_depth - reduction / 1024)
+                .clamp((PV && tt_move.is_some() && best_move.is_null()) as i32, new_depth + (PV || cut_node) as i32);
 
             td.stack[td.ply - 1].reduction = reduction;
 


### PR DESCRIPTION
…r refuted ttmove

Elo   | 2.97 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 4.00]
Games | N: 22898 W: 5663 L: 5467 D: 11768
Penta | [79, 2435, 6241, 2599, 95]
https://recklesschess.space/test/4788/

bench: 6810339