### PR TITLE
Remove insufficient material detection

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -218,24 +218,13 @@ impl Board {
 
     /// Returns `true` if the current position is a known draw by the fifty-move rule or repetition.
     pub fn is_draw(&self, ply: usize) -> bool {
-        self.draw_by_fifty_move_rule() || self.draw_by_repetition(ply as i32) || self.draw_by_insufficient_material()
+        self.draw_by_fifty_move_rule() || self.draw_by_repetition(ply as i32)
     }
 
     /// Return a draw score if a position repeats once earlier but strictly
     /// after the root, or repeats twice before or at the root.
     pub const fn draw_by_repetition(&self, ply: i32) -> bool {
         self.state.repetition != 0 && self.state.repetition < ply
-    }
-
-    /// Returns `true` if the current position is a known draw by insufficient material:
-    /// - Two kings only
-    /// - Two kings and one minor piece
-    pub fn draw_by_insufficient_material(&self) -> bool {
-        match self.occupancies().len() {
-            2 => true,
-            3 => self.pieces(PieceType::Knight) | self.pieces(PieceType::Bishop) != Bitboard(0),
-            _ => false,
-        }
     }
 
     pub fn draw_by_fifty_move_rule(&self) -> bool {


### PR DESCRIPTION
Elo   | 0.98 +- 1.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 33004 W: 8108 L: 8015 D: 16881
Penta | [90, 3431, 9364, 3530, 87]
https://recklesschess.space/test/5161/

bench: 2329541