### PR TITLE
Introduce four plies improvement

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -425,8 +425,16 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
 
     let mut improvement = 0;
-    if !in_check && td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() && is_valid(td.stack[td.ply - 2].static_eval) {
+
+    if td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() && is_valid(td.stack[td.ply - 2].static_eval) && !in_check {
         improvement = static_eval - td.stack[td.ply - 2].static_eval;
+    } else if td.ply >= 4
+        && td.stack[td.ply - 1].mv.is_some()
+        && td.stack[td.ply - 3].mv.is_some()
+        && is_valid(td.stack[td.ply - 4].static_eval)
+        && !in_check
+    {
+        improvement = static_eval - td.stack[td.ply - 4].static_eval;
     }
 
     let improving = improvement > 0;


### PR DESCRIPTION
 with no null moves in between

Elo   | 2.26 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39536 W: 10145 L: 9888 D: 19503
Penta | [71, 4685, 10003, 4934, 75]
https://recklesschess.space/test/7817/

Bench: 2580766