### PR TITLE
Increase aspiration delta based on number of fail highs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -96,7 +96,7 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
                 }
             }
 
-            delta += delta / 2;
+            delta += delta * (3 + reduction) / 8;
         }
 
         if td.stopped {


### PR DESCRIPTION
```
Elo   | 1.98 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [0.00, 4.00]
Games | N: 53092 W: 13111 L: 12808 D: 27173
Penta | [221, 6414, 13017, 6629, 265]
```
https://recklesschess.space/test/4819/

Bench: 5993568