### PR TITLE
More LMR extensions for PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -674,8 +674,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction += 768;
             }
 
-            let reduced_depth =
-                (new_depth - reduction / 1024).clamp(NODE::PV as i32, new_depth + (NODE::PV || cut_node) as i32);
+            let reduced_depth = (new_depth - reduction / 1024)
+                .clamp(NODE::PV as i32, new_depth + cut_node as i32 + 2 * NODE::PV as i32);
 
             td.stack[td.ply - 1].reduction = reduction;
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true);


### PR DESCRIPTION
Elo   | 3.74 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19808 W: 4959 L: 4746 D: 10103
Penta | [37, 2280, 5056, 2495, 36]
https://recklesschess.space/test/6617/

Bench: 1562705