### PR TITLE
Introduce evaluation grain

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -11,7 +11,10 @@ pub fn evaluate(td: &mut ThreadData) -> i32 {
     let mut eval = td.nnue.evaluate(&td.board);
 
     let material = material(&td.board);
+
     eval = (eval * (21682 + material) + td.optimism[td.board.side_to_move()] * (1923 + material)) / 28993;
+
+    eval = (eval / 16) * 16 - 1 + (td.board.hash() & 0x2) as i32;
 
     eval.clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1)
 }


### PR DESCRIPTION
```
Elo   | 1.85 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 57234 W: 14193 L: 13889 D: 29152
Penta | [143, 6691, 14631, 7023, 129]
```
https://recklesschess.space/test/5957/

Bench: 2089956