### PR TITLE
Fix move overhead and time bounds exceeding available time

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -32,12 +32,11 @@ impl TimeManager {
                 hard = ms;
             }
             Limits::Fischer(main, inc) => {
-                let main = main.saturating_sub(move_overhead);
                 let soft_scale = 0.024 + 0.042 * (1.0 - (-0.045 * fullmove_number as f64).exp());
                 let hard_scale = 0.135 + 0.145 * (1.0 - (-0.043 * fullmove_number as f64).exp());
 
-                let soft_bound = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
-                let hard_bound = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;
+                let soft_bound = (soft_scale * main.saturating_sub(move_overhead) as f64 + 0.75 * inc as f64) as u64;
+                let hard_bound = (hard_scale * main.saturating_sub(move_overhead) as f64 + 0.75 * inc as f64) as u64;
 
                 soft = soft_bound.min(main.saturating_sub(move_overhead));
                 hard = hard_bound.min(main.saturating_sub(move_overhead));

--- a/src/time.rs
+++ b/src/time.rs
@@ -36,8 +36,11 @@ impl TimeManager {
                 let soft_scale = 0.024 + 0.042 * (1.0 - (-0.045 * fullmove_number as f64).exp());
                 let hard_scale = 0.135 + 0.145 * (1.0 - (-0.043 * fullmove_number as f64).exp());
 
-                soft = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
-                hard = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;
+                let soft_bound = (soft_scale * main as f64 + 0.75 * inc as f64) as u64;
+                let hard_bound = (hard_scale * main as f64 + 0.75 * inc as f64) as u64;
+
+                soft = soft_bound.min(main.saturating_sub(move_overhead));
+                hard = hard_bound.min(main.saturating_sub(move_overhead));
             }
             Limits::Cyclic(main, inc, moves) => {
                 let main = main.saturating_sub(move_overhead);


### PR DESCRIPTION
Elo   | 1.68 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 15946 W: 3955 L: 3878 D: 8113
Penta | [30, 1666, 4511, 1729, 37]
https://recklesschess.space/test/5925/

Bench: 2145678
