### PR TITLE
Update default network to v43-b83cf478.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v42-2f1273a6.nnue";
+const NETWORK_NAME: &str = "v43-b83cf478.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
DFRC STC
Elo   | 14.03 +- 5.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4708 W: 997 L: 807 D: 2904
Penta | [26, 440, 1257, 580, 51]
https://recklesschess.space/test/7885/

DFRC Fixed nodes
Elo   | 14.37 +- 2.64 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40210 W: 14135 L: 12473 D: 13602
Penta | [1698, 4073, 7408, 4721, 2205]
https://recklesschess.space/test/7888/

Standard Fixed nodes
Elo   | -0.62 +- 2.32 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40040 W: 12857 L: 12929 D: 14254
Penta | [1231, 4507, 8560, 4547, 1175]
https://recklesschess.space/test/7886/

Bench: 2690159