### PR TITLE
Do correction when decisive eval

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -800,7 +800,6 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
     if !(in_check
         || best_move.is_noisy()
-        || is_decisive(best_score)
         || (bound == Bound::Upper && best_score >= static_eval)
         || (bound == Bound::Lower && best_score <= static_eval))
     {


### PR DESCRIPTION
Elo   | 4.72 +- 3.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 4.00]
Games | N: 13398 W: 3403 L: 3221 D: 6774
Penta | [60, 1562, 3317, 1656, 104]
https://recklesschess.space/test/4856/

tested with TB on
bench: 6970865