### PR TITLE
Allow even more LMR extensions for PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -675,7 +675,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             let reduced_depth = (new_depth - reduction / 1024)
-                .clamp(NODE::PV as i32, new_depth + cut_node as i32 + 2 * NODE::PV as i32);
+                .clamp(NODE::PV as i32, new_depth + cut_node as i32 + NODE::PV as i32)
+                + NODE::PV as i32;
 
             td.stack[td.ply - 1].reduction = reduction;
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true);


### PR DESCRIPTION
Elo   | 2.22 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40310 W: 10200 L: 9943 D: 20167
Penta | [81, 4626, 10487, 4877, 84]
https://recklesschess.space/test/6675/

Bench: 1751379