### PR TITLE
Introduce unlimited RFP depth using a quadratic depth term

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -397,10 +397,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     if !tt_pv
         && !in_check
         && !excluded
-        && depth <= 7
         && eval >= beta
         && eval
-            >= beta + 72 * depth - (70 * improving as i32) - (23 * cut_node as i32)
+            >= beta + 10 * depth * depth + 30 * depth - (70 * improving as i32) - (23 * cut_node as i32)
                 + 559 * correction_value.abs() / 1024
                 + 23
         && !is_loss(beta)


### PR DESCRIPTION
STC
Elo   | 2.07 +- 1.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 47224 W: 12106 L: 11825 D: 23293
Penta | [111, 5547, 12020, 5818, 116]
https://recklesschess.space/test/7080/

LTC
Elo   | 1.66 +- 1.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 60000 W: 14838 L: 14552 D: 30610
Penta | [15, 6746, 16199, 7018, 22]
https://recklesschess.space/test/7082/
