### PR TITLE
Introduce `improvement` in NMP margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -383,8 +383,12 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     let potential_singularity =
         depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
 
-    let improving =
-        !in_check && td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() && static_eval > td.stack[td.ply - 2].static_eval;
+    let mut improvement = 0;
+    if !in_check && td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() {
+        improvement = static_eval - td.stack[td.ply - 2].static_eval;
+    }
+
+    let improving = improvement > 0;
 
     // Razoring
     if !NODE::PV && !in_check && eval < alpha - 303 - 260 * depth * depth {
@@ -413,7 +417,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && eval >= beta
         && eval >= static_eval
-        && static_eval >= beta - 15 * depth + 159 * tt_pv as i32 + 203
+        && static_eval >= beta - 15 * depth + 159 * tt_pv as i32 + 203 - improvement / 15
         && td.ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
         && !potential_singularity

--- a/src/search.rs
+++ b/src/search.rs
@@ -384,7 +384,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
 
     let mut improvement = 0;
-    if !in_check && td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() {
+    if !in_check && td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() && is_valid(td.stack[td.ply - 2].static_eval) {
         improvement = static_eval - td.stack[td.ply - 2].static_eval;
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -417,7 +417,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && !excluded
         && eval >= beta
         && eval >= static_eval
-        && static_eval >= beta - 15 * depth + 159 * tt_pv as i32 + 203 - improvement / 15
+        && static_eval >= beta - 15 * depth + 159 * tt_pv as i32 - improvement / 10 + 185
         && td.ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
         && !potential_singularity


### PR DESCRIPTION
Elo   | 2.47 +- 1.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 35564 W: 8934 L: 8681 D: 17949
Penta | [71, 4166, 9058, 4413, 74]
https://recklesschess.space/test/6073/

Bench: 2021686