### PR TITLE
Reduce time usage at higher fullmove numbers

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -33,8 +33,8 @@ impl TimeManager {
             }
             Limits::Fischer(main, inc) => {
                 let main = main.saturating_sub(move_overhead);
-                let soft_scale = 0.025 + 0.05 * (1.0 - (-0.034 * fullmove_number as f64).exp());
-                let hard_scale = 0.135 + 0.21 * (1.0 - (-0.030 * fullmove_number as f64).exp());
+                let soft_scale = 0.024 + 0.042 * (1.0 - (-0.045 * fullmove_number as f64).exp());
+                let hard_scale = 0.135 + 0.210 * (1.0 - (-0.030 * fullmove_number as f64).exp());
 
                 soft = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
                 hard = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;


### PR DESCRIPTION
Elo   | 0.98 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 33414 W: 8295 L: 8201 D: 16918
Penta | [70, 3624, 9247, 3674, 92]
https://recklesschess.space/test/5911/

Bench: 2145678