### PR TITLE
Rank root moves with tablesbases

### DIFF
--- a/deps/Fathom/tbconfig.h
+++ b/deps/Fathom/tbconfig.h
@@ -91,7 +91,7 @@
 #define TB_VALUE_MATE 32000
 #define TB_VALUE_INFINITE 32767 /* value above all normal score values */
 #define TB_VALUE_DRAW 0
-#define TB_MAX_MATE_PLY 255
+#define TB_MAX_MATE_PLY 128 /* IMPORTANT: must reflect engine's MAX_PLY */
 
 /***************************************************************************/
 /* ENGINE INTEGRATION CONFIG                                               */

--- a/deps/Fathom/tbprobe.h
+++ b/deps/Fathom/tbprobe.h
@@ -89,7 +89,7 @@ extern unsigned tb_probe_root_impl(
 
 #define TB_MAX_MOVES                (192+1)
 #define TB_MAX_CAPTURES             64
-#define TB_MAX_PLY                  256
+#define TB_MAX_PLY                  128     /* IMPORTANT: must reflect engine's MAX_PLY */
 #define TB_CASTLING_K               0x1     /* White king-side. */
 #define TB_CASTLING_Q               0x2     /* White queen-side. */
 #define TB_CASTLING_k               0x4     /* Black king-side. */

--- a/src/tb.rs
+++ b/src/tb.rs
@@ -1,9 +1,13 @@
-use std::ffi::CString;
+use std::{ffi, mem, ptr};
 
 use crate::{
-    bindings::{tb_init, tb_probe_wdl, TB_DRAW, TB_LARGEST, TB_LOSS, TB_WIN},
+    bindings::{
+        tb_init, tb_probe_root_dtz, tb_probe_root_wdl, tb_probe_wdl, TbMove, TbRootMove, TbRootMoves, TB_DRAW,
+        TB_LARGEST, TB_LOSS, TB_MAX_MOVES, TB_WIN,
+    },
     board::Board,
-    types::{Color, PieceType},
+    thread::{RootMove, ThreadData},
+    types::{Color, PieceType, Score, MAX_PLY},
 };
 
 #[derive(Eq, PartialEq)]
@@ -16,7 +20,7 @@ pub enum GameOutcome {
 static mut TB_SIZE: usize = 0;
 
 pub fn tb_initilize(path: &str) -> Option<usize> {
-    let cpath = CString::new(path).ok()?;
+    let cpath = ffi::CString::new(path).ok()?;
 
     unsafe {
         tb_init(cpath.as_ptr());
@@ -56,5 +60,95 @@ pub fn tb_probe(board: &Board) -> Option<GameOutcome> {
         TB_LOSS => Some(GameOutcome::Loss),
         TB_DRAW => Some(GameOutcome::Draw),
         _ => None,
+    }
+}
+
+pub fn tb_rank_rootmoves(td: &mut ThreadData) {
+    let mut rootmoves_in_c: mem::MaybeUninit<TbRootMoves> = mem::MaybeUninit::uninit();
+
+    unsafe {
+        let tb_ptr = rootmoves_in_c.as_mut_ptr();
+
+        (*tb_ptr).size = td.root_moves.len().min(TB_MAX_MOVES as usize) as u32;
+
+        for (i, root_move) in td.root_moves.iter().enumerate() {
+            if i >= TB_MAX_MOVES as usize {
+                break;
+            }
+
+            let c_move_ptr = (*tb_ptr).moves.as_mut_ptr().add(i);
+            ptr::write(
+                c_move_ptr,
+                TbRootMove {
+                    move_: root_move.mv.encoded() as TbMove,
+                    pv: [0; MAX_PLY],
+                    pvSize: 0,
+                    tbScore: 0,
+                    tbRank: 0,
+                },
+            );
+        }
+
+        // Helper to copy back from C struct and sort
+        let update_rootmoves = |root_moves: &mut Vec<RootMove>, c_rootmoves: &TbRootMoves| {
+            for (i, rm) in root_moves.iter_mut().take(c_rootmoves.size as usize).enumerate() {
+                rm.tb_rank = c_rootmoves.moves[i].tbRank;
+                rm.tb_score = c_rootmoves.moves[i].tbScore;
+            }
+            root_moves.sort_by(|a, b| b.tb_rank.cmp(&a.tb_rank));
+        };
+
+        let dtz_success = tb_probe_root_dtz(
+            td.board.colors(Color::White).0,
+            td.board.colors(Color::Black).0,
+            td.board.pieces(PieceType::King).0,
+            td.board.pieces(PieceType::Queen).0,
+            td.board.pieces(PieceType::Rook).0,
+            td.board.pieces(PieceType::Bishop).0,
+            td.board.pieces(PieceType::Knight).0,
+            td.board.pieces(PieceType::Pawn).0,
+            td.board.halfmove_clock() as u32,
+            0,
+            td.board.en_passant() as u32 & 0x3F,
+            td.board.side_to_move() == Color::White,
+            false,
+            true,
+            tb_ptr,
+        );
+
+        if dtz_success != 0 {
+            let c_rootmoves: &TbRootMoves = &*tb_ptr;
+            update_rootmoves(&mut td.root_moves, c_rootmoves);
+            td.root_in_tb = true;
+            td.stop_probing_tb = true;
+            return;
+        }
+
+        // fallback to wdl
+        let wdl_success = tb_probe_root_wdl(
+            td.board.colors(Color::White).0,
+            td.board.colors(Color::Black).0,
+            td.board.pieces(PieceType::King).0,
+            td.board.pieces(PieceType::Queen).0,
+            td.board.pieces(PieceType::Rook).0,
+            td.board.pieces(PieceType::Bishop).0,
+            td.board.pieces(PieceType::Knight).0,
+            td.board.pieces(PieceType::Pawn).0,
+            td.board.halfmove_clock() as u32,
+            0,
+            td.board.en_passant() as u32 & 0x3F,
+            td.board.side_to_move() == Color::White,
+            true,
+            tb_ptr,
+        );
+
+        if wdl_success != 0 {
+            let c_rootmoves: &TbRootMoves = &*tb_ptr;
+            update_rootmoves(&mut td.root_moves, c_rootmoves);
+            td.root_in_tb = true;
+
+            // Keep probing in search if DTZ is not available and we are winning
+            td.stop_probing_tb = td.root_moves[0].score < Score::DRAW;
+        }
     }
 }


### PR DESCRIPTION
fixes #318

Test with TBs on, no adjudication

Elo   | 0.32 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 54138 W: 13686 L: 13636 D: 26816
Penta | [118, 5900, 14994, 5928, 129]
https://recklesschess.space/test/8150/

Bench: 2940440