### PR TITLE
Simplify futility pruning history offset

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -597,9 +597,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             // Bad Noisy Futility Pruning (BNFP)
             let noisy_futility_value = static_eval
                 + 118 * lmr_depth
-                + 80 * (history + 507) / 1024
+                + 80 * history / 1024
                 + 91 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 1024
-                + 28;
+                + 67;
 
             if !in_check && lmr_depth < 6 && move_picker.stage() == Stage::BadNoisy && noisy_futility_value <= alpha {
                 if !is_decisive(best_score) && best_score <= noisy_futility_value {


### PR DESCRIPTION
Elo   | 4.23 +- 3.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 12160 W: 3128 L: 2980 D: 6052
Penta | [30, 1377, 3117, 1527, 29]
https://recklesschess.space/test/7599/

Bench: 1969608