### PR TITLE
Rescore root moves

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -1,5 +1,6 @@
 use crate::{
     parameters::PIECE_VALUES,
+    search::NodeType,
     thread::ThreadData,
     types::{ArrayVec, Move, MoveList, PieceType, MAX_MOVES},
 };
@@ -61,7 +62,7 @@ impl MovePicker {
         self.stage
     }
 
-    pub fn next(&mut self, td: &ThreadData, skip_quiets: bool, ply: usize) -> Option<Move> {
+    pub fn next<NODE: NodeType>(&mut self, td: &ThreadData, skip_quiets: bool, ply: usize) -> Option<Move> {
         if self.stage == Stage::HashMove {
             self.stage = Stage::GenerateNoisy;
 
@@ -96,6 +97,10 @@ impl MovePicker {
                     continue;
                 }
 
+                if NODE::ROOT {
+                    self.score_noisy(td);
+                }
+
                 return Some(entry.mv);
             }
 
@@ -125,6 +130,10 @@ impl MovePicker {
                     let entry = &self.list.remove(index);
                     if entry.mv == self.tt_move {
                         continue;
+                    }
+
+                    if NODE::ROOT {
+                        self.score_quiet(td, ply);
                     }
 
                     return Some(entry.mv);

--- a/src/search.rs
+++ b/src/search.rs
@@ -21,7 +21,7 @@ pub enum Report {
     Full,
 }
 
-trait NodeType {
+pub trait NodeType {
     const PV: bool;
     const ROOT: bool;
 }
@@ -532,7 +532,7 @@ fn search<NODE: NodeType>(
 
         let probcut_depth = (depth - 4).max(0);
 
-        while let Some(mv) = move_picker.next(td, true, ply) {
+        while let Some(mv) = move_picker.next::<NODE>(td, true, ply) {
             if move_picker.stage() == Stage::BadNoisy {
                 break;
             }
@@ -580,7 +580,7 @@ fn search<NODE: NodeType>(
     let mut move_picker = MovePicker::new(tt_move);
     let mut skip_quiets = false;
 
-    while let Some(mv) = move_picker.next(td, skip_quiets, ply) {
+    while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets, ply) {
         if mv == td.stack[ply].excluded || !td.board.is_legal(mv) {
             continue;
         }
@@ -1114,7 +1114,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         _ => td.stack[ply - 1].mv.to(),
     };
 
-    while let Some(mv) = move_picker.next(td, !in_check, ply) {
+    while let Some(mv) = move_picker.next::<NODE>(td, !in_check, ply) {
         if !td.board.is_legal(mv) {
             continue;
         }


### PR DESCRIPTION
Elo   | 2.71 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 30774 W: 7875 L: 7635 D: 15264
Penta | [60, 3619, 7814, 3809, 85]
https://recklesschess.space/test/8296/

Bench: 3122471