### PR TITLE
Less cut node reduction in TTPV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -651,6 +651,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 683;
                 reduction -= 647 * (is_valid(tt_score) && tt_score > alpha) as i32;
                 reduction -= 791 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                reduction -= 768 * cut_node as i32;
             }
 
             if NODE::PV {


### PR DESCRIPTION
```
Elo   | 2.51 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 30372 W: 7478 L: 7259 D: 15635
Penta | [69, 3585, 7675, 3772, 85]
```
https://recklesschess.space/test/5433/

Bench: 2305149