### PR TITLE
Small speedup in movgen

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -57,16 +57,14 @@ impl super::Board {
         T: Fn(Square) -> Bitboard,
     {
         for from in self.our(piece) {
-            let targets = gen(from) & !self.us();
-
             if TYPE == NOISY {
-                for to in targets & self.them() {
+                for to in gen(from) & self.them() {
                     list.push(from, to, MoveKind::Capture);
                 }
             }
 
             if TYPE == QUIET {
-                for to in targets & !self.them() {
+                for to in gen(from) & !self.occupancies() {
                     list.push(from, to, MoveKind::Normal);
                 }
             }


### PR DESCRIPTION
Elo   | 2.00 +- 1.62 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 45080 W: 11419 L: 11160 D: 22501
Penta | [211, 4753, 12376, 4966, 234]
https://recklesschess.space/test/5587/

bench: 2064268