### PR TITLE
Speed up generating evasions

### DIFF
--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -10,6 +10,8 @@ use super::{File, Rank, Square};
 pub struct Bitboard(pub u64);
 
 impl Bitboard {
+    pub const ALL: Self = Self(0xFFFFFFFFFFFFFFFF);
+
     /// Creates a bitboard with all bits set in the specified rank.
     pub const fn rank(rank: Rank) -> Self {
         Self(0xFF << (rank as usize * 8))


### PR DESCRIPTION
```
Elo   | 8.69 +- 4.63 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 6038 W: 1592 L: 1441 D: 3005
Penta | [23, 660, 1517, 781, 38]
```
https://recklesschess.space/test/5597/

Bench: 2041929
