### PR TITLE
Faster conthist

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -151,12 +151,16 @@ pub struct ContinuationHistory {
 impl ContinuationHistory {
     const MAX_HISTORY: i32 = 16384;
 
-    pub fn get(&self, piece: Piece, sq: Square, cont_piece: Piece, cont_sq: Square) -> i32 {
-        self.entries[piece][sq][cont_piece][cont_sq] as i32
+    pub fn subtable_ptr(&mut self, piece: Piece, sq: Square) -> *mut [[i16; 64]; 13] {
+        self.entries[piece][sq].as_mut_ptr() as *mut [[i16; 64]; 13]
     }
 
-    pub fn update(&mut self, piece: Piece, sq: Square, cont_piece: Piece, cont_sq: Square, bonus: i32) {
-        let entry = &mut self.entries[piece][sq][cont_piece][cont_sq];
+    pub fn get(&self, subtable_ptr: *mut [[i16; 64]; 13], piece: Piece, sq: Square) -> i32 {
+        (unsafe { &*subtable_ptr }[piece][sq]) as i32
+    }
+
+    pub fn update(&mut self, subtable_ptr: *mut [[i16; 64]; 13], cont_piece: Piece, cont_sq: Square, bonus: i32) {
+        let entry = &mut unsafe { &mut *subtable_ptr }[cont_piece][cont_sq];
         apply_bonus::<{ Self::MAX_HISTORY }>(entry, bonus);
     }
 }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -22,7 +22,10 @@ pub struct StackEntry {
     pub tt_pv: bool,
     pub cutoff_count: i32,
     pub reduction: i32,
+    pub conthist: *mut [[i16; 64]; 13],
 }
+
+unsafe impl Send for StackEntry {}
 
 impl Default for StackEntry {
     fn default() -> Self {
@@ -35,6 +38,7 @@ impl Default for StackEntry {
             tt_pv: false,
             cutoff_count: 0,
             reduction: 0,
+            conthist: std::ptr::null_mut(),
         }
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -136,13 +136,9 @@ impl<'a> ThreadData<'a> {
             return 0;
         }
 
-        let piece = self.stack[self.ply - index].piece;
-        let sq = self.stack[self.ply - index].mv.to();
-
-        let cont_piece = self.board.piece_on(mv.from());
-        let cont_sq = mv.to();
-
-        self.continuation_history.get(piece, sq, cont_piece, cont_sq)
+        let piece = self.board.piece_on(mv.from());
+        let sq = mv.to();
+        self.continuation_history.get(self.stack[self.ply - index].conthist, piece, sq)
     }
 
     pub fn print_uci_info(&self, depth: i32, score: i32, now: Instant) {


### PR DESCRIPTION
Elo   | 1.60 +- 1.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 72000 W: 17739 L: 17408 D: 36853
Penta | [254, 7666, 19844, 7967, 269]
https://recklesschess.space/test/4976/

Bench: 2904705