### PR TITLE
Adjust standpat score to average with beta

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -934,6 +934,10 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
         }
 
         if best_score >= beta {
+            if !is_decisive(best_score) {
+                best_score = (best_score + beta) / 2;
+            }
+
             if entry.is_none() {
                 td.tt.write(
                     td.board.hash(),


### PR DESCRIPTION
```
Elo   | 1.35 +- 0.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 144952 W: 35644 L: 35082 D: 74226
Penta | [404, 17274, 36574, 17804, 420]
```
https://recklesschess.space/test/5533/

Bench: 2082194