### PR TITLE
Update default network to v32-ef4f1a58.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v31-1d230c1c.nnue";
+const NETWORK_NAME: &str = "v32-ef4f1a58.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Update the new default network: v32-ef4f1a58.nnue
Fixed Nodes:
Elo   | 3.06 +- 2.41 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 4.00]
Games | N: 39250 W: 13201 L: 12855 D: 13194
Penta | [1284, 4296, 8179, 4522, 1344]
https://recklesschess.space/test/5737/

STC:
Elo   | 4.18 +- 2.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 14792 W: 3869 L: 3691 D: 7232
Penta | [50, 1736, 3663, 1880, 67]
https://recklesschess.space/test/5738/

Bench: 2882441