### PR TITLE
Introduce hindsight TT cutoffs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -351,6 +351,23 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth -= 1;
     }
 
+    // Hindsight Early TT-Cut
+    if !PV
+        && !excluded
+        && tt_depth >= depth
+        && is_valid(tt_score)
+        && match tt_bound {
+            Bound::Upper => tt_score <= alpha,
+            Bound::Lower => tt_score >= beta,
+            _ => true,
+        }
+    {
+        if td.board.halfmove_clock() < 90 {
+            debug_assert!(is_valid(tt_score));
+            return tt_score;
+        }
+    }
+
     let improving =
         !in_check && td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() && static_eval > td.stack[td.ply - 2].static_eval;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -355,6 +355,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     if !PV
         && !excluded
         && tt_depth >= depth
+        && td.board.halfmove_clock() < 90
         && is_valid(tt_score)
         && match tt_bound {
             Bound::Upper => tt_score <= alpha,
@@ -362,10 +363,8 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             _ => true,
         }
     {
-        if td.board.halfmove_clock() < 90 {
-            debug_assert!(is_valid(tt_score));
-            return tt_score;
-        }
+        debug_assert!(is_valid(tt_score));
+        return tt_score;
     }
 
     let improving =


### PR DESCRIPTION
```
Elo   | 1.47 +- 1.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 4.00]
Games | N: 114356 W: 28001 L: 27518 D: 58837
Penta | [519, 13594, 28522, 13971, 572]
```
https://recklesschess.space/test/4822/

Bench: 6892319