### PR TITLE
Simplify LMR cutoff count rule

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -673,7 +673,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             if td.stack[td.ply].cutoff_count > 2 {
-                reduction += 732 + 55 * td.stack[td.ply].cutoff_count.max(7);
+                reduction += 1196;
             }
 
             if td.stack[td.ply - 1].killer == mv {


### PR DESCRIPTION
Elo   | -0.20 +- 1.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 105090 W: 26068 L: 26128 D: 52894
Penta | [265, 12629, 26838, 12527, 286]
https://recklesschess.space/test/5771/