### PR TITLE
Fix better mates in matetrack

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -190,6 +190,7 @@ impl<'a> ThreadData<'a> {
     }
 }
 
+#[derive(Clone)]
 pub struct RootMove {
     pub mv: Move,
     pub score: i32,
@@ -201,6 +202,7 @@ pub struct RootMove {
     pub pv: PrincipalVariationTable,
 }
 
+#[derive(Clone)]
 pub struct PrincipalVariationTable {
     table: [[Move; MAX_PLY + 1]; MAX_PLY + 1],
     len: [usize; MAX_PLY + 1],

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -8,7 +8,7 @@ use crate::{
     time::{Limits, TimeManager},
     tools,
     transposition::{TranspositionTable, DEFAULT_TT_SIZE},
-    types::{is_decisive, is_loss, is_win, Color},
+    types::{is_decisive, is_loss, is_win, Color, Score},
 };
 
 pub fn message_loop() {
@@ -140,11 +140,18 @@ fn go(
             let best = &threads[best];
             let current = &threads[current];
 
-            if is_decisive(best.root_moves[0].score) {
+            if is_win(best.root_moves[0].score) {
                 return current.root_moves[0].score > best.root_moves[0].score;
             }
 
-            if is_win(current.root_moves[0].score) {
+            if current.root_moves[0].score != -Score::INFINITE
+                && best.root_moves[0].score != -Score::INFINITE
+                && is_loss(best.root_moves[0].score)
+            {
+                return current.root_moves[0].score < best.root_moves[0].score;
+            }
+
+            if current.root_moves[0].score != -Score::INFINITE && is_decisive(current.root_moves[0].score) {
                 return true;
             }
 


### PR DESCRIPTION
Elo   | 0.31 +- 2.06 (95%)
SPRT  | 4.0+0.04s Threads=4 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-4.50, 0.00]
Games | N: 27118 W: 6831 L: 6807 D: 13480
Penta | [36, 3214, 7039, 3230, 40]
https://recklesschess.space/test/7656/

Bench: 2573754