### PR TITLE
Restrict early TT-cut history updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -283,7 +283,7 @@ fn search<NODE: NodeType>(
                 _ => true,
             }
         {
-            if tt_move.is_quiet() && tt_score >= beta {
+            if tt_move.is_quiet() && tt_score >= beta && td.stack[ply - 1].move_count < 4 {
                 let quiet_bonus = (141 * depth - 72).min(1544) + 68 * !cut_node as i32;
                 let conthist_bonus = (99 * depth - 61).min(1509) + 65 * !cut_node as i32;
 


### PR DESCRIPTION
Elo   | 3.88 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18984 W: 4874 L: 4662 D: 9448
Penta | [41, 2175, 4847, 2389, 40]
https://recklesschess.space/test/8649/

Bench: 3244521
