### PR TITLE
Align early TT cut with predicted cut node flag

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -249,8 +249,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             && tt_depth >= depth
             && is_valid(tt_score)
             && match tt_bound {
-                Bound::Upper => tt_score <= alpha,
-                Bound::Lower => tt_score >= beta,
+                Bound::Upper => tt_score <= alpha && (!cut_node || depth > 5),
+                Bound::Lower => tt_score >= beta && (cut_node || depth > 5),
                 _ => true,
             }
         {


### PR DESCRIPTION
```
Elo   | 3.67 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 17346 W: 4378 L: 4195 D: 8773
Penta | [40, 2014, 4392, 2177, 50]
```
https://recklesschess.space/test/5530/

Bench: 2186255