### PR TITLE
Simplify PCM history updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -954,9 +954,7 @@ fn search<NODE: NodeType>(
         }
     }
 
-    if !NODE::ROOT && bound == Bound::Upper && (!quiet_moves.is_empty() || depth > 3) {
-        tt_pv |= td.stack[ply - 1].tt_pv;
-
+    if !NODE::ROOT && bound == Bound::Upper {
         let pcm_move = td.stack[ply - 1].mv;
         if pcm_move.is_quiet() {
             let mut factor = 104;
@@ -979,6 +977,8 @@ fn search<NODE: NodeType>(
             }
         }
     }
+
+    tt_pv |= !NODE::ROOT && bound == Bound::Upper && td.stack[ply - 1].tt_pv && (!quiet_moves.is_empty() || depth > 3);
 
     debug_assert!(alpha < beta);
     if best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {


### PR DESCRIPTION
Elo   | 0.60 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 43988 W: 11182 L: 11106 D: 21700
Penta | [83, 5255, 11256, 5303, 97]
https://recklesschess.space/test/8544/

Bench: 2971287
