### PR TITLE
Separate FT activation and NNZ index finding

### DIFF
--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -161,8 +161,8 @@ impl Network {
 
     fn output_transformer(&self, board: &Board) -> i32 {
         unsafe {
-            let (ft_out, nnz_indexes, nnz_count) =
-                forward::activate_ft(&self.stack[self.index], &self.nnz_table, board.side_to_move());
+            let ft_out = forward::activate_ft(&self.stack[self.index], board.side_to_move());
+            let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
 
             let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count]);
             let l2_out = forward::propagate_l2(l1_out);

--- a/src/nnue/forward/vectorized.rs
+++ b/src/nnue/forward/vectorized.rs
@@ -8,15 +8,8 @@ use crate::{
     types::Color,
 };
 
-pub unsafe fn activate_ft(
-    accumulator: &Accumulator, nnz_table: &[SparseEntry], stm: Color,
-) -> (Aligned<[u8; L1_SIZE]>, Aligned<[u16; L1_SIZE / 4]>, usize) {
+pub unsafe fn activate_ft(accumulator: &Accumulator, stm: Color) -> Aligned<[u8; L1_SIZE]> {
     let mut output = Aligned::new([0; L1_SIZE]);
-
-    let nnz_increment = _mm_set1_epi16(8);
-    let mut nnz_base = _mm_setzero_si128();
-    let mut nnz_indexes = Aligned::new([0; L1_SIZE / 4]);
-    let mut nnz_count = 0;
 
     let zero = simd::zeroed();
     let one = simd::splat_i16(FT_QUANT as i16);
@@ -47,23 +40,35 @@ pub unsafe fn activate_ft(
             let unpacked = simd::permute(packed);
 
             *output.as_mut_ptr().add(i + flip * L1_SIZE / 2).cast() = unpacked;
-
-            let mask = simd::nnz_bitmask(unpacked);
-
-            for offset in (0..simd::I32_LANES).step_by(8) {
-                let slice = (mask >> offset) & 0xFF;
-                let entry = nnz_table.get_unchecked(slice as usize);
-
-                let store = nnz_indexes.as_mut_ptr().add(nnz_count).cast();
-                _mm_storeu_si128(store, _mm_add_epi16(nnz_base, *entry.indexes.as_ptr().cast()));
-
-                nnz_count += entry.count;
-                nnz_base = _mm_add_epi16(nnz_base, nnz_increment);
-            }
         }
     }
 
-    (output, nnz_indexes, nnz_count)
+    output
+}
+
+pub unsafe fn find_nnz(ft_out: &Aligned<[u8; L1_SIZE]>, nnz: &[SparseEntry]) -> (Aligned<[u16; L1_SIZE / 4]>, usize) {
+    let mut nnz_indexes = Aligned::new([0; L1_SIZE / 4]);
+    let mut nnz_count = 0;
+
+    let nnz_increment = _mm_set1_epi16(8);
+    let mut nnz_base = _mm_setzero_si128();
+
+    for i in (0..L1_SIZE).step_by(2 * simd::I16_LANES) {
+        let mask = simd::nnz_bitmask(*ft_out.as_ptr().add(i).cast());
+
+        for offset in (0..simd::I32_LANES).step_by(8) {
+            let slice = (mask >> offset) & 0xFF;
+            let entry = nnz.get_unchecked(slice as usize);
+
+            let store = nnz_indexes.as_mut_ptr().add(nnz_count).cast();
+            _mm_storeu_si128(store, _mm_add_epi16(nnz_base, *entry.indexes.as_ptr().cast()));
+
+            nnz_count += entry.count;
+            nnz_base = _mm_add_epi16(nnz_base, nnz_increment);
+        }
+    }
+
+    (nnz_indexes, nnz_count)
 }
 
 pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16]) -> Aligned<[f32; L2_SIZE]> {


### PR DESCRIPTION
Elo   | 2.22 +- 1.70 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40464 W: 10437 L: 10179 D: 19848
Penta | [132, 4421, 10891, 4633, 155]
https://recklesschess.space/test/6873/

Bench: 2013929