### PR TITLE
Simplify node/root delta handling in LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -705,7 +705,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             if NODE::PV {
-                reduction -= 393 + 552 * (beta - alpha > 30 * td.root_delta / 128) as i32;
+                reduction -= 393 + 552 * (beta - alpha) / td.root_delta;
             }
 
             if !tt_pv && cut_node {
@@ -775,7 +775,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
             }
 
             if NODE::PV {
-                reduction -= 491 + 780 * (beta - alpha > 25 * td.root_delta / 128) as i32;
+                reduction -= 491 + 780 * (beta - alpha) / td.root_delta;
             }
 
             if !tt_pv && cut_node {


### PR DESCRIPTION
Elo   | 1.04 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 32800 W: 8261 L: 8163 D: 16376
Penta | [85, 3802, 8523, 3910, 80]
https://recklesschess.space/test/7991/

Bench: 2746240