### PR TITLE
More staticeval history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -374,7 +374,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && is_valid(td.stack[td.ply - 1].static_eval)
     {
         let value = 722 * (-(static_eval + td.stack[td.ply - 1].static_eval)) / 128;
-        let bonus = value.clamp(-60, 128);
+        let bonus = value.clamp(-120, 256);
 
         td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), td.stack[td.ply - 1].mv, bonus);
     }


### PR DESCRIPTION
Elo   | 1.85 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 54466 W: 13839 L: 13549 D: 27078
Penta | [119, 6375, 13946, 6683, 110]
https://recklesschess.space/test/7571/

Bench: 2114071