### PR TITLE
Allow see pruning for recaptures in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -974,10 +974,10 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
                 best_score = best_score.max(futility_score);
                 continue;
             }
+        }
 
-            if !td.board.see(mv, -73) {
-                continue;
-            }
+        if !is_loss(best_score) && !td.board.see(mv, -73) {
+            continue;
         }
 
         make_move(td, mv);


### PR DESCRIPTION
Elo   | 3.15 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24574 W: 6217 L: 5994 D: 12363
Penta | [41, 2864, 6256, 3083, 43]
https://recklesschess.space/test/6382/

bench: 1508063