### PR TITLE
Simplify static evaluation from quiescence search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1055,15 +1055,13 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
             Some(entry) if is_valid(entry.eval) => entry.eval,
             _ => evaluate(td),
         };
-
-        let static_eval = corrected_eval(raw_eval, correction_value(td), td.board.halfmove_clock());
-        best_score = static_eval;
+        best_score = corrected_eval(raw_eval, correction_value(td), td.board.halfmove_clock());
 
         if is_valid(tt_score)
             && (!NODE::PV || !is_decisive(tt_score))
             && match tt_bound {
-                Bound::Upper => tt_score < static_eval,
-                Bound::Lower => tt_score > static_eval,
+                Bound::Upper => tt_score < best_score,
+                Bound::Lower => tt_score > best_score,
                 _ => true,
             }
         {
@@ -1096,7 +1094,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32) -> i3
             alpha = best_score;
         }
 
-        futility_base = static_eval + 79;
+        futility_base = best_score + 79;
     }
 
     let mut best_move = Move::NULL;


### PR DESCRIPTION
Elo   | 0.03 +- 1.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 76288 W: 19175 L: 19169 D: 37944
Penta | [159, 9060, 19701, 9064, 160]
https://recklesschess.space/test/7995/

Bench: 3099748
