### PR TITLE
more conthist bonus if the move is very late relatively

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -699,7 +699,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
                     if mv.is_quiet() {
                         let bonus = match score {
-                            s if s >= beta => (1 + 2 * (move_count > depth) as i32) * (152 * depth - 50).min(973),
+                            s if s >= beta => {
+                                (1 + 2 * (move_count > depth) as i32 + 2 * (move_count > 2 * depth) as i32)
+                                    * (152 * depth - 50).min(973)
+                            }
                             s if s <= alpha => -(139 * depth - 63).min(1166),
                             _ => 0,
                         };


### PR DESCRIPTION
Elo   | 1.62 +- 1.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 76702 W: 18948 L: 18590 D: 39164
Penta | [207, 9166, 19260, 9498, 220]
https://recklesschess.space/test/5504/

bench: 2227841