### PR TITLE
Simplify correction history guards

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -511,8 +511,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     let mut best_move = Move::NULL;
-    let mut had_best_noisy_move = false;
-
     let mut bound = Bound::Upper;
 
     let mut quiet_moves = ArrayVec::<Move, 32>::new();
@@ -742,9 +740,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 alpha = score;
                 best_move = mv;
 
-                if best_move.is_noisy() {
-                    had_best_noisy_move = true;
-                }
                 if NODE::PV {
                     td.pv.update(td.ply, mv);
 
@@ -860,7 +855,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     if !(in_check
-        || had_best_noisy_move
+        || best_move.is_noisy()
         || (bound == Bound::Upper && best_score >= static_eval)
         || (bound == Bound::Lower && best_score <= static_eval))
     {


### PR DESCRIPTION
Elo   | 0.73 +- 1.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.14 (-2.25, 2.89) [0.00, 3.00]
Games | N: 92218 W: 23357 L: 23162 D: 45699
Penta | [231, 11011, 23414, 11238, 215]
https://recklesschess.space/test/7005/

Bench: 2492819