### PR TITLE
Tweak futility pruning margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -578,7 +578,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                     >= (4 + initial_depth * initial_depth) / (2 - (improving || static_eval >= beta + 17) as i32);
 
             // Futility Pruning (FP)
-            let futility_value = static_eval + 107 * lmr_depth + 75 + 32 * history / 1024;
+            let futility_value =
+                static_eval + 107 * lmr_depth + 32 * history / 1024 + 90 * (static_eval >= alpha) as i32 + 75;
+
             if !in_check
                 && is_quiet
                 && lmr_depth < 8


### PR DESCRIPTION
Elo   | 1.69 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63680 W: 15951 L: 15641 D: 32088
Penta | [137, 7507, 16246, 7809, 141]
https://recklesschess.space/test/7592/

Bench: 2057295