### PR TITLE
Simplify improvement heuristic guards

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -408,14 +408,9 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
     let mut improvement = 0;
 
-    if td.ply >= 2 && td.stack[td.ply - 1].mv.is_some() && is_valid(td.stack[td.ply - 2].static_eval) && !in_check {
+    if td.ply >= 2 && is_valid(td.stack[td.ply - 2].static_eval) && !in_check {
         improvement = static_eval - td.stack[td.ply - 2].static_eval;
-    } else if td.ply >= 4
-        && td.stack[td.ply - 1].mv.is_some()
-        && td.stack[td.ply - 3].mv.is_some()
-        && is_valid(td.stack[td.ply - 4].static_eval)
-        && !in_check
-    {
+    } else if td.ply >= 4 && is_valid(td.stack[td.ply - 4].static_eval) && !in_check {
         improvement = static_eval - td.stack[td.ply - 4].static_eval;
     }
 


### PR DESCRIPTION
Elo   | 0.41 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 48122 W: 12235 L: 12178 D: 23709
Penta | [90, 5755, 12325, 5790, 101]
https://recklesschess.space/test/7856/

Bench: 2884024