### PR TITLE
Increase LMR for nodes that are likely to fail low

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -670,6 +670,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction += 1232;
             }
 
+            if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
+                reduction += 768;
+            }
+
             let reduced_depth =
                 (new_depth - reduction / 1024).clamp(NODE::PV as i32, new_depth + (NODE::PV || cut_node) as i32);
 


### PR DESCRIPTION
Elo   | 2.31 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 37754 W: 9533 L: 9282 D: 18939
Penta | [76, 4343, 9786, 4598, 74]
https://recklesschess.space/test/6441/

Bench: 1372313