### PR TITLE
Speed up pawn move generation

### DIFF
--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -1,6 +1,6 @@
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, Not};
 
-use super::{Rank, Square};
+use super::{File, Rank, Square};
 
 /// Represents a 64-bit unsigned integer with each bit indicating square occupancy.
 ///
@@ -13,6 +13,10 @@ impl Bitboard {
     /// Creates a bitboard with all bits set in the specified rank.
     pub const fn rank(rank: Rank) -> Self {
         Self(0xFF << (rank as usize * 8))
+    }
+
+    pub const fn file(file: File) -> Self {
+        Self(0x0101010101010101u64 << (file as usize))
     }
 
     /// Checks if the bitboard has zero bits set.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,3 +29,6 @@ pub const MAX_MOVES: usize = 218;
 
 #[rustfmt::skip]
 pub enum Rank { R1, R2, R3, R4, R5, R6, R7, R8 }
+
+#[rustfmt::skip]
+pub enum File { A, B, C, D, E, F, G, H }


### PR DESCRIPTION
```
Elo   | 3.51 +- 2.62 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19186 W: 4896 L: 4702 D: 9588
Penta | [107, 2213, 4750, 2425, 98]
```
https://recklesschess.space/test/5582/

Bench: 2064268