### PR TITLE
Use noisy history in bad noisy futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -562,7 +562,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             let capt_futility_value = static_eval
                 + 111 * lmr_depth
                 + 396 * move_count / 128
-                + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 12;
+                + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 12
+                + 80 * (history + 500) / 1024;
 
             if !in_check && lmr_depth < 6 && move_picker.stage() == Stage::BadNoisy && capt_futility_value <= alpha {
                 if !is_decisive(best_score) && best_score <= capt_futility_value {


### PR DESCRIPTION
Elo   | 1.71 +- 1.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 64518 W: 16030 L: 15712 D: 32776
Penta | [160, 7518, 16596, 7814, 171]
https://recklesschess.space/test/5990/

Bench: 2055857