### PR TITLE
Update default network to v28-adf74a81.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v27-ae50420d.nnue";
+const NETWORK_NAME: &str = "v28-adf74a81.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes:
Elo   | 2.92 +- 2.30 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.11 (-2.25, 2.89) [0.00, 4.00]
Games | N: 43772 W: 14560 L: 14192 D: 15020
Penta | [1452, 4792, 9135, 4950, 1557]
https://recklesschess.space/test/5284/

STC:
Elo   | 2.40 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 34128 W: 8699 L: 8463 D: 16966
Penta | [126, 4073, 8442, 4285, 138]
https://recklesschess.space/test/5285/

LTC:
Elo   | 4.63 +- 3.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 12078 W: 3008 L: 2847 D: 6223
Penta | [7, 1381, 3103, 1540, 8]
https://recklesschess.space/test/5287/

Bench: 2381858