### PR TITLE
Use initial depth in PCM history update

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -811,13 +811,13 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let pcm_move = td.stack[td.ply - 1].mv;
         if pcm_move.is_quiet() {
             let mut factor = 107;
-            factor += 141 * (depth > 5) as i32;
+            factor += 141 * (initial_depth > 5) as i32;
             factor += 231 * (!in_check && best_score <= static_eval.min(raw_eval) - 135) as i32;
             factor += 289
                 * (is_valid(td.stack[td.ply - 1].static_eval) && best_score <= -td.stack[td.ply - 1].static_eval - 102)
                     as i32;
 
-            let scaled_bonus = factor * (148 * depth - 43).min(1673) / 128;
+            let scaled_bonus = factor * (148 * initial_depth - 43).min(1673) / 128;
 
             td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
         }


### PR DESCRIPTION
Elo   | 1.61 +- 1.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 68526 W: 17069 L: 16751 D: 34706
Penta | [115, 8071, 17569, 8397, 111]
https://recklesschess.space/test/6769/

Bench: 1976418
