### PR TITLE
More PV LMR extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -709,7 +709,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             let reduced_depth = (new_depth - reduction / 1024)
                 .clamp(NODE::PV as i32, new_depth + cut_node as i32 + NODE::PV as i32)
-                + NODE::PV as i32;
+                + 2 * NODE::PV as i32;
 
             td.stack[td.ply - 1].reduction = reduction;
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true);


### PR DESCRIPTION
Elo   | 3.22 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24244 W: 6243 L: 6018 D: 11983
Penta | [46, 2826, 6175, 3007, 68]
https://recklesschess.space/test/7615/

Bench: 2484073