### PR TITLE
Prevent LMR from diving into quiescence search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -740,8 +740,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 1397;
             }
 
-            let reduced_depth = (new_depth - reduction / 1024)
-                .clamp(NODE::PV as i32, new_depth + cut_node as i32 + NODE::PV as i32)
+            let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + cut_node as i32 + NODE::PV as i32)
                 + 2 * NODE::PV as i32;
 
             td.stack[td.ply - 1].reduction = reduction;


### PR DESCRIPTION
Elo   | 2.61 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 18516 W: 4781 L: 4642 D: 9093
Penta | [27, 2176, 4738, 2265, 52]
https://recklesschess.space/test/7829/

Bench: 2718015