### PR TITLE
Move improving adjustment to precede pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -544,6 +544,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         let mut reduction = td.lmr.reduction(depth, move_count);
 
+        if !improving {
+            reduction += 800;
+        }
+
         if !NODE::ROOT && !is_loss(best_score) {
             let lmr_depth = (depth - reduction / 1024 + is_quiet as i32 * history / 7657).max(0);
 
@@ -653,10 +657,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             if td.board.in_check() {
                 reduction -= 820;
-            }
-
-            if !improving {
-                reduction += 800;
             }
 
             if td.stack[td.ply].cutoff_count > 2 {


### PR DESCRIPTION
Elo   | 1.48 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 83156 W: 20657 L: 20302 D: 42197
Penta | [215, 9812, 21171, 10163, 217]
https://recklesschess.space/test/6000/

Bench: 2241661
