### PR TITLE
Clamp eval range to TBs bounds

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,4 +1,8 @@
-use crate::{board::Board, thread::ThreadData, types::PieceType};
+use crate::{
+    board::Board,
+    thread::ThreadData,
+    types::{PieceType, Score},
+};
 
 const MATERIAL_VALUES: [i32; 6] = [128, 384, 416, 640, 1280, 0];
 
@@ -8,7 +12,7 @@ pub fn evaluate(td: &mut ThreadData) -> i32 {
 
     eval = eval * (22400 + material(&td.board)) / 32768;
 
-    eval.clamp(-16384, 16384)
+    eval.clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1)
 }
 
 fn material(board: &Board) -> i32 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -390,7 +390,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 + 512 * correction_value.abs() / 1024
                 + 25
     {
-        return ((eval + beta) / 2).clamp(-16384, 16384);
+        return ((eval + beta) / 2).clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1);
     }
 
     // Null Move Pruning (NMP)
@@ -1006,7 +1006,7 @@ fn correction_value(td: &ThreadData) -> i32 {
 }
 
 fn corrected_eval(eval: i32, correction_value: i32, hmr: u8) -> i32 {
-    (eval * (200 - hmr as i32) / 200 + correction_value).clamp(-16384, 16384)
+    (eval * (200 - hmr as i32) / 200 + correction_value).clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX + 1)
 }
 
 fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32) {


### PR DESCRIPTION
Elo   | 0.50 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 29344 W: 7160 L: 7118 D: 15066
Penta | [128, 3126, 8128, 3156, 134]
https://recklesschess.space/test/4857/

bench: 6921601