### PR TITLE
Use captured piece values in bad noisy futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::{
     evaluate::evaluate,
     movepick::{MovePicker, Stage},
+    parameters::PIECE_VALUES,
     tb::{tb_probe, tb_size, GameOutcome},
     thread::ThreadData,
     transposition::{Bound, TtDepth},
@@ -558,7 +559,11 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             // Bad Noisy Futility Pruning (BNFP)
-            let capt_futility_value = static_eval + 111 * lmr_depth + 396 * move_count / 128;
+            let capt_futility_value = static_eval
+                + 111 * lmr_depth
+                + 396 * move_count / 128
+                + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 12;
+
             if !in_check && lmr_depth < 6 && move_picker.stage() == Stage::BadNoisy && capt_futility_value <= alpha {
                 if !is_decisive(best_score) && best_score <= capt_futility_value {
                     best_score = capt_futility_value;


### PR DESCRIPTION
```
Elo   | 2.06 +- 1.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 46246 W: 11584 L: 11310 D: 23352
Penta | [112, 5447, 11738, 5707, 119]
```
https://recklesschess.space/test/5955/

Bench: 2056347
