### PR TITLE
Introduce capture and in_check slots in continuation histories

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -143,14 +143,16 @@ impl Default for CorrectionHistory {
 
 pub struct ContinuationCorrectionHistory {
     // [piece][to][continuation_piece][continuation_to]
-    entries: Box<[[PieceToHistory<i16>; 64]; 13]>,
+    entries: Box<[[[[PieceToHistory<i16>; 64]; 13]; 2]; 2]>,
 }
 
 impl ContinuationCorrectionHistory {
     const MAX_HISTORY: i32 = 16222;
 
-    pub fn subtable_ptr(&mut self, piece: Piece, sq: Square) -> *mut PieceToHistory<i16> {
-        self.entries[piece][sq].as_mut_ptr().cast()
+    pub fn subtable_ptr(
+        &mut self, in_check: bool, capture: bool, piece: Piece, sq: Square,
+    ) -> *mut PieceToHistory<i16> {
+        self.entries[in_check as usize][capture as usize][piece][sq].as_mut_ptr().cast()
     }
 
     pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, sq: Square) -> i32 {
@@ -171,14 +173,16 @@ impl Default for ContinuationCorrectionHistory {
 
 pub struct ContinuationHistory {
     // [piece][to][continuation_piece][continuation_to]
-    entries: Box<[[PieceToHistory<i16>; 64]; 13]>,
+    entries: Box<[[[[PieceToHistory<i16>; 64]; 13]; 2]; 2]>,
 }
 
 impl ContinuationHistory {
     const MAX_HISTORY: i32 = 15324;
 
-    pub fn subtable_ptr(&mut self, piece: Piece, sq: Square) -> *mut PieceToHistory<i16> {
-        self.entries[piece][sq].as_mut_ptr().cast()
+    pub fn subtable_ptr(
+        &mut self, in_check: bool, capture: bool, piece: Piece, sq: Square,
+    ) -> *mut PieceToHistory<i16> {
+        self.entries[in_check as usize][capture as usize][piece][sq].as_mut_ptr().cast()
     }
 
     pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, sq: Square) -> i32 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1116,10 +1116,12 @@ fn update_continuation_histories(td: &mut ThreadData, piece: Piece, sq: Square, 
 }
 
 fn make_move(td: &mut ThreadData, mv: Move) {
-    td.stack[td.ply].conthist = td.continuation_history.subtable_ptr(td.board.moved_piece(mv), mv.to());
-    td.stack[td.ply].contcorrhist = td.continuation_corrhist.subtable_ptr(td.board.moved_piece(mv), mv.to());
-    td.stack[td.ply].piece = td.board.moved_piece(mv);
     td.stack[td.ply].mv = mv;
+    td.stack[td.ply].piece = td.board.moved_piece(mv);
+    td.stack[td.ply].conthist =
+        td.continuation_history.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
+    td.stack[td.ply].contcorrhist =
+        td.continuation_corrhist.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
     td.ply += 1;
 
     td.nodes.increment();


### PR DESCRIPTION
Elo   | -1.16 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24472 W: 6079 L: 6161 D: 12232
Penta | [56, 2996, 6216, 2910, 58]
https://recklesschess.space/test/7195/

Elo   | 2.69 +- 1.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28976 W: 7199 L: 6975 D: 14802
Penta | [6, 3244, 7771, 3454, 13]
https://recklesschess.space/test/7196/

Bench: 2819421