### PR TITLE
Speedup is_legal

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -322,8 +322,7 @@ impl Board {
         }
 
         if self.piece_on(from).piece_type() == PieceType::King {
-            let attackers = self.attackers_to(to, self.occupancies() ^ from.to_bb()) & self.them();
-            return attackers.is_empty();
+            return !self.threats().contains(to);
         }
 
         if self.pinned().contains(from) {
@@ -440,7 +439,7 @@ impl Board {
     }
 
     pub fn update_threats(&mut self) {
-        let occupancies = self.occupancies();
+        let occupancies = self.occupancies() ^ self.our(PieceType::King);
         let mut threats = Bitboard::default();
 
         for square in self.their(PieceType::Pawn) {


### PR DESCRIPTION
Elo   | 1.89 +- 1.50 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49996 W: 12974 L: 12702 D: 24320
Penta | [184, 5142, 14085, 5392, 195]
https://recklesschess.space/test/6272/

Bench: 1681798