### PR TITLE
Simplify FDS R condition

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -780,10 +780,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 45 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 132;
             }
 
-            if tt_move.is_null() {
-                reduction += 832;
-            }
-
             td.stack[td.ply - 1].reduction = 1024 * ((initial_depth - 1) - new_depth);
             score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth - (reduction > 3000) as i32, !cut_node);
             td.stack[td.ply - 1].reduction = 0;


### PR DESCRIPTION
Elo   | 4.16 +- 4.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 6520 W: 1630 L: 1552 D: 3338
Penta | [3, 723, 1728, 805, 1]
https://recklesschess.space/test/7425/

Bench: 2052487