### PR TITLE
Only do probcut on cutnodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -488,7 +488,12 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     // ProbCut
     let probcut_beta = beta + 265 - 60 * improving as i32;
 
-    if depth >= 3 && !is_decisive(beta) && (!is_valid(tt_score) || tt_score >= probcut_beta) && !tt_move.is_quiet() {
+    if cut_node
+        && depth >= 3
+        && !is_decisive(beta)
+        && (!is_valid(tt_score) || tt_score >= probcut_beta)
+        && !tt_move.is_quiet()
+    {
         let mut move_picker = MovePicker::new_probcut(probcut_beta - static_eval);
 
         let probcut_depth = (depth - 4).max(0);


### PR DESCRIPTION
was Hit #0: Total 48990, Hits 46763, Hit Rate (%) 95.45 of the cutoffs

Elo   | 1.52 +- 1.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 78438 W: 20012 L: 19669 D: 38757
Penta | [172, 9179, 20204, 9462, 202]
https://recklesschess.space/test/7456/

Bench: 2102494