### PR TITLE
Adjust TT-cut history bonus based on cut node

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -249,8 +249,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
         {
             if tt_move.is_quiet() && tt_score >= beta {
-                let quiet_bonus = (134 * depth - 72).min(1380);
-                let conthist_bonus = (100 * depth - 62).min(1415);
+                let quiet_bonus = (134 * depth - 72).min(1380) + 69 * !cut_node as i32;
+                let conthist_bonus = (100 * depth - 62).min(1415) + 69 * !cut_node as i32;
 
                 td.quiet_history.update(td.board.threats(), td.board.side_to_move(), tt_move, quiet_bonus);
                 update_continuation_histories(td, td.board.moved_piece(tt_move), tt_move.to(), conthist_bonus);


### PR DESCRIPTION
Elo   | 1.66 +- 1.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 65602 W: 16286 L: 15973 D: 33343
Penta | [123, 7708, 16819, 8035, 116]
https://recklesschess.space/test/6618/

Bench: 1535557