### PR TITLE
Simplify away time management guard

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -140,10 +140,6 @@ pub fn start(td: &mut ThreadData, report: Report) {
         }
 
         let multiplier = || {
-            if td.completed_depth < 7 {
-                return 1.0;
-            }
-
             let nodes_factor = 2.15 - 1.5 * (td.node_table.get(td.pv.best_move()) as f32 / td.counter.local() as f32);
 
             let pv_stability = 1.25 - 0.05 * pv_stability as f32;


### PR DESCRIPTION
Passing [-3, 1] (LLR: 3.8906)
Elo   | 1.00 +- 1.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.08 (-2.25, 2.89) [0.00, 4.00]
Games | N: 39126 W: 9742 L: 9629 D: 19755
Penta | [112, 4149, 10925, 4268, 109]
https://recklesschess.space/test/5735/

Passing [-3, 1] (LLR: 5.6908)
Elo   | 1.91 +- 1.72 (95%)
SPRT  | 30.0+0.30s Threads=1 Hash=16MB
LLR   | 2.37 (-2.25, 2.89) [0.00, 4.00]
Games | N: 33476 W: 8119 L: 7935 D: 17422
Penta | [12, 3421, 9702, 3577, 26]
https://recklesschess.space/test/5736/

Bench: 2882441