### PR TITLE
Tighten nodes time management adjustment bounds

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -169,8 +169,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
             let eval_stability = 1.2 - 0.04 * eval_stability.min(8) as f32;
 
-            let score_trend =
-                (800 + 20 * (td.previous_best_score - td.root_moves[0].score)).clamp(750, 1500) as f32 / 1000.0;
+            let score_trend = (0.8 + 0.05 * (td.previous_best_score - td.root_moves[0].score) as f32).clamp(0.80, 1.45);
 
             nodes_factor * pv_stability * eval_stability * score_trend
         };


### PR DESCRIPTION
Elo   | 3.24 +- 2.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23262 W: 5915 L: 5698 D: 11649
Penta | [47, 2504, 6320, 2705, 55]
https://recklesschess.space/test/7877/

Bench: 3205672