### PR TITLE
Track noisy best moves to prevent corrhist update

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -513,6 +513,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     let mut best_move = Move::NULL;
+    let mut had_best_noisy_move = false;
+
     let mut bound = Bound::Upper;
 
     let mut quiet_moves = ArrayVec::<Move, 32>::new();
@@ -721,6 +723,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 alpha = score;
                 best_move = mv;
 
+                if best_move.is_noisy() {
+                    had_best_noisy_move = true;
+                }
                 if NODE::PV {
                     td.pv.update(td.ply, mv);
 
@@ -819,7 +824,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     if !(in_check
-        || best_move.is_noisy()
+        || had_best_noisy_move
         || (bound == Bound::Upper && best_score >= static_eval)
         || (bound == Bound::Lower && best_score <= static_eval))
     {


### PR DESCRIPTION
Elo   | 1.86 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 54272 W: 13430 L: 13139 D: 27703
Penta | [127, 6303, 14013, 6538, 155]
https://recklesschess.space/test/5995/

bench: 2188368