### PR TITLE
Apply post LMR to quiet moves only

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -652,19 +652,17 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 if new_depth > reduced_depth {
                     score = -search::<false>(td, -alpha - 1, -alpha, new_depth, !cut_node);
 
-                    let mut bonus = match score {
-                        s if s >= beta => (1 + 2 * (move_count > depth) as i32) * (143 * depth - 65).min(1212),
-                        s if s <= alpha => -(135 * depth - 71).min(1177),
-                        _ => 0,
-                    };
+                    if mv.is_quiet() {
+                        let bonus = match score {
+                            s if s >= beta => (1 + 2 * (move_count > depth) as i32) * (143 * depth - 65).min(1212),
+                            s if s <= alpha => -(135 * depth - 71).min(1177),
+                            _ => 0,
+                        };
 
-                    if !is_quiet {
-                        bonus /= 5;
+                        td.ply -= 1;
+                        update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
+                        td.ply += 1;
                     }
-
-                    td.ply -= 1;
-                    update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
-                    td.ply += 1;
                 }
             } else if score > alpha && score < best_score + 15 {
                 new_depth -= 1;


### PR DESCRIPTION
```
Elo   | 1.04 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 22364 W: 5481 L: 5414 D: 11469
Penta | [95, 2689, 5567, 2716, 115]
```
https://recklesschess.space/test/4851/

Bench: 6913708