### PR TITLE
Update default network to v45-997688b4.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v44-1eb6e185.nnue";
+const NETWORK_NAME: &str = "v45-997688b4.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
FRC
Elo   | 7.45 +- 3.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7886 W: 1112 L: 943 D: 5831
Penta | [26, 610, 2515, 753, 39]
https://recklesschess.space/test/8004/

DFRC
Elo   | 3.97 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20490 W: 5239 L: 5005 D: 10246
Penta | [134, 2409, 4962, 2569, 171]
https://recklesschess.space/test/8002/

Standard fixed nodes
Elo   | 1.38 +- 2.29 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40184 W: 12791 L: 12631 D: 14762
Penta | [1129, 4559, 8555, 4721, 1128]
https://recklesschess.space/test/8000/

Standard non-regression
Elo   | -0.02 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 81426 W: 20927 L: 20932 D: 39567
Penta | [306, 9882, 20360, 9841, 324]
https://recklesschess.space/test/8001/

Bench: 2601134