### PR TITLE
Introduce secondary TT aging

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -195,6 +195,9 @@ impl TranspositionTable {
             || depth + 4 + 2 * pv as i32 > entry.depth as i32
             || entry.flags.age() != tt_age)
         {
+            if entry.depth >= 5 && entry.flags.bound() != Bound::Exact {
+                entry.depth -= 1;
+            }
             return;
         }
 


### PR DESCRIPTION
Credits to @xu-shawn for the idea.

Elo   | 1.80 +- 1.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 57374 W: 14590 L: 14292 D: 28492
Penta | [118, 6747, 14666, 7031, 125]
https://recklesschess.space/test/7876/

Bench: 3127214