### PR TITLE
Improve safety and correctness of unsafe code

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -416,7 +416,8 @@ impl Board {
             }
 
             if mv.is_double_push() {
-                return from.shift(2 * offset) == to
+                return from.rank() == (if self.side_to_move == Color::White { 1 } else { 6 })
+                    && from.shift(2 * offset) == to
                     && !self.occupancies().contains(from.shift(offset))
                     && !self.occupancies().contains(to);
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -292,7 +292,6 @@ fn search<NODE: NodeType>(
             }
 
             if td.board.halfmove_clock() < 90 {
-                debug_assert!(is_valid(tt_score));
                 return tt_score;
             }
         }
@@ -991,7 +990,6 @@ fn search<NODE: NodeType>(
 
     tt_pv |= !NODE::ROOT && bound == Bound::Upper && move_count > 2 && td.stack[ply - 1].tt_pv;
 
-    debug_assert!(alpha < beta);
     if best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {
         best_score = (best_score * depth + beta) / (depth + 1);
     }
@@ -1012,6 +1010,7 @@ fn search<NODE: NodeType>(
         update_correction_histories(td, depth, best_score - static_eval, ply);
     }
 
+    debug_assert!(alpha < beta);
     debug_assert!(-Score::INFINITE < best_score && best_score < Score::INFINITE);
 
     best_score
@@ -1171,7 +1170,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
             if score > alpha {
                 best_move = mv;
-                alpha = score;
 
                 if NODE::PV {
                     td.pv_table.update(ply, mv);
@@ -1180,6 +1178,8 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
                 if score >= beta {
                     break;
                 }
+
+                alpha = score;
             }
         }
     }
@@ -1196,6 +1196,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
     td.tt.write(tt_slot, hash, TtDepth::SOME, raw_eval, best_score, bound, best_move, ply, tt_pv);
 
+    debug_assert!(alpha < beta);
     debug_assert!(-Score::INFINITE < best_score && best_score < Score::INFINITE);
 
     best_score

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -32,15 +32,23 @@ pub struct Flags {
 
 impl Flags {
     pub const fn new(bound: Bound, pv: bool, age: u8) -> Self {
+        debug_assert!(age <= AGE_MASK);
+
         Self { data: (bound as u8) | ((pv as u8) << 2) | (age << 3) }
     }
 
     pub const fn bound(self) -> Bound {
-        unsafe { std::mem::transmute(self.data & 0b11) }
+        match self.data & 0b11 {
+            0 => Bound::None,
+            1 => Bound::Exact,
+            2 => Bound::Lower,
+            3 => Bound::Upper,
+            _ => unreachable!(),
+        }
     }
 
     pub const fn pv(self) -> bool {
-        (self.data & 0b100) != 0
+        (self.data & (1 << 2)) != 0
     }
 
     pub const fn age(self) -> u8 {

--- a/src/types/color.rs
+++ b/src/types/color.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[repr(u8)]
 pub enum Color {
     White,
     Black,

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -42,11 +42,11 @@ impl Move {
     }
 
     pub const fn from(self) -> Square {
-        unsafe { mem::transmute((self.0 & 0b0000_0000_0011_1111) as u8) }
+        Square::new((self.0 & 0b0000_0000_0011_1111) as u8)
     }
 
     pub const fn to(self) -> Square {
-        unsafe { mem::transmute(((self.0 & 0b0000_1111_1100_0000) >> 6) as u8) }
+        Square::new(((self.0 & 0b0000_1111_1100_0000) >> 6) as u8)
     }
 
     pub const fn encoded(self) -> usize {

--- a/src/types/piece.rs
+++ b/src/types/piece.rs
@@ -6,6 +6,7 @@ use std::{
 use super::Color;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[repr(u8)]
 pub enum Piece {
     WhitePawn,
     BlackPawn,
@@ -30,6 +31,8 @@ impl Piece {
     }
 
     pub const fn from_index(index: usize) -> Self {
+        debug_assert!(index < Self::NUM);
+
         unsafe { std::mem::transmute(index as u8) }
     }
 

--- a/src/types/square.rs
+++ b/src/types/square.rs
@@ -6,6 +6,7 @@ use super::Bitboard;
 ///
 /// [LERFM]: https://www.chessprogramming.org/Square_Mapping_Considerations#Little-Endian_Rank-File_Mapping
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[repr(u8)]
 #[rustfmt::skip]
 pub enum Square {
     A1, B1, C1, D1, E1, F1, G1, H1,
@@ -23,16 +24,12 @@ pub enum Square {
 impl Square {
     pub const NUM: usize = 64;
 
-    /// Creates a new square from the given value.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that the value is in the range `0..64`.
     pub const fn new(value: u8) -> Self {
+        debug_assert!(value < Self::NUM as u8);
+
         unsafe { std::mem::transmute(value) }
     }
 
-    /// Creates a square from the given rank and file.
     pub const fn from_rank_file(rank: u8, file: u8) -> Self {
         Self::new((rank << 3) | file)
     }
@@ -45,9 +42,11 @@ impl Square {
         self as u8 >> 3
     }
 
-    /// Shifts the square by the given offset.
     pub const fn shift(self, offset: i8) -> Self {
-        Self::new((self as i8 + offset) as u8)
+        let value = self as i8 + offset;
+        debug_assert!(0 <= value && value < Self::NUM as i8);
+
+        Self::new(value as u8)
     }
 
     pub const fn to_bb(self) -> Bitboard {


### PR DESCRIPTION
Elo   | -0.58 +- 1.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 55400 W: 13945 L: 14037 D: 27418
Penta | [91, 5752, 16090, 5692, 75]
https://recklesschess.space/test/8801/

Bench: 3239556
