### PR TITLE
Change the way nodes are counted

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -189,8 +189,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         return qsearch::<NODE>(td, alpha, beta);
     }
 
-    td.counter.increment();
-
     if NODE::PV {
         td.sel_depth = td.sel_depth.max(td.ply as i32 + 1);
     }
@@ -856,8 +854,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
         td.pv.clear(td.ply);
     }
 
-    td.counter.increment();
-
     if NODE::PV {
         td.sel_depth = td.sel_depth.max(td.ply as i32 + 1);
     }
@@ -1099,6 +1095,7 @@ fn make_move(td: &mut ThreadData, mv: Move) {
     td.stack[td.ply].mv = mv;
     td.ply += 1;
 
+    td.counter.increment();
     td.nnue.push(mv, &td.board);
     td.board.make_move(mv);
     td.tt.prefetch(td.board.hash());


### PR DESCRIPTION
Switch from counting search calls to counting legal moves made.

Elo   | 0.37 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 51084 W: 12607 L: 12552 D: 25925
Penta | [99, 5240, 14809, 5295, 99]
https://recklesschess.space/test/5828/

Bench: 2133278