### PR TITLE
Assign a missing reduction recalculation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -695,7 +695,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 new_depth -= (score < best_score + new_depth) as i32;
 
                 if new_depth > reduced_depth {
+                    td.stack[td.ply - 1].reduction = 1024 * ((initial_depth - 1) - new_depth);
                     score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node);
+                    td.stack[td.ply - 1].reduction = 0;
 
                     if mv.is_quiet() {
                         let bonus = match score {


### PR DESCRIPTION
Elo   | -0.23 +- 1.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 112178 W: 27332 L: 27405 D: 57441
Penta | [325, 13526, 28463, 13447, 328]
https://recklesschess.space/test/5514/

bench: 2249072