### PR TITLE
Allow triple extensions for noisy TT moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -636,9 +636,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 if score < singular_beta {
                     extension = 1;
                     extension += (score < singular_beta - 2 - 277 * NODE::PV as i32) as i32;
-                    extension += (is_quiet
-                        && score < singular_beta - 67 - 315 * NODE::PV as i32 + 16 * correction_value.abs() / 128)
-                        as i32;
+                    extension +=
+                        (score < singular_beta - 67 - 315 * NODE::PV as i32 + 16 * correction_value.abs() / 128) as i32;
 
                     if extension > 1 && depth < 14 {
                         depth += 1;


### PR DESCRIPTION
Elo   | 0.68 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.53 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 21824 W: 5355 L: 5312 D: 11157
Penta | [7, 2527, 5800, 2572, 6]
https://recklesschess.space/test/7356/

Bench: 2517276