### PR TITLE
Less FDS reduction for TT moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -770,15 +770,15 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 1086;
             }
 
-            if mv == tt_move {
-                reduction = -1887;
-            }
-
             if is_quiet {
                 reduction -= 143 * (history - 556) / 1024;
             } else {
                 reduction -= 67 * (history - 551) / 1024;
                 reduction -= 45 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 132;
+            }
+
+            if mv == tt_move {
+                reduction -= 3072;
             }
 
             td.stack[td.ply - 1].reduction = 1024 * ((initial_depth - 1) - new_depth);


### PR DESCRIPTION
Elo   | 1.33 +- 1.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 102156 W: 26281 L: 25890 D: 49985
Penta | [247, 11706, 26757, 12145, 223]
https://recklesschess.space/test/7445/

Bench: 1978902