### PR TITLE
Simplify LMR conditions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -600,7 +600,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut score = Score::ZERO;
 
         // Late Move Reductions (LMR)
-        if depth >= 3 && move_count > 1 + is_root as i32 && (is_quiet || !tt_pv) {
+        if depth >= 3 && move_count > 1 + is_root as i32 {
             reduction -= 84 * (history - 554) / 1024;
             reduction -= 4071 * correction_value.abs() / 1024;
             reduction -= 56 * move_count;


### PR DESCRIPTION
```
Elo   | 7.17 +- 4.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 5572 W: 1431 L: 1316 D: 2825
Penta | [22, 615, 1396, 732, 21]
```
https://recklesschess.space/test/4847/

Bench: 6665286