### PR TITLE
Simplify quiet move history updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -932,7 +932,7 @@ fn search<NODE: NodeType>(
                 td.board.piece_on(best_move.to()).piece_type(),
                 bonus_noisy,
             );
-        } else if !quiet_moves.is_empty() || depth > 3 {
+        } else {
             td.quiet_history.update(td.board.threats(), td.board.side_to_move(), best_move, bonus_quiet);
             update_continuation_histories(td, ply, td.board.moved_piece(best_move), best_move.to(), bonus_cont);
 


### PR DESCRIPTION
Elo   | 1.09 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 32002 W: 8231 L: 8131 D: 15640
Penta | [60, 3767, 8251, 3859, 64]
https://recklesschess.space/test/8542/

Bench: 3022524