### PR TITLE
Revert "Introduce secondary TT aging (#514)"

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -201,9 +201,6 @@ impl TranspositionTable {
             || depth + 4 + 2 * pv as i32 > entry.depth as i32
             || entry.flags.age() != tt_age)
         {
-            if entry.depth >= 5 && entry.flags.bound() != Bound::Exact {
-                entry.depth -= 1;
-            }
             return;
         }
 


### PR DESCRIPTION
This reverts commit 4e1c372be22e95c7702c2fa2f58f9054ff8a58d1.

Elo   | 3.94 +- 2.91 (95%)
SPRT  | 40.0+0.40s Threads=8 Hash=512MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11920 W: 2962 L: 2827 D: 6131
Penta | [1, 1227, 3369, 1362, 1]
https://recklesschess.space/test/8122/

Bench: 2940440