### PR TITLE
Simplify FP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -542,13 +542,12 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             skip_quiets |= move_count >= lmp_threshold(depth, improving);
 
             // Futility Pruning (FP)
-            skip_quiets |= !in_check && is_quiet && lmr_depth < 9 && static_eval + 97 * lmr_depth + 175 <= alpha;
-
             let futility_value = static_eval + 120 * lmr_depth + 80;
             if !in_check && is_quiet && lmr_depth < 9 && futility_value <= alpha {
                 if !is_decisive(best_score) && best_score <= futility_value {
                     best_score = futility_value;
                 }
+                skip_quiets = true;
                 continue;
             }
 


### PR DESCRIPTION
Passed STC:
Elo   | 1.97 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 15518 W: 3830 L: 3742 D: 7946
Penta | [63, 1837, 3857, 1953, 49]
https://recklesschess.space/test/5049/

Passed LTC:
Elo   | 0.40 +- 1.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 31120 W: 7186 L: 7150 D: 16784
Penta | [20, 3594, 8304, 3614, 28]
https://recklesschess.space/test/5051/

bench: 2565936