### PR TITLE
Skip hindsight late TT cuts for potential singular moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -384,6 +384,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth -= 1;
     }
 
+    let potential_singularity =
+        depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
+
     // Hindsight Late TT-Cut
     if cut_node
         && !excluded
@@ -394,6 +397,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             Bound::Upper => false,
             _ => tt_score >= beta,
         }
+        && !potential_singularity
     {
         debug_assert!(is_valid(tt_score));
         return tt_score;
@@ -420,9 +424,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     {
         return ((eval + beta) / 2).clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1);
     }
-
-    let potential_singularity =
-        depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
 
     // Null Move Pruning (NMP)
     if cut_node


### PR DESCRIPTION
```
Elo   | 2.45 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.25, 2.89) [0.00, 4.00]
Games | N: 33596 W: 8288 L: 8051 D: 17257
Penta | [90, 3957, 8489, 4150, 112]
```
https://recklesschess.space/test/5540/

Bench: 2380273