### PR TITLE
Swap order of RFPs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -420,6 +420,19 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         return qsearch::<NonPV>(td, alpha, beta);
     }
 
+    // Static Evaluation Reverse Futility Pruning (SERFP)
+    if !tt_pv
+        && !in_check
+        && !excluded
+        && depth < 9
+        && eval >= beta
+        && static_eval >= beta + 75 * depth - (85 * improving as i32) + 580 * correction_value.abs() / 1024
+        && !is_loss(beta)
+        && !is_win(eval)
+    {
+        return beta + (static_eval - beta) / 3;
+    }
+
     // Reverse Futility Pruning (RFP)
     if !tt_pv
         && !in_check
@@ -434,18 +447,6 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
         && tt_bound != Bound::Upper
     {
         return (eval + beta) / 2;
-    }
-
-    if !tt_pv
-        && !in_check
-        && !excluded
-        && depth < 9
-        && eval >= beta
-        && static_eval >= beta + 75 * depth - (85 * improving as i32) + 580 * correction_value.abs() / 1024
-        && !is_loss(beta)
-        && !is_win(eval)
-    {
-        return beta + (static_eval - beta) / 3;
     }
 
     // Null Move Pruning (NMP)


### PR DESCRIPTION
Elo   | 1.29 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 115692 W: 29379 L: 28950 D: 57363
Penta | [295, 13783, 29272, 14190, 306]
https://recklesschess.space/test/7898/

Bench: 3350433