### PR TITLE
Introduce MVV term into LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -641,6 +641,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 106 * (history - 574) / 1024;
             } else {
                 reduction -= 95 * (history - 557) / 1024;
+                reduction -= PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 3;
             }
 
             reduction -= 3268 * correction_value.abs() / 1024;


### PR DESCRIPTION
Elo   | 2.09 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44630 W: 11209 L: 10940 D: 22481
Penta | [86, 5257, 11362, 5522, 88]
https://recklesschess.space/test/6810/

Bench: 2039745