### PR TITLE
Adjust quiet SEE pruning margin based on static evaluation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -659,6 +659,7 @@ fn search<NODE: NodeType>(
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
                 -325 * lmr_depth * lmr_depth / 16 - 31 * history / 1024 + 16
+                    - 5 * lmr_depth * (static_eval >= beta) as i32
             } else {
                 -102 * depth - 45 * history / 1024 + 46
             };

--- a/src/search.rs
+++ b/src/search.rs
@@ -659,7 +659,7 @@ fn search<NODE: NodeType>(
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
                 -325 * lmr_depth * lmr_depth / 16 - 31 * history / 1024 + 16
-                    - 5 * lmr_depth * (static_eval >= beta) as i32
+                    + 5 * lmr_depth * (static_eval < alpha) as i32
             } else {
                 -102 * depth - 45 * history / 1024 + 46
             };

--- a/src/search.rs
+++ b/src/search.rs
@@ -658,8 +658,9 @@ fn search<NODE: NodeType>(
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                -325 * lmr_depth * lmr_depth / 16 - 31 * history / 1024 + 16
+                -325 * lmr_depth * lmr_depth / 16 - 31 * history / 1024
                     + 5 * lmr_depth * (static_eval < alpha) as i32
+                    + 16
             } else {
                 -102 * depth - 45 * history / 1024 + 46
             };


### PR DESCRIPTION
Elo   | 2.24 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40378 W: 10294 L: 10034 D: 20050
Penta | [79, 4713, 10336, 4991, 70]
https://recklesschess.space/test/8568/

Bench: 3151582
