### PR TITLE
Simplify post-LMR updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -678,16 +678,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node);
                     td.stack[td.ply - 1].reduction = 0;
 
-                    if mv.is_quiet() {
-                        let bonus = match score {
-                            s if s >= beta => {
-                                (1 + 2 * (move_count > depth) as i32 + 2 * (move_count > 2 * depth) as i32)
-                                    * (152 * depth - 50).min(973)
-                            }
-                            s if s <= alpha => -(139 * depth - 63).min(1166),
-                            _ => 0,
-                        };
-
+                    if mv.is_quiet() && score >= beta {
+                        let bonus = (1 + 2 * (move_count > depth) as i32 + 2 * (move_count > 2 * depth) as i32)
+                            * (152 * depth - 50).min(973);
                         td.ply -= 1;
                         update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
                         td.ply += 1;


### PR DESCRIPTION
Elo   | 1.17 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 31012 W: 7781 L: 7677 D: 15554
Penta | [79, 3743, 7755, 3853, 76]
https://recklesschess.space/test/5976/

bench: 2162183