### PR TITLE
Reduce maximum time usage at higher fullmove numbers

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -34,7 +34,7 @@ impl TimeManager {
             Limits::Fischer(main, inc) => {
                 let main = main.saturating_sub(move_overhead);
                 let soft_scale = 0.024 + 0.042 * (1.0 - (-0.045 * fullmove_number as f64).exp());
-                let hard_scale = 0.135 + 0.210 * (1.0 - (-0.030 * fullmove_number as f64).exp());
+                let hard_scale = 0.135 + 0.145 * (1.0 - (-0.043 * fullmove_number as f64).exp());
 
                 soft = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
                 hard = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;


### PR DESCRIPTION
Elo   | 0.35 +- 1.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 53150 W: 12938 L: 12885 D: 27327
Penta | [106, 5659, 14976, 5744, 90]
https://recklesschess.space/test/5917/

Bench: 2145678