### PR TITLE
Refine late TT cut

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -362,15 +362,14 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     // Hindsight Late TT-Cut
-    if !PV
+    if cut_node
         && !excluded
         && tt_depth >= depth
         && td.board.halfmove_clock() < 90
         && is_valid(tt_score)
         && match tt_bound {
-            Bound::Upper => tt_score <= alpha,
-            Bound::Lower => tt_score >= beta,
-            _ => true,
+            Bound::Upper => false,
+            _ => tt_score >= beta,
         }
     {
         debug_assert!(is_valid(tt_score));


### PR DESCRIPTION
+99% is a cutnode and prevent misaligned bounds

Elo   | 3.46 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19264 W: 4796 L: 4604 D: 9864
Penta | [79, 2257, 4789, 2407, 100]
https://recklesschess.space/test/4991/

bench: 2879917