### PR TITLE
Adjust aspiration window alpha after fail high

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -113,6 +113,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
                     reduction = 0;
                 }
                 s if s >= beta => {
+                    alpha = (beta - delta).max(alpha);
                     beta = (score + delta).min(Score::INFINITE);
                     reduction += 1;
                 }


### PR DESCRIPTION
Elo   | 2.48 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36306 W: 9273 L: 9014 D: 18019
Penta | [77, 4280, 9194, 4511, 91]
https://recklesschess.space/test/8151/

Bench: 3317947