### PR TITLE
Adjust reduction based on improvement

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -542,7 +542,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut reduction = td.lmr.reduction(depth, move_count);
 
         if !improving {
-            reduction += 800;
+            reduction += 800 - improvement;
         }
 
         if !NODE::ROOT && !is_loss(best_score) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -542,7 +542,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut reduction = td.lmr.reduction(depth, move_count);
 
         if !improving {
-            reduction += 800 - improvement;
+            reduction += (500 - 26 * improvement / 8).min(1200);
         }
 
         if !NODE::ROOT && !is_loss(best_score) {


### PR DESCRIPTION
Elo   | 2.12 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44566 W: 11156 L: 10884 D: 22526
Penta | [92, 5213, 11402, 5483, 93]
https://recklesschess.space/test/6092/

Bench: 1959081