### PR TITLE
Penalize first two refuted moves from previous ply

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -958,9 +958,8 @@ fn search<NODE: NodeType>(
             td.noisy_history.update(td.board.threats(), td.board.moved_piece(mv), mv.to(), captured, -malus_noisy);
         }
 
-        if !NODE::ROOT && td.stack[ply - 1].mv.is_quiet() && td.stack[ply - 1].move_count == 1 {
+        if !NODE::ROOT && td.stack[ply - 1].mv.is_quiet() && td.stack[ply - 1].move_count < 2 {
             let malus = (78 * initial_depth - 52).min(811);
-
             update_continuation_histories(td, ply - 1, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to(), -malus);
         }
     }


### PR DESCRIPTION
Elo   | 1.14 +- 0.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 141350 W: 36034 L: 35571 D: 69745
Penta | [229, 15594, 38598, 15993, 261]
https://recklesschess.space/test/8666/

Bench: 3239556