### PR TITLE
Use only non-decisive scores in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -348,6 +348,7 @@ fn search<NODE: NodeType>(
         eval = Score::NONE;
 
         if is_valid(tt_score)
+            && !is_decisive(tt_score)
             && match tt_bound {
                 Bound::Upper => tt_score <= alpha,
                 Bound::Lower => tt_score >= beta,


### PR DESCRIPTION
Elo   | 2.24 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 19394 W: 4914 L: 4789 D: 9691
Penta | [24, 2165, 5217, 2244, 47]
https://recklesschess.space/test/8656/

Bench: 3053942
