### PR TITLE
Do more updates when failed low

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -738,7 +738,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
     }
 
-    if bound == Bound::Upper && td.ply >= 1 && depth > 3 {
+    if bound == Bound::Upper && td.ply >= 1 && (!quiet_moves.is_empty() || depth > 3) {
         tt_pv |= td.stack[td.ply - 1].tt_pv;
 
         let factor = 1


### PR DESCRIPTION
Do more PCM and add more nodes to ttpv tree if we at least searched one quiet move

Elo   | 2.04 +- 1.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.25, 2.89) [0.00, 4.00]
Games | N: 50294 W: 12357 L: 12062 D: 25875
Penta | [246, 5941, 12480, 6232, 248]
https://recklesschess.space/test/4798/

bench: 6525480