### PR TITLE
Add root moves tracking

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -127,7 +127,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
                 }
             }
 
-            if report == Report::Full {
+            if report == Report::Full && td.nodes.global() > 10_000_000 {
                 td.print_uci_info(depth);
             }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -49,7 +49,6 @@ pub fn start(td: &mut ThreadData, report: Report) {
     td.stopped = false;
 
     td.pv.clear(0);
-    td.node_table.clear();
     td.nodes.clear();
     td.tb_hits.clear();
 
@@ -67,6 +66,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
             lowerbound: false,
             upperbound: false,
             sel_depth: 0,
+            nodes: 0,
         })
         .collect();
 
@@ -156,7 +156,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
         }
 
         let multiplier = || {
-            let nodes_factor = 2.15 - 1.5 * (td.node_table.get(td.pv.best_move()) as f32 / td.nodes.local() as f32);
+            let nodes_factor = 2.15 - 1.5 * (td.root_moves[0].nodes as f32 / td.nodes.local() as f32);
 
             let pv_stability = 1.25 - 0.05 * pv_stability.min(8) as f32;
 
@@ -750,9 +750,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
 
         if NODE::ROOT {
-            td.node_table.add(mv, td.nodes.local() - initial_nodes);
-
             let root_move = td.root_moves.iter_mut().find(|v| v.mv == mv).unwrap();
+
+            root_move.nodes += td.nodes.local() - initial_nodes;
 
             if move_count == 1 || score > alpha {
                 match score {

--- a/src/search.rs
+++ b/src/search.rs
@@ -212,7 +212,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     }
 
     if NODE::PV {
-        td.sel_depth = td.sel_depth.max(td.ply as i32 + 1);
+        td.sel_depth = td.sel_depth.max(td.ply as i32);
     }
 
     if td.time_manager.check_time(td) {
@@ -925,7 +925,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
 
     if NODE::PV {
         td.pv.clear(td.ply);
-        td.sel_depth = td.sel_depth.max(td.ply as i32 + 1);
+        td.sel_depth = td.sel_depth.max(td.ply as i32);
     }
 
     if td.time_manager.check_time(td) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -66,6 +66,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
             display_score: -Score::INFINITE,
             lowerbound: false,
             upperbound: false,
+            sel_depth: 0,
         })
         .collect();
 
@@ -771,6 +772,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 }
 
                 root_move.score = score;
+                root_move.sel_depth = td.sel_depth;
             } else {
                 root_move.score = -Score::INFINITE;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@ use crate::{
     movepick::{MovePicker, Stage},
     parameters::PIECE_VALUES,
     tb::{tb_probe, tb_size, GameOutcome},
-    thread::ThreadData,
+    thread::{RootMove, ThreadData},
     transposition::{Bound, TtDepth},
     types::{
         is_decisive, is_loss, is_valid, is_win, mate_in, mated_in, tb_loss_in, tb_win_in, ArrayVec, Color, Move, Piece,
@@ -55,6 +55,20 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
     td.nnue.full_refresh(&td.board);
 
+    td.root_moves = td
+        .board
+        .generate_all_moves()
+        .iter()
+        .filter(|v| td.board.is_legal(v.mv))
+        .map(|v| RootMove {
+            mv: v.mv,
+            score: -Score::INFINITE,
+            display_score: -Score::INFINITE,
+            lowerbound: false,
+            upperbound: false,
+        })
+        .collect();
+
     let mut average = Score::NONE;
     let mut last_move = Move::NULL;
 
@@ -90,8 +104,11 @@ pub fn start(td: &mut ThreadData, report: Report) {
             // Root Search
             let score = search::<Root>(td, alpha, beta, (depth - reduction).max(1), false);
 
+            td.root_moves.sort_by(|a, b| b.score.cmp(&a.score));
+
             if td.stopped {
                 break;
+            }
             }
 
             match score {
@@ -128,7 +145,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
             last_move = td.pv.best_move();
         }
 
-        if (td.best_score - average).abs() < 12 {
+        if (td.root_moves[0].score - average).abs() < 12 {
             eval_stability += 1;
         } else {
             eval_stability = 0;
@@ -141,7 +158,8 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
             let eval_stability = 1.2 - 0.04 * eval_stability.min(8) as f32;
 
-            let score_trend = (800 + 20 * (td.previous_best_score - td.best_score)).clamp(750, 1500) as f32 / 1000.0;
+            let score_trend =
+                (800 + 20 * (td.previous_best_score - td.root_moves[0].score)).clamp(750, 1500) as f32 / 1000.0;
 
             nodes_factor * pv_stability * eval_stability * score_trend
         };
@@ -151,15 +169,15 @@ pub fn start(td: &mut ThreadData, report: Report) {
         }
 
         if report == Report::Full {
-            td.print_uci_info(depth, td.best_score);
+            td.print_uci_info(depth);
         }
     }
 
     if report != Report::None {
-        td.print_uci_info(td.root_depth, td.best_score);
+        td.print_uci_info(td.root_depth);
     }
 
-    td.previous_best_score = td.best_score;
+    td.previous_best_score = td.root_moves[0].score;
 }
 
 fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, depth: i32, cut_node: bool) -> i32 {
@@ -729,6 +747,30 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         if NODE::ROOT {
             td.node_table.add(mv, td.nodes.local() - initial_nodes);
+
+            let root_move = td.root_moves.iter_mut().find(|v| v.mv == mv).unwrap();
+
+            if move_count == 1 || score > alpha {
+                match score {
+                    v if v <= alpha => {
+                        root_move.display_score = alpha;
+                        root_move.upperbound = true;
+                    }
+                    v if v >= beta => {
+                        root_move.display_score = beta;
+                        root_move.lowerbound = true;
+                    }
+                    _ => {
+                        root_move.display_score = score;
+                        root_move.upperbound = false;
+                        root_move.lowerbound = false;
+                    }
+                }
+
+                root_move.score = score;
+            } else {
+                root_move.score = -Score::INFINITE;
+            }
         }
 
         if score > best_score {
@@ -741,10 +783,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
                 if NODE::PV {
                     td.pv.update(td.ply, mv);
-
-                    if NODE::ROOT {
-                        td.best_score = score;
-                    }
                 }
 
                 if score >= beta {

--- a/src/search.rs
+++ b/src/search.rs
@@ -109,7 +109,6 @@ pub fn start(td: &mut ThreadData, report: Report) {
             if td.stopped {
                 break;
             }
-            }
 
             match score {
                 s if s <= alpha => {
@@ -125,6 +124,10 @@ pub fn start(td: &mut ThreadData, report: Report) {
                     average = if average == Score::NONE { score } else { (average + score) / 2 };
                     break;
                 }
+            }
+
+            if report == Report::Full {
+                td.print_uci_info(depth);
             }
 
             delta += delta * (38 + 15 * reduction) / 128;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -176,7 +176,7 @@ impl<'a> ThreadData<'a> {
 
         print!(
             "info depth {depth} seldepth {} score {score} nodes {} time {ms} nps {nps:.0} hashfull {} tbhits {} pv",
-            self.sel_depth,
+            root_move.sel_depth,
             self.nodes.global(),
             self.tt.hashfull(),
             self.tb_hits.global(),
@@ -200,6 +200,7 @@ pub struct RootMove {
     pub display_score: i32,
     pub upperbound: bool,
     pub lowerbound: bool,
+    pub sel_depth: i32,
 }
 
 pub struct PrincipalVariationTable {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -10,7 +10,7 @@ use crate::{
     stack::Stack,
     time::{Limits, TimeManager},
     transposition::TranspositionTable,
-    types::{normalize_to_cp, Move, Score, Square, MAX_MOVES, MAX_PLY},
+    types::{normalize_to_cp, Move, Score, MAX_MOVES, MAX_PLY},
 };
 
 pub struct ThreadPool<'a> {
@@ -85,7 +85,6 @@ pub struct ThreadData<'a> {
     pub major_corrhist: CorrectionHistory,
     pub non_pawn_corrhist: [CorrectionHistory; 2],
     pub continuation_corrhist: ContinuationCorrectionHistory,
-    pub node_table: NodeTable,
     pub lmr: LmrTable,
     pub optimism: [i32; 2],
     pub stopped: bool,
@@ -119,7 +118,6 @@ impl<'a> ThreadData<'a> {
             major_corrhist: CorrectionHistory::default(),
             non_pawn_corrhist: [CorrectionHistory::default(), CorrectionHistory::default()],
             continuation_corrhist: ContinuationCorrectionHistory::default(),
-            node_table: NodeTable::default(),
             lmr: LmrTable::default(),
             optimism: [0; 2],
             stopped: false,
@@ -201,6 +199,7 @@ pub struct RootMove {
     pub upperbound: bool,
     pub lowerbound: bool,
     pub sel_depth: i32,
+    pub nodes: u64,
 }
 
 pub struct PrincipalVariationTable {
@@ -262,30 +261,6 @@ impl Default for LmrTable {
         }
 
         Self { table }
-    }
-}
-
-pub struct NodeTable {
-    table: Box<[u64]>,
-}
-
-impl NodeTable {
-    pub const fn add(&mut self, mv: Move, nodes: u64) {
-        self.table[mv.encoded()] += nodes;
-    }
-
-    pub const fn get(&self, mv: Move) -> u64 {
-        self.table[mv.encoded()]
-    }
-
-    pub fn clear(&mut self) {
-        *self = Self::default();
-    }
-}
-
-impl Default for NodeTable {
-    fn default() -> Self {
-        Self { table: vec![0; Square::NUM * Square::NUM].into_boxed_slice() }
     }
 }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -166,6 +166,14 @@ impl<'a> ThreadData<'a> {
             format!("mate {}", if score.is_positive() { mate } else { -mate })
         };
 
+        let score = if root_move.upperbound {
+            format!("{score} upperbound")
+        } else if root_move.lowerbound {
+            format!("{score} lowerbound")
+        } else {
+            score
+        };
+
         print!(
             "info depth {depth} seldepth {} score {score} nodes {} time {ms} nps {nps:.0} hashfull {} tbhits {} pv",
             self.sel_depth,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -125,8 +125,8 @@ fn go(
         listener
     });
 
-    let min_score = threads.iter().map(|v| v.best_score).min().unwrap();
-    let vote_value = |td: &ThreadData| (td.best_score - min_score + 10) * td.completed_depth;
+    let min_score = threads.iter().map(|v| v.root_moves[0].score).min().unwrap();
+    let vote_value = |td: &ThreadData| (td.root_moves[0].score - min_score + 10) * td.completed_depth;
 
     let mut votes = vec![0; 4096];
     for result in threads.iter() {
@@ -140,18 +140,18 @@ fn go(
             let best = &threads[best];
             let current = &threads[current];
 
-            if is_decisive(best.best_score) {
-                return current.best_score > best.best_score;
+            if is_decisive(best.root_moves[0].score) {
+                return current.root_moves[0].score > best.root_moves[0].score;
             }
 
-            if is_win(current.best_score) {
+            if is_win(current.root_moves[0].score) {
                 return true;
             }
 
             let best_vote = votes[best.pv.best_move().encoded()];
             let current_vote = votes[current.pv.best_move().encoded()];
 
-            !is_loss(current.best_score)
+            !is_loss(current.root_moves[0].score)
                 && (current_vote > best_vote || (current_vote == best_vote && vote_value(current) > vote_value(best)))
         };
 


### PR DESCRIPTION
* Add UCI score bound indicators (`upperbound`/`lowerbound`)
* Track and report `sel_depth` per root move
* Fix `sel_depth` calculation according to UCI specs (prevent overcounting)

Elo   | 0.11 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 67812 W: 17273 L: 17252 D: 33287
Penta | [135, 7202, 19229, 7187, 153]
https://recklesschess.space/test/7250/

Bench: 2696137
