### PR TITLE
Use unadjusted depth in razoring pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -411,7 +411,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     let improving = improvement > 0;
 
     // Razoring
-    if !NODE::PV && !in_check && eval < alpha - 305 - 239 * depth * depth {
+    if !NODE::PV && !in_check && eval < alpha - 305 - 239 * initial_depth * initial_depth {
         return qsearch::<NonPV>(td, alpha, beta);
     }
 


### PR DESCRIPTION
Elo   | 3.30 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23678 W: 6097 L: 5872 D: 11709
Penta | [45, 2769, 6014, 2938, 73]
https://recklesschess.space/test/7357/

Bench: 2418487