### PR TITLE
Simplify LMR move count condition

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -684,7 +684,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         let mut score = Score::ZERO;
 
         // Late Move Reductions (LMR)
-        if depth >= 2 && move_count > 1 + NODE::ROOT as i32 {
+        if depth >= 2 && move_count > 1 {
             if is_quiet {
                 reduction += 523;
                 reduction -= 139 * history / 1024;


### PR DESCRIPTION
Elo   | 0.01 +- 1.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 77558 W: 19552 L: 19549 D: 38457
Penta | [174, 9331, 19763, 9340, 171]
https://recklesschess.space/test/7692/

Bench: 2867862