### PR TITLE
Speed up null move pruning dive

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -429,9 +429,14 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         td.board.make_null_move();
 
-        td.stack[td.ply].reduction = 1024 * (r - 1);
-        let score = -search::<NonPV>(td, -beta, -beta + 1, depth - r, false);
-        td.stack[td.ply].reduction = 0;
+        let score = if (depth - r) <= 0 {
+            -qsearch::<NonPV>(td, -beta, -beta + 1)
+        } else {
+            td.stack[td.ply].reduction = 1024 * (r - 1);
+            let value = -search::<NonPV>(td, -beta, -beta + 1, depth - r, false);
+            td.stack[td.ply].reduction = 0;
+            value
+        };
 
         td.board.undo_null_move();
         td.ply -= 1;


### PR DESCRIPTION
Elo   | 2.91 +- 2.06 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26126 W: 6831 L: 6612 D: 12683
Penta | [84, 2656, 7384, 2835, 104]
https://recklesschess.space/test/6287/

Bench: 1732975