### PR TITLE
Update default network to v25-f71908d1.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v24-75b969ef.nnue";
+const NETWORK_NAME: &str = "v25-f71908d1.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed Node:
Elo | -0.03 +- 2.66 (95%)
SPRT | N=25000 Threads=1 Hash=8MB
LLR | -2.30 (-2.25, 2.89) [0.00, 4.00]
Games | N: 34034 W: 11320 L: 11323 D: 11391
Penta | [1274, 3725, 7021, 3724, 1273]
https://recklesschess.space/test/5056/

STC:
Elo | 5.28 +- 3.40 (95%)
SPRT | 8.0+0.08s Threads=1 Hash=16MB
LLR | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11194 W: 2845 L: 2675 D: 5674
Penta | [45, 1291, 2764, 1443, 54]
https://recklesschess.space/test/5054/

LTC:
Elo | 2.35 +- 1.89 (95%)
SPRT | 40.0+0.40s Threads=1 Hash=64MB
LLR | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 31488 W: 7463 L: 7250 D: 16775
Penta | [28, 3602, 8267, 3823, 24]
https://recklesschess.space/test/5057/

Bench: 2532135