### PR TITLE
Tweak LMP threshold

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -539,7 +539,7 @@ fn search<const PV: bool>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             let lmr_depth = (depth - reduction / 1024 + is_quiet as i32 * history / 7084).max(0);
 
             // Late Move Pruning (LMP)
-            skip_quiets |= move_count >= lmp_threshold(depth, improving);
+            skip_quiets |= move_count >= lmp_threshold(depth, improving || static_eval >= beta);
 
             // Futility Pruning (FP)
             let futility_value = static_eval + 120 * lmr_depth + 80;


### PR DESCRIPTION
```
Elo   | 3.20 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 4.00]
Games | N: 22280 W: 5555 L: 5350 D: 11375
Penta | [89, 2592, 5570, 2803, 86]
```
https://recklesschess.space/test/5063/

Bench: 2296069