### PR TITLE
Simplify bad noisy futility pruning margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -598,9 +598,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             // Bad Noisy Futility Pruning (BNFP)
             let noisy_futility_value = static_eval
                 + 118 * lmr_depth
-                + 360 * move_count / 128
                 + 80 * (history + 507) / 1024
-                + 91 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 1024;
+                + 91 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 1024
+                + 28;
 
             if !in_check && lmr_depth < 6 && move_picker.stage() == Stage::BadNoisy && noisy_futility_value <= alpha {
                 if !is_decisive(best_score) && best_score <= noisy_futility_value {


### PR DESCRIPTION
Elo   | 0.51 +- 1.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 46700 W: 11910 L: 11842 D: 22948
Penta | [110, 5586, 11899, 5636, 119]
https://recklesschess.space/test/7498/

Bench: 2145120