### PR TITLE
Adjust best_score in BNFP also

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -553,11 +553,11 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             // Bad Noisy Futility Pruning (BNFP)
-            if !in_check
-                && lmr_depth < 6
-                && move_picker.stage() == Stage::BadNoisy
-                && static_eval + 122 * lmr_depth + 371 * move_count / 128 <= alpha
-            {
+            let capt_futility_value = static_eval + 122 * lmr_depth + 371 * move_count / 128;
+            if !in_check && lmr_depth < 6 && move_picker.stage() == Stage::BadNoisy && capt_futility_value <= alpha {
+                if !is_decisive(best_score) && best_score <= capt_futility_value {
+                    best_score = capt_futility_value;
+                }
                 break;
             }
 


### PR DESCRIPTION
Elo   | 3.39 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19478 W: 4819 L: 4629 D: 10030
Penta | [68, 2269, 4888, 2433, 81]
https://recklesschess.space/test/5045/

bench: 2336498