### PR TITLE
No probcut for positions with ttmove quiet

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -467,7 +467,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     // ProbCut
     let probcut_beta = beta + 271 - 61 * improving as i32;
 
-    if depth >= 3 && !is_decisive(beta) && (!is_valid(tt_score) || tt_score >= probcut_beta) {
+    if depth >= 3 && !is_decisive(beta) && (!is_valid(tt_score) || tt_score >= probcut_beta) && !tt_move.is_quiet() {
         let mut move_picker = MovePicker::new_probcut(probcut_beta - static_eval);
 
         let probcut_depth = 0.max(depth - 4);


### PR DESCRIPTION
[Deblunder] No probcut for positions with ttmove quiet, 1% probability here

Elo   | 1.93 +- 1.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49894 W: 12871 L: 12594 D: 24429
Penta | [103, 5730, 13020, 5975, 119]
https://recklesschess.space/test/7083/

Bench: 2438743