### PR TITLE
Adjust futility pruning margin by history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -552,7 +552,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             skip_quiets |= move_count >= (4 + depth * depth) / (2 - (improving || static_eval >= beta + 18) as i32);
 
             // Futility Pruning (FP)
-            let futility_value = static_eval + 122 * lmr_depth + 78;
+            let futility_value = static_eval + 122 * lmr_depth + 78 + history / 32;
             if !in_check && is_quiet && lmr_depth < 9 && futility_value <= alpha {
                 if !is_decisive(best_score) && best_score <= futility_value {
                     best_score = futility_value;


### PR DESCRIPTION
Elo   | 3.63 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20694 W: 5216 L: 5000 D: 10478
Penta | [39, 2402, 5258, 2600, 48]
https://recklesschess.space/test/6216/

Bench: 1689386