### PR TITLE
Simplify SEE threshold

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -611,7 +611,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                -22 * lmr_depth * lmr_depth - 44 * (history + 19) / 1024
+                -22 * lmr_depth * lmr_depth + 17
             } else {
                 -104 * depth + 46 - 45 * (history + 13) / 1024
             };


### PR DESCRIPTION
Elo   | 6.50 +- 3.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 8290 W: 2182 L: 2027 D: 4081
Penta | [21, 919, 2112, 1070, 23]
https://recklesschess.space/test/7510/

Elo   | 0.22 +- 1.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 35682 W: 8704 L: 8681 D: 18297
Penta | [10, 4136, 9537, 4137, 21]
https://recklesschess.space/test/7511/