### PR TITLE
Decouple shared history from pruning heuristics

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -609,7 +609,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                let lmr_reduction = if is_quiet { reduction - 143 * history / 1024 } else { reduction };
+                let lmr_reduction = reduction - 143 * history / 1024;
                 let lmr_depth = (depth - lmr_reduction / 1024).max(0);
                 -22 * lmr_depth * lmr_depth + 17
             } else {

--- a/src/search.rs
+++ b/src/search.rs
@@ -608,8 +608,13 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
-            let threshold =
-                if is_quiet { -22 * lmr_depth * lmr_depth + 17 } else { -104 * depth - 45 * history / 1024 + 46 };
+            let threshold = if is_quiet {
+                let lmr_reduction = if is_quiet { reduction - 143 * history / 1024 } else { reduction };
+                let lmr_depth = (depth - lmr_reduction / 1024).max(0);
+                -22 * lmr_depth * lmr_depth + 17
+            } else {
+                -104 * depth - 45 * history / 1024 + 46
+            };
 
             if !td.board.see(mv, threshold) {
                 continue;

--- a/src/search.rs
+++ b/src/search.rs
@@ -569,8 +569,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         }
 
         if !NODE::ROOT && !is_loss(best_score) {
-            let lmr_reduction = if is_quiet { reduction - 143 * history / 1024 } else { reduction };
-            let lmr_depth = (depth - lmr_reduction / 1024).max(0);
+            let lmr_depth = (depth - reduction / 1024).max(0);
 
             // Late Move Pruning (LMP)
             skip_quiets |= !in_check
@@ -579,11 +578,11 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             // Futility Pruning (FP)
             let futility_value =
-                static_eval + 107 * lmr_depth + 32 * history / 1024 + 90 * (static_eval >= alpha) as i32 + 75;
+                static_eval + 107 * lmr_depth + 48 * history / 1024 + 90 * (static_eval >= alpha) as i32 + 85;
 
             if !in_check
                 && is_quiet
-                && lmr_depth < 8
+                && lmr_depth < 9
                 && futility_value <= alpha
                 && !td.board.might_give_check_if_you_squint(mv)
             {

--- a/src/search.rs
+++ b/src/search.rs
@@ -609,9 +609,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                let lmr_reduction = reduction - 143 * history / 1024;
-                let lmr_depth = depth - lmr_reduction / 1024;
-                -22 * lmr_depth * lmr_depth + 17
+                let r = reduction - 143 * history / 1024;
+                let see_depth = depth - r / 1024;
+                -22 * see_depth * see_depth + 17
             } else {
                 -104 * depth - 45 * history / 1024 + 46
             };

--- a/src/search.rs
+++ b/src/search.rs
@@ -610,7 +610,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
                 let lmr_reduction = reduction - 143 * history / 1024;
-                let lmr_depth = (depth - lmr_reduction / 1024).max(0);
+                let lmr_depth = depth - lmr_reduction / 1024;
                 -22 * lmr_depth * lmr_depth + 17
             } else {
                 -104 * depth - 45 * history / 1024 + 46


### PR DESCRIPTION
Elo   | 0.16 +- 1.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 66072 W: 16664 L: 16633 D: 32775
Penta | [120, 7917, 16938, 7934, 127]
https://recklesschess.space/test/7633/

Elo   | 1.51 +- 2.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 12434 W: 3046 L: 2992 D: 6396
Penta | [5, 1408, 3337, 1462, 5]
https://recklesschess.space/test/7635/

Bench: 2573754