### PR TITLE
Prune more check evasions in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -937,8 +937,8 @@ fn qsearch<const PV: bool>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
                 break;
             }
 
-            if mv.is_quiet() {
-                continue;
+            if in_check && mv.is_quiet() {
+                break;
             }
 
             if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {


### PR DESCRIPTION
Elo   | 2.11 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 43548 W: 10709 L: 10445 D: 22394
Penta | [181, 5107, 10962, 5315, 209]
https://recklesschess.space/test/4861/

bench: 6921601