### PR TITLE
Update default network to v27-ae50420d.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v26-62b43636.nnue";
+const NETWORK_NAME: &str = "v27-ae50420d.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 11.78 +- 6.23 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 6226 W: 2196 L: 1985 D: 2045
Penta | [194, 667, 1254, 730, 268]
https://recklesschess.space/test/5163/

STC
Elo   | 11.89 +- 5.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 4.00]
Games | N: 4326 W: 1149 L: 1001 D: 2176
Penta | [10, 475, 1060, 593, 25]
https://recklesschess.space/test/5164/

Bench: 2373762