### PR TITLE
Save static eval immediately in TT

### DIFF
--- a/src/types/score.rs
+++ b/src/types/score.rs
@@ -46,6 +46,10 @@ pub const fn is_decisive(score: i32) -> bool {
     is_win(score) || is_loss(score)
 }
 
+pub const fn is_valid(score: i32) -> bool {
+    score != Score::NONE
+}
+
 pub fn normalize_to_cp(score: i32, board: &Board) -> i32 {
     let material = board.pieces(PieceType::Pawn).len()
         + 3 * board.pieces(PieceType::Knight).len()


### PR DESCRIPTION
Elo   | 1.98 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 51342 W: 12664 L: 12372 D: 26306
Penta | [263, 6013, 12828, 6303, 264]
https://recklesschess.space/test/4812/

Bench: 7312331