### PR TITLE
Add time adjustment based on score trend

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -146,7 +146,9 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
             eval_stability = 0;
         }
 
-        if td.time_manager.soft_limit(td, pv_stability, eval_stability) {
+        let multiplier = (800 + 20 * (td.previous_best_score - td.best_score)).clamp(750, 1500) as f32 / 1000.0;
+
+        if td.time_manager.soft_limit(td, pv_stability, eval_stability, multiplier) {
             break;
         }
 
@@ -158,6 +160,8 @@ pub fn start(td: &mut ThreadData, report: Report) -> SearchResult {
     if report != Report::None {
         td.print_uci_info(td.root_depth, td.best_score, now);
     }
+
+    td.previous_best_score = td.best_score;
 
     SearchResult {
         best_move: td.pv.best_move(),

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -85,6 +85,7 @@ pub struct ThreadData<'a> {
     pub completed_depth: i32,
     pub ply: usize,
     pub nmp_min_ply: i32,
+    pub previous_best_score: i32,
 }
 
 impl<'a> ThreadData<'a> {
@@ -120,6 +121,7 @@ impl<'a> ThreadData<'a> {
             completed_depth: 0,
             ply: 0,
             nmp_min_ply: 0,
+            previous_best_score: 0,
         }
     }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -60,7 +60,7 @@ impl TimeManager {
         }
     }
 
-    pub fn soft_limit(&self, td: &ThreadData, pv_stability: usize, eval_stability: usize) -> bool {
+    pub fn soft_limit(&self, td: &ThreadData, pv_stability: usize, eval_stability: usize, multiplier: f32) -> bool {
         match self.limits {
             Limits::Infinite => false,
             Limits::Depth(maximum) => td.completed_depth >= maximum,
@@ -76,6 +76,8 @@ impl TimeManager {
                     limit *= 1.25 - 0.05 * pv_stability as f32;
 
                     limit *= 1.2 - 0.04 * eval_stability as f32;
+
+                    limit *= multiplier;
                 }
 
                 self.start_time.elapsed() >= Duration::from_secs_f32(limit)


### PR DESCRIPTION
Elo   | 4.34 +- 2.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 4.00]
Games | N: 12976 W: 3217 L: 3055 D: 6704
Penta | [8, 1396, 3514, 1566, 4]
https://recklesschess.space/test/5718/

Bench: 2327974
