### PR TITLE
Update default network to v44-1eb6e185.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v43-b83cf478.nnue";
+const NETWORK_NAME: &str = "v44-1eb6e185.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 5.31 +- 2.31 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40014 W: 13089 L: 12478 D: 14447
Penta | [1078, 4429, 8540, 4724, 1236]
https://recklesschess.space/test/7922/

STC
Elo   | 2.45 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36928 W: 9609 L: 9349 D: 17970
Penta | [133, 4350, 9232, 4622, 127]
https://recklesschess.space/test/7924/

LTC
Elo   | 2.20 +- 1.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39514 W: 10009 L: 9759 D: 19746
Penta | [25, 4534, 10386, 4790, 22]
https://recklesschess.space/test/7925/

Bench: 2838854