### PR TITLE
Print PV and update seldepth in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -805,6 +805,10 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
 
     td.counter.increment();
 
+    if PV {
+        td.sel_depth = td.sel_depth.max(td.ply as i32 + 1);
+    }
+
     if td.time_manager.check_time(td) {
         td.stopped = true;
         return Score::ZERO;
@@ -942,6 +946,10 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
             if score > alpha {
                 best_move = mv;
                 alpha = score;
+
+                if PV {
+                    td.pv.update(td.ply, mv);
+                }
 
                 if score >= beta {
                     break;


### PR DESCRIPTION
Elo   | 1.10 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 15176 W: 3681 L: 3633 D: 7862
Penta | [49, 1615, 4216, 1655, 53]

Bench: 7312331