### PR TITLE
Adjust returned fail high scores in main search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -889,6 +889,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
     }
 
+    if best_score >= beta && !is_decisive(best_score) && !is_decisive(beta) {
+        best_score = (best_score * depth + beta) / (depth + 1);
+    }
+
     if NODE::PV {
         best_score = best_score.min(max_score);
     }


### PR DESCRIPTION
Elo   | 2.41 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36750 W: 9451 L: 9196 D: 18103
Penta | [83, 4352, 9275, 4557, 108]
https://recklesschess.space/test/7335/

Bench: 2147448