### PR TITLE
Prevent TT moves from being reduced to quiescence search at PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -798,6 +798,10 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
 
         // Principal Variation Search (PVS)
         if NODE::PV && (move_count == 1 || score > alpha) {
+            if mv == tt_move && tt_depth > 1 && td.root_depth > 8 {
+                new_depth = new_depth.max(1);
+            }
+
             score = -search::<PV>(td, -beta, -alpha, new_depth, false);
         }
 


### PR DESCRIPTION
Elo   | 2.40 +- 1.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33542 W: 8312 L: 8080 D: 17150
Penta | [12, 3748, 9017, 3984, 10]
https://recklesschess.space/test/7893/

Bench: 3159041