### PR TITLE
Use common piece values for material scaling

### DIFF
--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,10 +1,9 @@
 use crate::{
     board::Board,
+    parameters::PIECE_VALUES,
     thread::ThreadData,
     types::{PieceType, Score},
 };
-
-const MATERIAL_VALUES: [i32; 6] = [129, 403, 435, 679, 1242, 0];
 
 /// Calculates the score of the current position from the perspective of the side to move.
 pub fn evaluate(td: &mut ThreadData) -> i32 {
@@ -22,6 +21,6 @@ pub fn evaluate(td: &mut ThreadData) -> i32 {
 fn material(board: &Board) -> i32 {
     [PieceType::Pawn, PieceType::Knight, PieceType::Bishop, PieceType::Rook, PieceType::Queen]
         .iter()
-        .map(|&pt| board.pieces(pt).len() as i32 * MATERIAL_VALUES[pt])
+        .map(|&pt| board.pieces(pt).len() as i32 * PIECE_VALUES[pt])
         .sum::<i32>()
 }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,4 +1,4 @@
-pub const PIECE_VALUES: [i32; 7] = [100, 375, 400, 625, 1200, 0, 0];
+pub const PIECE_VALUES: [i32; 7] = [109, 403, 435, 679, 1242, 0, 0];
 
 #[allow(unused_macros)]
 #[cfg(not(feature = "spsa"))]


### PR DESCRIPTION
Elo   | 1.12 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 31970 W: 8072 L: 7969 D: 15929
Penta | [71, 3809, 8123, 3910, 72]
https://recklesschess.space/test/7695/

Bench: 2752553