### PR TITLE
Guard against potential_singularity in NMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -419,6 +419,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         return ((eval + beta) / 2).clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1);
     }
 
+    let potential_singularity =
+        depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
+
     // Null Move Pruning (NMP)
     if cut_node
         && !in_check
@@ -428,6 +431,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && static_eval >= beta - 15 * depth + 153 * tt_pv as i32 + 190
         && td.ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
+        && !potential_singularity
     {
         let r = 4 + depth / 3 + ((eval - beta) / 252).min(3) + (tt_move.is_null() || tt_move.is_noisy()) as i32;
 
@@ -592,12 +596,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         if !NODE::ROOT && !excluded && td.ply < 2 * td.root_depth as usize && mv == tt_move {
             let entry = &entry.unwrap();
 
-            if depth >= 5
-                && tt_depth >= depth - 3
-                && tt_bound != Bound::Upper
-                && is_valid(tt_score)
-                && !is_decisive(tt_score)
-            {
+            if potential_singularity {
                 debug_assert!(is_valid(tt_score));
                 let singular_beta = tt_score - depth;
                 let singular_depth = (depth - 1) / 2;


### PR DESCRIPTION
Elo   | 2.31 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 34642 W: 8568 L: 8338 D: 17736
Penta | [92, 4011, 8903, 4205, 110]
https://recklesschess.space/test/5277/

bench: 2159202