### PR TITLE
Update default network to v40-038b85e3.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v39-309b70ac.nnue";
+const NETWORK_NAME: &str = "v40-038b85e3.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 1.01 +- 2.31 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40908 W: 13218 L: 13099 D: 14591
Penta | [1252, 4569, 8668, 4738, 1227]
https://recklesschess.space/test/7075/

STC
Elo   | 3.65 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21300 W: 5626 L: 5402 D: 10272
Penta | [80, 2488, 5299, 2694, 89]
https://recklesschess.space/test/7073/

LTC
Elo   | 3.89 +- 2.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18232 W: 4675 L: 4471 D: 9086
Penta | [9, 2074, 4751, 2268, 14]
https://recklesschess.space/test/7077/

Bench: 2612139