### PR TITLE
Official release version of Reckless v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "reckless"
-version = "0.8.0-dev"
+version = "0.8.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reckless"
-version = "0.8.0-dev"
+version = "0.8.0"
 edition = "2021"
 build = "build/build.rs"
 publish = false

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -55,7 +55,7 @@ pub fn message_loop() {
 }
 
 fn uci() {
-    println!("id name Reckless {}", env!("ENGINE_VERSION"));
+    println!("id name Reckless {}", env!("CARGO_PKG_VERSION"));
     println!("id author Arseniy Surkov, Shahin M. Shahin, and Styx");
     println!("option name Hash type spin default {DEFAULT_TT_SIZE} min 1 max 262144");
     println!("option name Threads type spin default 1 min 1 max 512");


### PR DESCRIPTION
Reckless has come a long way since its early days as a solo project.

During the [FIDE & Google Efficient Chess AI Challenge][kaggle], I worked with Shahin (@peregrineshahin) on the team that finished in second place. After the competition in late February 2025, the whole search algorithm started being rebuilt from the ground up. Shortly after, @peregrineshahin joined the project as one of its co-authors, with Styx (@styxdoto) joining a bit later.

Together, we have transformed Reckless into a formidable chess engine, moving far and beyond the capabilities of its predecessor.

We are now releasing Reckless v0.8.0, one of the strongest chess engines in the world and the strongest chess engine written in Rust.

## Playing Strength

Reckless v0.8.0 is enormously stronger than the previous release. In practical terms, v0.7.0 is no longer a meaningful opponent of measuring progress. Nevertheless, using a balanced opening book `8moves_v3`, the results of the progression are as follows:

STC 8.0+0.08s
```
Elo   | 334.77 +- 6.38 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 10116 W: 7583 L: 38 D: 2495
Penta | [0, 4, 216, 2127, 2711]
https://recklesschess.space/test/7421/
```

LTC 40.0+0.40s
```
Elo   | 301.49 +- 8.15 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 5004 W: 3506 L: 2 D: 1496
Penta | [0, 0, 150, 1200, 1152]
https://recklesschess.space/test/7422/
```

## Update highlights

### Syzygy Tablebase Support

We have added support for Syzygy endgame tablebases with up to 7 pieces, thanks to the [Fathom][fathom] library.

### Chess960 Support

Reckless can now play Chess960 (Fischer Random Chess), with full support for castling rules and position setup. It also handles assymmetrical starting positions, commonly referred to as Double Fischer Random Chess (DFRC).

### NNUE Improvements

The originally used custom network trainer has been replaced with [Bullet], a specialized ML library developed by @jw1912. Over 30 iterations of stronger networks have been merged, leading to a multi-layer NNUE model trained on billions of positions.

## Looking Ahead

Since the last release, we have made over 500 commits, and the project remains very much active. We are looking forward to making Reckless better, adding new features, and more!

[kaggle]: https://www.kaggle.com/competitions/fide-google-efficiency-chess-ai-challenge
[fathom]: https://github.com/jdart1/Fathom
[bullet]: https://github.com/jw1912/bullet

Bench: 2020975