### PR TITLE
Simplify NMP reduction formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -483,7 +483,7 @@ fn search<NODE: NodeType>(
         && !potential_singularity
         && !is_loss(beta)
     {
-        let r = 5 + depth / 3 + ((eval - beta) / 257).min(3);
+        let r = (5756 + 321 * depth) / 1024;
 
         td.stack[ply].conthist = std::ptr::null_mut();
         td.stack[ply].contcorrhist = std::ptr::null_mut();


### PR DESCRIPTION
Elo   | -0.29 +- 0.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 125774 W: 31388 L: 31492 D: 62894
Penta | [252, 15043, 32395, 14951, 246]
https://recklesschess.space/test/8407/

Bench: 3242141