### PR TITLE
Adjust malus based on move type counts

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -773,13 +773,14 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
     if best_move.is_some() {
         let bonus_noisy = (128 * depth - 60).min(1150) - 69 * cut_node as i32;
-        let malus_noisy = (145 * initial_depth - 67).min(1457) - 13 * (move_count - 1);
+        let malus_noisy = (145 * initial_depth - 67).min(1457) - 26 * noisy_moves.len() as i32;
 
         let bonus_quiet = (151 * depth - 68).min(1597) - 64 * cut_node as i32;
-        let malus_quiet = (134 * initial_depth - 55).min(1273) - 17 * (move_count - 1) + 200 * skip_quiets as i32;
+        let malus_quiet =
+            (134 * initial_depth - 55).min(1273) - 34 * quiet_moves.len() as i32 + 200 * skip_quiets as i32;
 
         let bonus_cont = (97 * depth - 57).min(1250) - 69 * cut_node as i32;
-        let malus_cont = (277 * initial_depth - 49).min(978) - 14 * (move_count - 1) + 126 * skip_quiets as i32;
+        let malus_cont = (277 * initial_depth - 49).min(978) - 28 * quiet_moves.len() as i32 + 126 * skip_quiets as i32;
 
         if best_move.is_noisy() {
             td.noisy_history.update(


### PR DESCRIPTION
Elo   | 2.01 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 47168 W: 11748 L: 11475 D: 23945
Penta | [82, 5554, 12038, 5829, 81]
https://recklesschess.space/test/6794/

Bench: 1920698
