### PR TITLE
Simplify adding TTPV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -978,7 +978,7 @@ fn search<NODE: NodeType>(
         }
     }
 
-    tt_pv |= !NODE::ROOT && bound == Bound::Upper && td.stack[ply - 1].tt_pv && (!quiet_moves.is_empty() || depth > 3);
+    tt_pv |= !NODE::ROOT && bound == Bound::Upper && move_count > 2 && td.stack[ply - 1].tt_pv;
 
     debug_assert!(alpha < beta);
     if best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {


### PR DESCRIPTION
Elo   | -0.03 +- 1.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 84302 W: 21132 L: 21140 D: 42030
Penta | [160, 10079, 21698, 10037, 177]
https://recklesschess.space/test/8548/

Bench: 3190302