### PR TITLE
Fix en-passant in SEE

### DIFF
--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -31,6 +31,10 @@ impl super::Board {
         occupancies.clear(mv.from());
         occupancies.set(mv.to());
 
+        if mv.is_en_passant() {
+            occupancies.clear(mv.to() ^ 8);
+        }
+
         let mut attackers = self.attackers_to(mv.to(), occupancies) & occupancies;
         let mut stm = !self.side_to_move();
 


### PR DESCRIPTION
Elo   | 0.72 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 39642 W: 10013 L: 9931 D: 19698
Penta | [95, 4517, 10504, 4621, 84]
https://recklesschess.space/test/7084/

Bench: 2637886