### PR TITLE
Simplify LMR extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -717,8 +717,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
                 reduction -= 1397;
             }
 
-            let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + cut_node as i32 + NODE::PV as i32)
-                + 2 * NODE::PV as i32;
+            let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + 1) + 2 * NODE::PV as i32;
 
             td.stack[td.ply - 1].reduction = reduction;
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true);


### PR DESCRIPTION
Elo   | 1.22 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 30254 W: 7755 L: 7649 D: 14850
Penta | [66, 3603, 7682, 3711, 65]
https://recklesschess.space/test/7874/

Bench: 3205672