### PR TITLE
Adjust history bonuses based on cut node

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -775,10 +775,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let bonus_noisy = (124 * depth - 65).min(1177);
         let malus_noisy = (145 * initial_depth - 75).min(1403) - 14 * (move_count - 1);
 
-        let bonus_quiet = (148 * depth - 71).min(1458);
+        let bonus_quiet = (148 * depth - 71).min(1458) - 64 * cut_node as i32;
         let malus_quiet = (125 * initial_depth - 52).min(1263) - 17 * (move_count - 1) + 196 * skip_quiets as i32;
 
-        let bonus_cont = (114 * depth - 53).min(1318);
+        let bonus_cont = (114 * depth - 53).min(1318) - 64 * cut_node as i32;
         let malus_cont = (244 * initial_depth - 51).min(907) - 15 * (move_count - 1) + 128 * skip_quiets as i32;
 
         if best_move.is_noisy() {


### PR DESCRIPTION
Elo   | 4.35 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16996 W: 4342 L: 4129 D: 8525
Penta | [34, 1938, 4348, 2137, 41]
https://recklesschess.space/test/6307/

Bench: 1627743
