### PR TITLE
Adjust futility score based on capturing piece

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1070,7 +1070,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
             alpha = best_score;
         }
 
-        futility_base = static_eval + 100;
+        futility_base = static_eval + 80;
     }
 
     let mut best_move = Move::NULL;
@@ -1103,7 +1103,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
                 break;
             }
 
-            let futility_score = futility_base + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 8;
+            let futility_score = futility_base + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 4;
 
             if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {
                 best_score = best_score.max(futility_score);

--- a/src/search.rs
+++ b/src/search.rs
@@ -1103,7 +1103,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
                 break;
             }
 
-            let futility_score = futility_base + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 4;
+            let futility_score = futility_base + 32 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
 
             if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {
                 best_score = best_score.max(futility_score);

--- a/src/search.rs
+++ b/src/search.rs
@@ -1020,7 +1020,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
     }
 
     let mut best_score = -Score::INFINITE;
-    let mut futility_score = Score::NONE;
+    let mut futility_base = Score::NONE;
     let mut raw_eval = Score::NONE;
 
     // Evaluation
@@ -1070,7 +1070,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
             alpha = best_score;
         }
 
-        futility_score = static_eval + 129;
+        futility_base = static_eval + 100;
     }
 
     let mut best_move = Move::NULL;
@@ -1102,6 +1102,8 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
             if in_check && mv.is_quiet() {
                 break;
             }
+
+            let futility_score = futility_base + PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 8;
 
             if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {
                 best_score = best_score.max(futility_score);


### PR DESCRIPTION
Elo   | 1.30 +- 1.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 108918 W: 27566 L: 27159 D: 54193
Penta | [207, 12835, 27983, 13212, 222]
https://recklesschess.space/test/7610/

Bench: 2134870