### PR TITLE
Increase quiet history malus if LMP/FP has been triggered

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -764,10 +764,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let malus_noisy = (145 * initial_depth - 75).min(1403) - 14 * (move_count - 1);
 
         let bonus_quiet = (148 * depth - 71).min(1458);
-        let malus_quiet = (125 * initial_depth - 52).min(1263) - 17 * (move_count - 1);
+        let malus_quiet = (125 * initial_depth - 52).min(1263) - 17 * (move_count - 1) + 196 * skip_quiets as i32;
 
         let bonus_cont = (114 * depth - 53).min(1318);
-        let malus_cont = (244 * initial_depth - 51).min(907) - 15 * (move_count - 1);
+        let malus_cont = (244 * initial_depth - 51).min(907) - 15 * (move_count - 1) + 128 * skip_quiets as i32;
 
         if best_move.is_noisy() {
             td.noisy_history.update(


### PR DESCRIPTION
```
Elo   | 2.04 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 47264 W: 11800 L: 11523 D: 23941
Penta | [112, 5536, 12062, 5807, 115]
```
https://recklesschess.space/test/5953/

Bench: 2163911
