### PR TITLE
more conthist

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -189,7 +189,8 @@ impl MovePicker {
             entry.score += 1188 * td.quiet_history.get(td.board.threats(), td.board.side_to_move(), mv) / 1024
                 + 1028 * td.conthist(1, mv) / 1024
                 + 868 * td.conthist(2, mv) / 1024
-                + 473 * td.conthist(3, mv) / 1024;
+                + 868 * td.conthist(4, mv) / 1024
+                + 868 * td.conthist(6, mv) / 1024;
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1110,6 +1110,20 @@ fn update_continuation_histories(td: &mut ThreadData, piece: Piece, sq: Square, 
             td.continuation_history.update(entry.conthist, piece, sq, 957 * bonus / 1024);
         }
     }
+
+    if td.ply >= 4 {
+        let entry = &td.stack[td.ply - 4];
+        if entry.mv.is_some() {
+            td.continuation_history.update(entry.conthist, piece, sq, 1024 * bonus / 1024);
+        }
+    }
+
+    if td.ply >= 6 {
+        let entry = &td.stack[td.ply - 6];
+        if entry.mv.is_some() {
+            td.continuation_history.update(entry.conthist, piece, sq, 1024 * bonus / 1024);
+        }
+    }
 }
 
 fn make_move(td: &mut ThreadData, mv: Move) {


### PR DESCRIPTION
Elo   | 1.69 +- 1.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 4.00]
Games | N: 68780 W: 17054 L: 16719 D: 35007
Penta | [207, 8107, 17425, 8446, 205]
https://recklesschess.space/test/5341/

bench: 2359478