### PR TITLE
Increase reduction for cut nodes without a TT move

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -686,6 +686,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             if cut_node {
                 reduction += 1247;
+                reduction += 927 * tt_move.is_null() as i32;
             }
 
             if td.board.in_check() || !td.board.has_non_pawns() {


### PR DESCRIPTION
Elo   | 2.24 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40402 W: 10508 L: 10247 D: 19647
Penta | [100, 4731, 10297, 4954, 119]
https://recklesschess.space/test/7336/

Bench: 2344668