### PR TITLE
Update default network to v24-75b969ef.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v23-0121dc1d.nnue";
+const NETWORK_NAME: &str = "v24-75b969ef.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Nodes
```
Elo   | 2.65 +- 1.99 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.38 (-2.25, 2.89) [0.00, 4.00]
Games | N: 60026 W: 20142 L: 19685 D: 20199
Penta | [2117, 6501, 12471, 6656, 2268]
```
https://recklesschess.space/test/5031/

STC
```
Elo   | 2.56 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 30578 W: 7565 L: 7340 D: 15673
Penta | [116, 3621, 7577, 3872, 103]
```
https://recklesschess.space/test/5032/

LTC
```
Elo   | 9.09 +- 4.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 5392 W: 1333 L: 1192 D: 2867
Penta | [7, 559, 1425, 696, 9]
```
https://recklesschess.space/test/5034/

Bench: 2572022