### PR TITLE
Skip late move pruning in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -571,8 +571,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             let lmr_depth = (depth - lmr_reduction / 1024).max(0);
 
             // Late Move Pruning (LMP)
-            skip_quiets |= move_count
-                >= (4 + initial_depth * initial_depth) / (2 - (improving || static_eval >= beta + 17) as i32);
+            skip_quiets |= !in_check
+                && move_count
+                    >= (4 + initial_depth * initial_depth) / (2 - (improving || static_eval >= beta + 17) as i32);
 
             // Futility Pruning (FP)
             let futility_value = static_eval + 107 * lmr_depth + 75 + 32 * history / 1024;


### PR DESCRIPTION
Elo   | 1.19 +- 0.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 138522 W: 35494 L: 35021 D: 68007
Penta | [331, 16157, 35836, 16582, 355]
https://recklesschess.space/test/7394/

Bench: 2134701