### PR TITLE
Defer pruning depth quantization

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -546,7 +546,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
 
         if !NODE::ROOT && !is_loss(best_score) {
-            let lmr_depth = (depth - reduction / 1024 + is_quiet as i32 * history / 7657).max(0);
+            let lmr_reduction = if is_quiet { reduction - 137 * history / 1024 } else { reduction };
+            let lmr_depth = (depth - lmr_reduction / 1024).max(0);
 
             // Late Move Pruning (LMP)
             skip_quiets |= move_count >= (4 + depth * depth) / (2 - (improving || static_eval >= beta + 18) as i32);


### PR DESCRIPTION
Elo   | 0.50 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 46988 W: 11738 L: 11671 D: 23579
Penta | [91, 5635, 11997, 5658, 113]
https://recklesschess.space/test/6226/

Bench: 1735042