### PR TITLE
Update default network to v29-17a39e43.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v28-adf74a81.nnue";
+const NETWORK_NAME: &str = "v29-17a39e43.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
STC:
Elo   | 5.06 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 4.00]
Games | N: 12284 W: 3172 L: 2993 D: 6119
Penta | [62, 1387, 3060, 1576, 57]
https://recklesschess.space/test/5354/

LTC:
Elo   | 3.71 +- 2.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 16112 W: 3902 L: 3730 D: 8480
Penta | [14, 1849, 4154, 2029, 10]
https://recklesschess.space/test/5356/

Fixed Node (w adj) : 
Elo   | 3.77 +- 2.90 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 4.00]
Games | N: 27774 W: 9382 L: 9081 D: 9311
Penta | [986, 2894, 5851, 3145, 1011]
https://recklesschess.space/test/5353/

Fixed Node (w/o Adj):
Elo   | 4.03 +- 2.94 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.31 (-2.25, 2.89) [0.00, 4.00]
Games | N: 27304 W: 9229 L: 8912 D: 9163
Penta | [941, 2948, 5628, 3123, 1012]
https://recklesschess.space/test/5360/

Bench: 2220523