### PR TITLE
Remove obsolete optimization

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -454,11 +454,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         td.board.make_null_move();
 
-        let score = if (depth - r) <= 0 {
-            -qsearch::<NonPV>(td, -beta, -beta + 1)
-        } else {
-            -search::<NonPV>(td, -beta, -beta + 1, depth - r, false)
-        };
+        let score = -search::<NonPV>(td, -beta, -beta + 1, depth - r, false);
 
         td.board.undo_null_move();
         td.ply -= 1;


### PR DESCRIPTION
Elo   | 0.78 +- 1.76 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 38352 W: 9969 L: 9883 D: 18500
Penta | [158, 4204, 10372, 4278, 164]
https://recklesschess.space/test/7580/

Bench: 2030695