### PR TITLE
Prevent rare wrong Reverse Futility Pruning with TT bound Upper

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -405,6 +405,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 + 23
         && !is_loss(beta)
         && !is_win(eval)
+        && tt_bound != Bound::Upper
     {
         return (eval + beta) / 2;
     }


### PR DESCRIPTION
less than 0.25% probability

Elo   | 1.95 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50646 W: 12925 L: 12641 D: 25080
Penta | [125, 5987, 12832, 6237, 142]
https://recklesschess.space/test/6989/

Bench: 2206432