### PR TITLE
Prevent useless probcut at decisive score

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -516,7 +516,7 @@ fn search<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, mut beta: i32, de
     if cut_node
         && depth >= 3
         && !is_decisive(beta)
-        && (!is_valid(tt_score) || tt_score >= probcut_beta)
+        && (!is_valid(tt_score) || tt_score >= probcut_beta && !is_decisive(tt_score))
         && !tt_move.is_quiet()
     {
         let mut move_picker = MovePicker::new_probcut(probcut_beta - static_eval);


### PR DESCRIPTION
if we aren't going to accept probcut if decisive it then makes sense to prevent it in the first place reducing explosions

Elo   | 1.78 +- 2.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 23484 W: 5935 L: 5815 D: 11734
Penta | [67, 2659, 6160, 2799, 57]
https://recklesschess.space/test/8108/

Bench: 3117598