### PR TITLE
Update default network to v37-629c190c.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v36-87055d4b.nnue";
+const NETWORK_NAME: &str = "v37-629c190c.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Standard fixed nodes
Elo   | 3.17 +- 2.21 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.42 (-2.94, 2.94) [0.00, 3.00]
Games | N: 42774 W: 13498 L: 13108 D: 16168
Penta | [1102, 4905, 9110, 5041, 1229]
https://recklesschess.space/test/6671/

Standard non-regression STC
Elo   | 0.89 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 36008 W: 9083 L: 8991 D: 17934
Penta | [62, 4325, 9168, 4357, 92]
https://recklesschess.space/test/6672/

DFRC STC
Elo   | 23.38 +- 6.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 2768 W: 769 L: 583 D: 1416
Penta | [9, 252, 694, 402, 27]
https://recklesschess.space/test/6674/

Bench: 1661082