### PR TITLE
Simplify post-LMR bonus formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -727,8 +727,8 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node);
 
                     if mv.is_quiet() && score >= beta {
-                        let bonus = (1 + 2 * (move_count > depth) as i32 + 2 * (move_count > 2 * depth) as i32)
-                            * (159 * depth - 62).min(866);
+                        let bonus = (1 + (move_count / depth)) * (159 * depth - 62).min(866);
+
                         td.ply -= 1;
                         update_continuation_histories(td, td.stack[td.ply].piece, mv.to(), bonus);
                         td.ply += 1;


### PR DESCRIPTION
Elo   | 0.62 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 43748 W: 11014 L: 10936 D: 21798
Penta | [81, 5229, 11200, 5259, 105]
https://recklesschess.space/test/7532/

Bench: 2142741