### PR TITLE
Update default network to  v46-e44f9d34.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v45-997688b4.nnue";
+const NETWORK_NAME: &str = "v46-e44f9d34.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Update Default Network to  v46-e44f9d34.nnue
STC:
Elo   | 1.43 +- 1.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 95254 W: 24763 L: 24371 D: 46120
Penta | [302, 11350, 23917, 11770, 288]
https://recklesschess.space/test/8449/

LTC:
Elo   | 3.57 +- 2.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20326 W: 5168 L: 4959 D: 10199
Penta | [14, 2284, 5364, 2481, 20]
https://recklesschess.space/test/8450/

Bench: 3338504

Co-authored-by: @codedeliveryservice 