### PR TITLE
Less reduction for opponent's pawns only

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -662,7 +662,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction += 1193;
             }
 
-            if td.board.in_check() {
+            if td.board.in_check() || !td.board.has_non_pawns() {
                 reduction -= 794;
             }
 


### PR DESCRIPTION
Elo   | 1.25 +- 1.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 105622 W: 26267 L: 25886 D: 53469
Penta | [200, 11191, 29628, 11612, 180]
https://recklesschess.space/test/6515/

Bench: 1418543