### PR TITLE
Simplify NMP reduction formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -437,7 +437,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && td.board.has_non_pawns()
         && !potential_singularity
     {
-        let r = 4 + depth / 3 + ((eval - beta) / 225).min(3) + (tt_move.is_null() || tt_move.is_noisy()) as i32;
+        let r = 5 + depth / 3 + ((eval - beta) / 225).min(3);
 
         td.stack[td.ply].conthist = std::ptr::null_mut();
         td.stack[td.ply].piece = Piece::None;


### PR DESCRIPTION
Elo   | 0.09 +- 1.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 69498 W: 17281 L: 17263 D: 34954
Penta | [201, 8351, 17647, 8329, 221]
https://recklesschess.space/test/5774/
