### PR TITLE
Simplify quiescence search futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1147,7 +1147,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             let futility_score = futility_base + 32 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
 
             if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {
-                best_score = best_score.max(futility_score);
                 continue;
             }
         }


### PR DESCRIPTION
Elo   | 0.06 +- 1.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 72652 W: 18362 L: 18350 D: 35940
Penta | [135, 8654, 18746, 8646, 145]
https://recklesschess.space/test/8612/

Bench: 3051376