### PR TITLE
Use asymmetric delta increase in aspiration window

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -118,13 +118,13 @@ pub fn start(td: &mut ThreadData, report: Report) {
                     beta = (alpha + beta) / 2;
                     alpha = (score - delta).max(-Score::INFINITE);
                     reduction = 0;
-                    delta += delta * (50 + 20 * reduction) / 128;
+                    delta += delta * (30 + 20 * reduction) / 128;
                 }
                 s if s >= beta => {
                     alpha = (beta - delta).max(alpha);
                     beta = (score + delta).min(Score::INFINITE);
                     reduction += 1;
-                    delta += delta * (30 + 10 * reduction) / 128;
+                    delta += delta * (50 + 10 * reduction) / 128;
                 }
                 _ => {
                     average = if average == Score::NONE { score } else { (average + score) / 2 };

--- a/src/search.rs
+++ b/src/search.rs
@@ -118,7 +118,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
                     beta = (alpha + beta) / 2;
                     alpha = (score - delta).max(-Score::INFINITE);
                     reduction = 0;
-                    delta += delta * (30 + 20 * reduction) / 128;
+                    delta += delta * 30 / 128;
                 }
                 s if s >= beta => {
                     alpha = (beta - delta).max(alpha);

--- a/src/search.rs
+++ b/src/search.rs
@@ -118,11 +118,13 @@ pub fn start(td: &mut ThreadData, report: Report) {
                     beta = (alpha + beta) / 2;
                     alpha = (score - delta).max(-Score::INFINITE);
                     reduction = 0;
+                    delta += delta * (50 + 20 * reduction) / 128;
                 }
                 s if s >= beta => {
                     alpha = (beta - delta).max(alpha);
                     beta = (score + delta).min(Score::INFINITE);
                     reduction += 1;
+                    delta += delta * (30 + 10 * reduction) / 128;
                 }
                 _ => {
                     average = if average == Score::NONE { score } else { (average + score) / 2 };
@@ -133,8 +135,6 @@ pub fn start(td: &mut ThreadData, report: Report) {
             if report == Report::Full && td.nodes.global() > 10_000_000 {
                 td.print_uci_info(depth);
             }
-
-            delta += delta * (38 + 15 * reduction) / 128;
         }
 
         if !td.stopped {


### PR DESCRIPTION
Elo   | 1.44 +- 1.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 88376 W: 22460 L: 22094 D: 43822
Penta | [228, 10417, 22531, 10785, 227]
https://recklesschess.space/test/8181/

Bench: 3426606