### PR TITLE
Introduce partial continuation history PCM bonus

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -820,6 +820,14 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             let scaled_bonus = factor * (148 * initial_depth - 43).min(1673) / 128;
 
             td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
+
+            if td.ply >= 2 {
+                let entry = &td.stack[td.ply - 2];
+                if entry.mv.is_some() {
+                    let bonus = (148 * initial_depth - 43).min(1673);
+                    td.continuation_history.update(entry.conthist, td.stack[td.ply - 1].piece, pcm_move.to(), bonus);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Elo   | 1.62 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 3.00]
Games | N: 70552 W: 17564 L: 17235 D: 35753
Penta | [127, 8275, 18160, 8570, 144]
https://recklesschess.space/test/6782/

Bench: 2118796