### PR TITLE
Speed up finding index of highest-scored move

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -79,13 +79,7 @@ impl MovePicker {
 
         if self.stage == Stage::GoodNoisy {
             while !self.list.is_empty() {
-                let mut index = 0;
-                for i in 1..self.list.len() {
-                    if self.list[i].score > self.list[index].score {
-                        index = i;
-                    }
-                }
-
+                let index = self.find_best_score_index();
                 let entry = &self.list.remove(index);
                 if entry.mv == self.tt_move {
                     continue;
@@ -120,13 +114,7 @@ impl MovePicker {
         if self.stage == Stage::Quiet {
             if !skip_quiets {
                 while !self.list.is_empty() {
-                    let mut index = 0;
-                    for i in 1..self.list.len() {
-                        if self.list[i].score > self.list[index].score {
-                            index = i;
-                        }
-                    }
-
+                    let index = self.find_best_score_index();
                     let entry = &self.list.remove(index);
                     if entry.mv == self.tt_move {
                         continue;
@@ -156,6 +144,10 @@ impl MovePicker {
         }
 
         None
+    }
+
+    fn find_best_score_index(&self) -> usize {
+        self.list.iter().enumerate().max_by_key(|&(_, entry)| entry.score).map(|(i, _)| i).unwrap_or(0)
     }
 
     fn score_noisy(&mut self, td: &ThreadData) {


### PR DESCRIPTION
Elo   | 3.58 +- 2.36 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23262 W: 6127 L: 5887 D: 11248
Penta | [107, 2709, 5766, 2935, 114]
https://recklesschess.space/test/8458/

Bench: 3052606
