### PR TITLE
Stricter TT-cut

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -240,7 +240,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         if !NODE::PV
             && !excluded
-            && tt_depth >= depth
+            && tt_depth > depth - (tt_score <= beta) as i32 - (tt_bound == Bound::Exact) as i32
             && is_valid(tt_score)
             && match tt_bound {
                 Bound::Upper => tt_score <= alpha && (!cut_node || depth > 5),


### PR DESCRIPTION
Elo   | 1.93 +- 1.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50638 W: 12816 L: 12534 D: 25288
Penta | [114, 5934, 12945, 6208, 118]
https://recklesschess.space/test/7011/

Bench: 2576771