### PR TITLE
Reduced LMR depth threshold

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -642,7 +642,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut score = Score::ZERO;
 
         // Late Move Reductions (LMR)
-        if depth >= 3 && move_count > 1 + NODE::ROOT as i32 {
+        if depth >= 2 && move_count > 1 + NODE::ROOT as i32 {
             if is_quiet {
                 reduction -= 106 * (history - 574) / 1024;
             } else {
@@ -679,6 +679,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
                 reduction += 768;
+            }
+            
+            if depth == 2 {
+                reduction -= 1024;
             }
 
             let reduced_depth = (new_depth - reduction / 1024)

--- a/src/search.rs
+++ b/src/search.rs
@@ -680,7 +680,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
                 reduction += 768;
             }
-            
+
             if depth == 2 {
                 reduction -= 1024;
             }


### PR DESCRIPTION
Elo   | 4.12 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17694 W: 4493 L: 4283 D: 8918
Penta | [24, 2020, 4558, 2212, 33]
https://recklesschess.space/test/6898/

Bench: 2207880