### PR TITLE
Use constant scale for hard bound time allocation

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -33,7 +33,7 @@ impl TimeManager {
             }
             Limits::Fischer(main, inc) => {
                 let soft_scale = 0.024 + 0.042 * (1.0 - (-0.045 * fullmove_number as f64).exp());
-                let hard_scale = 0.135 + 0.145 * (1.0 - (-0.043 * fullmove_number as f64).exp());
+                let hard_scale = 0.742;
 
                 let soft_bound = (soft_scale * main.saturating_sub(move_overhead) as f64 + 0.75 * inc as f64) as u64;
                 let hard_bound = (hard_scale * main.saturating_sub(move_overhead) as f64 + 0.75 * inc as f64) as u64;


### PR DESCRIPTION
Elo   | 8.19 +- 3.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7808 W: 2028 L: 1844 D: 3936
Penta | [19, 744, 2199, 918, 24]
https://recklesschess.space/test/8348/

Elo   | 5.89 +- 3.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9668 W: 2487 L: 2323 D: 4858
Penta | [2, 823, 3024, 979, 6]
https://recklesschess.space/test/8349/

Bench: 3122471
