### PR TITLE
Adjust triple extension margin based on correction history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -617,7 +617,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 if score < singular_beta {
                     extension = 1;
                     extension += (score < singular_beta - 2 - 300 * NODE::PV as i32) as i32;
-                    extension += (is_quiet && score < singular_beta - 64 - 300 * NODE::PV as i32) as i32;
+                    extension += (is_quiet
+                        && score < singular_beta - 64 - 300 * NODE::PV as i32 + correction_value.abs() / 8)
+                        as i32;
 
                     if extension > 1 && depth < 14 {
                         depth += 1;


### PR DESCRIPTION
Elo   | 1.61 +- 1.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 68164 W: 17076 L: 16760 D: 34328
Penta | [116, 7970, 17593, 8288, 115]
https://recklesschess.space/test/6882/

Bench: 2290269