### PR TITLE
Simplify calculation of reduced depth

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -669,10 +669,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction += 732 + 55 * td.stack[td.ply].cutoff_count.max(7);
             }
 
-            let reduced_depth = (new_depth - reduction / 1024).clamp(
-                (NODE::PV && tt_move.is_some() && best_move.is_null()) as i32,
-                new_depth + (NODE::PV || cut_node) as i32,
-            );
+            let reduced_depth =
+                (new_depth - reduction / 1024).clamp(NODE::PV as i32, new_depth + (NODE::PV || cut_node) as i32);
 
             td.stack[td.ply - 1].reduction = reduction;
 


### PR DESCRIPTION
Elo   | -0.04 +- 1.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 81922 W: 20203 L: 20212 D: 41507
Penta | [186, 8945, 22708, 8936, 186]
https://recklesschess.space/test/5785/
