### PR TITLE
Adjust noisy history bonus based on cut node

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -767,7 +767,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     if best_move.is_some() {
-        let bonus_noisy = (128 * depth - 60).min(1150);
+        let bonus_noisy = (128 * depth - 60).min(1150) - 69 * cut_node as i32;
         let malus_noisy = (145 * initial_depth - 67).min(1457) - 13 * (move_count - 1);
 
         let bonus_quiet = (151 * depth - 68).min(1597) - 64 * cut_node as i32;


### PR DESCRIPTION
Elo   | 2.24 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39840 W: 9948 L: 9691 D: 20201
Penta | [83, 4663, 10167, 4928, 79]
https://recklesschess.space/test/6380/

