### PR TITLE
Update default network to v26-62b43636.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v25-f71908d1.nnue";
+const NETWORK_NAME: &str = "v26-62b43636.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed Node:
Elo   | 14.84 +- 6.53 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.45 (-2.25, 2.89) [0.00, 4.00]
Games | N: 5552 W: 1959 L: 1722 D: 1871
Penta | [172, 553, 1150, 668, 233]
https://recklesschess.space/test/5130/

STC:
Elo   | 12.56 +- 5.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.18 (-2.25, 2.89) [0.00, 4.00]
Games | N: 4372 W: 1150 L: 992 D: 2230
Penta | [7, 485, 1055, 621, 18]
https://recklesschess.space/test/5131/

LTC:
Elo   | 17.20 +- 6.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 4.00]
Games | N: 2668 W: 679 L: 547 D: 1442
Penta | [0, 245, 714, 373, 2]
https://recklesschess.space/test/5132/

Bench: 2169319