### PR TITLE
Fix rootmoves are not filtered based on TB rank

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1119,6 +1119,14 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             continue;
         }
 
+        if NODE::ROOT && td.root_in_tb {
+            debug_assert!(td.root_moves[0].tb_rank == td.root_moves.iter().map(|rm| rm.tb_rank).max().unwrap_or(0));
+
+            if td.root_moves.iter().any(|rm| rm.mv == mv && rm.tb_rank != td.root_moves[0].tb_rank) {
+                continue;
+            }
+        }
+
         move_count += 1;
 
         if !is_loss(best_score) && mv.to() != previous_square {


### PR DESCRIPTION
Credits to @Ciekce for hinting at the mistake

Elo   | -0.00 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 28190 W: 7069 L: 7069 D: 14052
Penta | [52, 2900, 8194, 2894, 55]
https://recklesschess.space/test/8448/

Bench: 3122471