### PR TITLE
Add speculative check detection to futility pruning

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -425,6 +425,20 @@ impl Board {
         attacks.contains(to)
     }
 
+    pub fn might_give_check_if_you_squint(&mut self, mv: Move) -> bool {
+        let occupancies = self.occupancies() ^ mv.from().to_bb() ^ mv.to().to_bb();
+        let direct_attacks = match self.moved_piece(mv).piece_type() {
+            PieceType::Pawn => pawn_attacks(mv.to(), self.side_to_move),
+            PieceType::Knight => knight_attacks(mv.to()),
+            PieceType::Bishop => bishop_attacks(mv.to(), occupancies),
+            PieceType::Rook => rook_attacks(mv.to(), occupancies),
+            PieceType::Queen => queen_attacks(mv.to(), occupancies),
+            _ => Bitboard::default(),
+        };
+
+        direct_attacks.contains(self.their(PieceType::King).lsb())
+    }
+
     pub fn update_threats(&mut self) {
         let occupancies = self.occupancies();
         let mut threats = Bitboard::default();

--- a/src/search.rs
+++ b/src/search.rs
@@ -553,7 +553,12 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             // Futility Pruning (FP)
             let futility_value = static_eval + 122 * lmr_depth + 78 + history / 32;
-            if !in_check && is_quiet && lmr_depth < 9 && futility_value <= alpha {
+            if !in_check
+                && is_quiet
+                && lmr_depth < 9
+                && futility_value <= alpha
+                && !td.board.might_give_check_if_you_squint(mv)
+            {
                 if !is_decisive(best_score) && best_score <= futility_value {
                     best_score = futility_value;
                 }


### PR DESCRIPTION
Elo   | 1.62 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.25, 2.89) [0.00, 3.00]
Games | N: 72896 W: 18385 L: 18045 D: 36466
Penta | [156, 8580, 18625, 8942, 145]
https://recklesschess.space/test/6270/

Bench: 1681798