### PR TITLE
Refine replacement scaling

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -169,8 +169,12 @@ impl TranspositionTable {
         let mut lowest_quality = i32::MAX;
 
         for candidate in &cluster.entries {
-            let quality = candidate.depth as i32 - 4 * candidate.relative_age(tt_age);
+            if candidate.depth as i32 == TtDepth::NONE {
+                replacement_slot = std::ptr::from_ref(candidate);
+                return (None, replacement_slot);
+            }
 
+            let quality = candidate.depth as i32 - 4 * candidate.relative_age(tt_age);
             if quality < lowest_quality {
                 replacement_slot = std::ptr::from_ref(candidate);
                 lowest_quality = quality;


### PR DESCRIPTION
replace with an empty entry than a filled one.

Elo   | 1.62 +- 1.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=512MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 60422 W: 15399 L: 15118 D: 29905
Penta | [88, 6196, 17364, 6473, 90]
https://recklesschess.space/test/8506/

Elo   | -0.59 +- 1.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 57792 W: 14517 L: 14615 D: 28660
Penta | [107, 6035, 16680, 5997, 77]
https://recklesschess.space/test/8513/

Bench: 3442761