### PR TITLE
Simplify away history scaling factors

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -180,12 +180,11 @@ impl MovePicker {
                 continue;
             }
 
-            entry.score = (td.quiet_history.get(threats, side, mv)
+            entry.score = td.quiet_history.get(threats, side, mv)
                 + td.conthist(1, mv)
                 + td.conthist(2, mv)
                 + td.conthist(4, mv)
-                + td.conthist(6, mv))
-                / 1024;
+                + td.conthist(6, mv);
         }
     }
 }

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -180,11 +180,11 @@ impl MovePicker {
                 continue;
             }
 
-            entry.score = (1188 * td.quiet_history.get(threats, side, mv)
-                + 1028 * td.conthist(1, mv)
-                + 868 * td.conthist(2, mv)
-                + 868 * td.conthist(4, mv)
-                + 868 * td.conthist(6, mv))
+            entry.score = (td.quiet_history.get(threats, side, mv)
+                + td.conthist(1, mv)
+                + td.conthist(2, mv)
+                + td.conthist(4, mv)
+                + td.conthist(6, mv))
                 / 1024;
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1071,7 +1071,7 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32) {
 }
 
 fn update_continuation_histories(td: &mut ThreadData, piece: Piece, sq: Square, bonus: i32) {
-    const BONUSES: [(usize, i32); 5] = [(1, 1523), (2, 1144), (3, 957), (4, 1024), (6, 1024)];
+    const BONUSES: [(usize, i32); 5] = [(1, 1536), (2, 1024), (3, 1024), (4, 1024), (6, 1024)];
 
     for (offset, scale) in BONUSES {
         if td.ply >= offset {


### PR DESCRIPTION
Elo   | 1.36 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 29024 W: 7219 L: 7105 D: 14700
Penta | [67, 3427, 7414, 3533, 71]
https://recklesschess.space/test/6288/

Bench: 1732975
