### PR TITLE
Lower aspiration windows threshold

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -73,7 +73,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
         let mut reduction = 0;
 
         // Aspiration Windows
-        if depth >= 4 {
+        if depth >= 2 {
             delta += average * average / 26802;
 
             alpha = (average - delta).max(-Score::INFINITE);


### PR DESCRIPTION
Elo   | 1.55 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 75766 W: 19075 L: 18738 D: 37953
Penta | [150, 8919, 19435, 9202, 177]
https://recklesschess.space/test/6434/

Bench: 1616449
