### PR TITLE
Introduce general futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -544,6 +544,14 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             // Futility Pruning (FP)
             skip_quiets |= !in_check && is_quiet && lmr_depth < 9 && static_eval + 97 * lmr_depth + 175 <= alpha;
 
+            let futility_value = static_eval + 120 * lmr_depth + 80;
+            if !in_check && is_quiet && lmr_depth < 9 && futility_value <= alpha {
+                if !is_decisive(best_score) && best_score <= futility_value {
+                    best_score = futility_value;
+                }
+                continue;
+            }
+
             // Bad Noisy Futility Pruning (BNFP)
             if !in_check
                 && lmr_depth < 6


### PR DESCRIPTION
```
Elo   | 2.11 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 4.00]
Games | N: 44444 W: 10969 L: 10699 D: 22776
Penta | [182, 5270, 11039, 5558, 173]
```
https://recklesschess.space/test/5021/

Bench: 2683831