### PR TITLE
Introduce secondary RFP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -437,6 +437,18 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         return (eval + beta) / 2;
     }
 
+    if !tt_pv
+        && !in_check
+        && !excluded
+        && depth < 9
+        && eval >= beta
+        && static_eval >= beta + 75 * depth - (85 * improving as i32) + 580 * correction_value.abs() / 1024
+        && !is_loss(beta)
+        && !is_win(eval)
+    {
+        return beta + (static_eval - beta) / 3;
+    }
+
     // Null Move Pruning (NMP)
     if cut_node
         && !in_check


### PR DESCRIPTION
STC
Elo   | 4.41 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16154 W: 4226 L: 4021 D: 7907
Penta | [28, 1847, 4132, 2032, 38]
https://recklesschess.space/test/7873/

LTC
Elo   | 1.98 +- 1.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 45346 W: 11292 L: 11034 D: 23020
Penta | [8, 5148, 12107, 5398, 12]
https://recklesschess.space/test/7882/

Bench: 3275252