### PR TITLE
Use unadjusted depth in late move pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -571,7 +571,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             let lmr_depth = (depth - lmr_reduction / 1024).max(0);
 
             // Late Move Pruning (LMP)
-            skip_quiets |= move_count >= (4 + depth * depth) / (2 - (improving || static_eval >= beta + 17) as i32);
+            skip_quiets |= move_count
+                >= (4 + initial_depth * initial_depth) / (2 - (improving || static_eval >= beta + 17) as i32);
 
             // Futility Pruning (FP)
             let futility_value = static_eval + 107 * lmr_depth + 75 + 32 * history / 1024;


### PR DESCRIPTION
Elo   | 5.54 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12428 W: 3260 L: 3062 D: 6106
Penta | [24, 1397, 3188, 1567, 38]
https://recklesschess.space/test/7382/

Bench: 2851212