### PR TITLE
Refactor thread data sharing into unified context

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::Ordering;
+
 use crate::{
     evaluate::evaluate,
     movepick::{MovePicker, Stage},
@@ -49,8 +51,6 @@ pub fn start(td: &mut ThreadData, report: Report) {
     td.stopped = false;
 
     td.pv_table.clear(0);
-    td.nodes.clear_local();
-    td.tb_hits.clear_local();
 
     td.nnue.full_refresh(&td.board);
 
@@ -104,9 +104,6 @@ pub fn start(td: &mut ThreadData, report: Report) {
             // Root Search
             let score = search::<Root>(td, alpha, beta, (depth - reduction).max(1), false, 0);
 
-            td.nodes.flush();
-            td.tb_hits.flush();
-
             td.root_moves.sort_by(|a, b| b.score.cmp(&a.score));
 
             if td.stopped {
@@ -132,7 +129,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
                 }
             }
 
-            if report == Report::Full && td.nodes.global() > 10_000_000 {
+            if report == Report::Full && td.shared.aggregate_nodes() > 10_000_000 {
                 td.print_uci_info(depth);
             }
         }
@@ -171,7 +168,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
         }
 
         let multiplier = || {
-            let nodes_factor = 2.15 - 1.5 * (td.root_moves[0].nodes as f32 / td.nodes.local() as f32);
+            let nodes_factor = 2.15 - 1.5 * (td.root_moves[0].nodes as f32 / td.nodes() as f32);
 
             let pv_stability = 1.25 - 0.05 * pv_stability.min(8) as f32;
 
@@ -257,7 +254,7 @@ fn search<NODE: NodeType>(
     let initial_depth = depth;
 
     let hash = td.board.hash();
-    let (entry, tt_slot) = td.tt.read(hash, td.board.halfmove_clock(), ply);
+    let (entry, tt_slot) = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
     let mut tt_depth = 0;
     let mut tt_move = Move::NULL;
     let mut tt_score = Score::NONE;
@@ -306,7 +303,7 @@ fn search<NODE: NodeType>(
         && !td.stop_probing_tb
     {
         if let Some(outcome) = tb_probe(&td.board) {
-            td.tb_hits.increment();
+            td.shared.tb_hits[td.id].fetch_add(1, Ordering::Relaxed);
 
             let (score, bound) = match outcome {
                 GameOutcome::Win => (tb_win_in(ply), Bound::Lower),
@@ -319,7 +316,7 @@ fn search<NODE: NodeType>(
                 || (bound == Bound::Upper && score <= alpha)
             {
                 let depth = (depth + 6).min(MAX_PLY as i32 - 1);
-                td.tt.write(tt_slot, hash, depth, Score::NONE, score, bound, Move::NULL, ply, tt_pv);
+                td.shared.tt.write(tt_slot, hash, depth, Score::NONE, score, bound, Move::NULL, ply, tt_pv);
                 return score;
             }
 
@@ -377,7 +374,7 @@ fn search<NODE: NodeType>(
         }
     } else {
         raw_eval = evaluate(td);
-        td.tt.write(tt_slot, hash, TtDepth::SOME, raw_eval, Score::NONE, Bound::None, Move::NULL, ply, tt_pv);
+        td.shared.tt.write(tt_slot, hash, TtDepth::SOME, raw_eval, Score::NONE, Bound::None, Move::NULL, ply, tt_pv);
 
         static_eval = corrected_eval(raw_eval, correction_value, td.board.halfmove_clock());
         eval = static_eval;
@@ -557,7 +554,7 @@ fn search<NODE: NodeType>(
             }
 
             if score >= probcut_beta {
-                td.tt.write(tt_slot, hash, probcut_depth + 1, raw_eval, score, Bound::Lower, mv, ply, tt_pv);
+                td.shared.tt.write(tt_slot, hash, probcut_depth + 1, raw_eval, score, Bound::Lower, mv, ply, tt_pv);
 
                 if !is_decisive(score) {
                     return score - (probcut_beta - beta);
@@ -708,7 +705,7 @@ fn search<NODE: NodeType>(
             }
         }
 
-        let initial_nodes = td.nodes.local();
+        let initial_nodes = td.nodes();
 
         make_move(td, ply, mv);
 
@@ -854,9 +851,10 @@ fn search<NODE: NodeType>(
         }
 
         if NODE::ROOT {
+            let current_nodes = td.nodes();
             let root_move = td.root_moves.iter_mut().find(|v| v.mv == mv).unwrap();
 
-            root_move.nodes += td.nodes.local() - initial_nodes;
+            root_move.nodes += current_nodes - initial_nodes;
 
             if move_count == 1 || score > alpha {
                 match score {
@@ -1001,7 +999,7 @@ fn search<NODE: NodeType>(
     }
 
     if !excluded {
-        td.tt.write(tt_slot, hash, depth, raw_eval, best_score, bound, best_move, ply, tt_pv);
+        td.shared.tt.write(tt_slot, hash, depth, raw_eval, best_score, bound, best_move, ply, tt_pv);
     }
 
     if !(in_check
@@ -1051,7 +1049,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     }
 
     let hash = td.board.hash();
-    let (entry, tt_slot) = td.tt.read(hash, td.board.halfmove_clock(), ply);
+    let (entry, tt_slot) = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
     let mut tt_pv = NODE::PV;
     let mut tt_score = Score::NONE;
     let mut tt_bound = Bound::None;
@@ -1103,7 +1101,17 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
 
             if entry.is_none() {
-                td.tt.write(tt_slot, hash, TtDepth::SOME, raw_eval, best_score, Bound::Lower, Move::NULL, ply, tt_pv);
+                td.shared.tt.write(
+                    tt_slot,
+                    hash,
+                    TtDepth::SOME,
+                    raw_eval,
+                    best_score,
+                    Bound::Lower,
+                    Move::NULL,
+                    ply,
+                    tt_pv,
+                );
             }
 
             return best_score;
@@ -1196,7 +1204,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
     let bound = if best_score >= beta { Bound::Lower } else { Bound::Upper };
 
-    td.tt.write(tt_slot, hash, TtDepth::SOME, raw_eval, best_score, bound, best_move, ply, tt_pv);
+    td.shared.tt.write(tt_slot, hash, TtDepth::SOME, raw_eval, best_score, bound, best_move, ply, tt_pv);
 
     debug_assert!(alpha < beta);
     debug_assert!(-Score::INFINITE < best_score && best_score < Score::INFINITE);
@@ -1285,10 +1293,12 @@ fn make_move(td: &mut ThreadData, ply: usize, mv: Move) {
     td.stack[ply].contcorrhist =
         td.continuation_corrhist.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
 
-    td.nodes.increment();
+    td.shared.nodes[td.id].fetch_add(1, Ordering::Relaxed);
+
     td.nnue.push(mv, &td.board);
     td.board.make_move(mv);
-    td.tt.prefetch(td.board.hash());
+
+    td.shared.tt.prefetch(td.board.hash());
 }
 
 fn undo_move(td: &mut ThreadData, mv: Move) {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,6 +1,9 @@
 use std::{
     ops::Index,
-    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use crate::{
@@ -14,33 +17,69 @@ use crate::{
     types::{normalize_to_cp, Move, Score, MAX_MOVES, MAX_PLY},
 };
 
-pub struct ThreadPool<'a> {
-    pub workers: Vec<pool::WorkerThread>,
-    pub vector: Vec<Box<ThreadData<'a>>>,
+pub struct SharedContext {
+    pub tt: TranspositionTable,
+    pub stop: AtomicBool,
+    pub nodes: [AtomicU64; Self::MAX_THREADS],
+    pub tb_hits: [AtomicU64; Self::MAX_THREADS],
 }
 
-impl<'a> ThreadPool<'a> {
-    pub fn new(tt: &'a TranspositionTable, stop: &'a AtomicBool, nodes: &'a AtomicU64, tb_hits: &'a AtomicU64) -> Self {
+unsafe impl Send for SharedContext {}
+
+impl SharedContext {
+    const MAX_THREADS: usize = 512;
+
+    pub fn aggregate_nodes(&self) -> u64 {
+        self.nodes.iter().map(|nodes| nodes.load(Ordering::Relaxed)).sum()
+    }
+
+    pub fn aggregate_tb_hits(&self) -> u64 {
+        self.tb_hits.iter().map(|tb_hits| tb_hits.load(Ordering::Relaxed)).sum()
+    }
+
+    pub fn reset_counters(&self) {
+        for id in 0..Self::MAX_THREADS {
+            self.nodes[id].store(0, Ordering::Relaxed);
+            self.tb_hits[id].store(0, Ordering::Relaxed);
+        }
+    }
+}
+
+impl Default for SharedContext {
+    fn default() -> Self {
+        Self {
+            tt: TranspositionTable::default(),
+            stop: AtomicBool::default(),
+            nodes: std::array::from_fn(|_| AtomicU64::default()),
+            tb_hits: std::array::from_fn(|_| AtomicU64::default()),
+        }
+    }
+}
+
+pub struct ThreadPool {
+    pub workers: Vec<pool::WorkerThread>,
+    pub vector: Vec<Box<ThreadData>>,
+}
+
+impl ThreadPool {
+    pub fn new(shared: Arc<SharedContext>) -> Self {
         let workers = pool::make_worker_threads(1);
-        let data = make_thread_data(tt, stop, nodes, tb_hits, &workers);
+        let data = make_thread_data(shared, &workers);
 
         Self { workers, vector: data }
     }
 
     pub fn set_count(&mut self, threads: usize) {
-        let tt = self.vector[0].tt;
-        let stop = self.vector[0].stop;
-        let nodes = self.vector[0].nodes.global;
-        let tb_hits = self.vector[0].tb_hits.global;
+        let shared = self.vector[0].shared.clone();
 
         self.workers.drain(..).for_each(pool::WorkerThread::join);
         self.workers = pool::make_worker_threads(threads);
 
         std::mem::drop(self.vector.drain(..));
-        self.vector = make_thread_data(tt, stop, nodes, tb_hits, &self.workers);
+        self.vector = make_thread_data(shared, &self.workers);
     }
 
-    pub fn main_thread(&mut self) -> &mut ThreadData<'a> {
+    pub fn main_thread(&mut self) -> &mut ThreadData {
         &mut self.vector[0]
     }
 
@@ -48,38 +87,33 @@ impl<'a> ThreadPool<'a> {
         self.vector.len()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Box<ThreadData<'a>>> {
+    pub fn iter(&self) -> impl Iterator<Item = &Box<ThreadData>> {
         self.vector.iter()
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Box<ThreadData<'a>>> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Box<ThreadData>> {
         self.vector.iter_mut()
     }
 
     pub fn clear(&mut self) {
-        let tt = self.vector[0].tt;
-        let stop = self.vector[0].stop;
-        let nodes = self.vector[0].nodes.global;
-        let tb_hits = self.vector[0].tb_hits.global;
+        let shared = self.vector[0].shared.clone();
 
         std::mem::drop(self.vector.drain(..));
-        self.vector = make_thread_data(tt, stop, nodes, tb_hits, &self.workers);
+        self.vector = make_thread_data(shared, &self.workers);
     }
 }
 
-impl<'a> Index<usize> for ThreadPool<'a> {
-    type Output = ThreadData<'a>;
+impl Index<usize> for ThreadPool {
+    type Output = ThreadData;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.vector[index]
     }
 }
 
-pub struct ThreadData<'a> {
-    pub tt: &'a TranspositionTable,
-    pub stop: &'a AtomicBool,
-    pub nodes: AtomicCounter<'a>,
-    pub tb_hits: AtomicCounter<'a>,
+pub struct ThreadData {
+    pub id: usize,
+    pub shared: Arc<SharedContext>,
     pub board: Board,
     pub time_manager: TimeManager,
     pub stack: Stack,
@@ -107,13 +141,11 @@ pub struct ThreadData<'a> {
     pub stop_probing_tb: bool,
 }
 
-impl<'a> ThreadData<'a> {
-    pub fn new(tt: &'a TranspositionTable, stop: &'a AtomicBool, nodes: &'a AtomicU64, tb_hits: &'a AtomicU64) -> Self {
+impl ThreadData {
+    pub fn new(shared: Arc<SharedContext>) -> Self {
         Self {
-            tt,
-            stop,
-            nodes: AtomicCounter::new(nodes),
-            tb_hits: AtomicCounter::new(tb_hits),
+            id: 0,
+            shared,
             board: Board::starting_position(),
             time_manager: TimeManager::new(Limits::Infinite, 0, 0),
             stack: Stack::default(),
@@ -142,8 +174,12 @@ impl<'a> ThreadData<'a> {
         }
     }
 
+    pub fn nodes(&self) -> u64 {
+        self.shared.nodes[self.id].load(Ordering::Relaxed)
+    }
+
     pub fn get_stop(&self) -> bool {
-        self.stop.load(Ordering::Relaxed)
+        self.shared.stop.load(Ordering::Relaxed)
     }
 
     pub fn conthist(&self, ply: usize, index: usize, mv: Move) -> i32 {
@@ -158,7 +194,7 @@ impl<'a> ThreadData<'a> {
 
     pub fn print_uci_info(&self, depth: i32) {
         let elapsed = self.time_manager.elapsed();
-        let nps = self.nodes.global() as f64 / elapsed.as_secs_f64();
+        let nps = self.shared.aggregate_nodes() as f64 / elapsed.as_secs_f64();
         let ms = elapsed.as_millis();
 
         let root_move = &self.root_moves[0];
@@ -195,9 +231,9 @@ impl<'a> ThreadData<'a> {
         print!(
             "info depth {depth} seldepth {} score {score} nodes {} time {ms} nps {nps:.0} hashfull {} tbhits {} pv",
             root_move.sel_depth,
-            self.nodes.global(),
-            self.tt.hashfull(),
-            self.tb_hits.global(),
+            self.shared.aggregate_nodes(),
+            self.shared.tt.hashfull(),
+            self.shared.aggregate_tb_hits(),
         );
 
         print!(" {}", root_move.mv.to_uci(&self.board));
@@ -306,62 +342,16 @@ impl Default for LmrTable {
     }
 }
 
-pub struct AtomicCounter<'a> {
-    buffer: u64,
-    local: u64,
-    global: &'a AtomicU64,
-}
-
-impl<'a> AtomicCounter<'a> {
-    pub const fn new(global: &'a AtomicU64) -> Self {
-        Self { buffer: 0, local: 0, global }
-    }
-
-    pub const fn local(&self) -> u64 {
-        self.local + self.buffer
-    }
-
-    pub fn global(&self) -> u64 {
-        self.buffer + self.global.load(Ordering::Relaxed)
-    }
-
-    pub fn increment(&mut self) {
-        const BUFFER_SIZE: u64 = 2048;
-
-        self.buffer += 1;
-        if self.buffer >= BUFFER_SIZE {
-            self.flush();
-        }
-    }
-
-    pub fn clear_local(&mut self) {
-        self.local = 0;
-        self.buffer = 0;
-    }
-
-    pub fn clear_global(&self) {
-        self.global.store(0, Ordering::Relaxed);
-    }
-
-    pub fn flush(&mut self) {
-        self.local += self.buffer;
-        self.global.fetch_add(self.buffer, Ordering::Relaxed);
-        self.buffer = 0;
-    }
-}
-
-pub fn make_thread_data<'a>(
-    tt: &'a TranspositionTable, stop: &'a AtomicBool, nodes: &'a AtomicU64, tb_hits: &'a AtomicU64,
-    worker_threads: &[pool::WorkerThread],
-) -> Vec<Box<ThreadData<'a>>> {
-    std::thread::scope(|scope| -> Vec<Box<ThreadData<'a>>> {
+pub fn make_thread_data(shared: Arc<SharedContext>, worker_threads: &[pool::WorkerThread]) -> Vec<Box<ThreadData>> {
+    std::thread::scope(|scope| -> Vec<Box<ThreadData>> {
         let handles = worker_threads
             .iter()
             .map(|worker| {
                 let (tx, rx) = std::sync::mpsc::channel();
+                let shared = shared.clone();
                 let join_handle = scope.spawn_into(
                     move || {
-                        tx.send(Box::new(ThreadData::new(tt, stop, nodes, tb_hits))).unwrap();
+                        tx.send(Box::new(ThreadData::new(shared))).unwrap();
                     },
                     worker,
                 );

--- a/src/time.rs
+++ b/src/time.rs
@@ -70,7 +70,7 @@ impl TimeManager {
         match self.limits {
             Limits::Infinite => false,
             Limits::Depth(maximum) => td.completed_depth >= maximum,
-            Limits::Nodes(maximum) => td.nodes.global() >= maximum,
+            Limits::Nodes(maximum) => td.shared.aggregate_nodes() >= maximum,
             Limits::Time(maximum) => self.start_time.elapsed() >= Duration::from_millis(maximum),
             _ => self.start_time.elapsed() >= Duration::from_secs_f32(self.soft_bound.as_secs_f32() * multiplier()),
         }
@@ -81,14 +81,14 @@ impl TimeManager {
             return false;
         }
 
-        if td.nodes.local() & 2047 == 2047 && td.get_stop() {
+        if td.nodes() & 2047 == 2047 && td.get_stop() {
             return true;
         }
 
         match self.limits {
             Limits::Infinite | Limits::Depth(_) => false,
-            Limits::Nodes(maximum) => td.nodes.global() > maximum,
-            _ => td.nodes.local() & 2047 == 2047 && self.start_time.elapsed() >= self.hard_bound,
+            Limits::Nodes(maximum) => td.shared.aggregate_nodes() > maximum,
+            _ => td.nodes() & 2047 == 2047 && self.start_time.elapsed() >= self.hard_bound,
         }
     }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -70,7 +70,7 @@ impl TimeManager {
         match self.limits {
             Limits::Infinite => false,
             Limits::Depth(maximum) => td.completed_depth >= maximum,
-            Limits::Nodes(maximum) => td.shared.aggregate_nodes() >= maximum,
+            Limits::Nodes(maximum) => td.shared.nodes.aggregate() >= maximum,
             Limits::Time(maximum) => self.start_time.elapsed() >= Duration::from_millis(maximum),
             _ => self.start_time.elapsed() >= Duration::from_secs_f32(self.soft_bound.as_secs_f32() * multiplier()),
         }
@@ -87,7 +87,7 @@ impl TimeManager {
 
         match self.limits {
             Limits::Infinite | Limits::Depth(_) => false,
-            Limits::Nodes(maximum) => td.shared.aggregate_nodes() > maximum,
+            Limits::Nodes(maximum) => td.shared.nodes.aggregate() > maximum,
             _ => td.nodes() & 2047 == 2047 && self.start_time.elapsed() >= self.hard_bound,
         }
     }

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -86,8 +86,7 @@ pub fn bench<const PRETTY: bool>(depth: Option<i32>) {
     for position in POSITIONS {
         let now = Instant::now();
 
-        td.shared.reset_counters();
-
+        td.shared.nodes.reset();
         td.board = Board::from_fen(position).unwrap();
         td.time_manager = TimeManager::new(Limits::Depth(depth), 0, 0);
 

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -7,17 +7,13 @@
 //! Note that although it can be used as a benchmarking tool,
 //! it is not comprehensive enough to be definitive.
 
-use std::{
-    sync::atomic::{AtomicBool, AtomicU64},
-    time::Instant,
-};
+use std::{sync::Arc, time::Instant};
 
 use crate::{
     board::Board,
     search::{self, Report},
-    thread::ThreadData,
+    thread::{SharedContext, ThreadData},
     time::{Limits, TimeManager},
-    transposition::TranspositionTable,
 };
 
 const POSITIONS: &[&str] = &[
@@ -79,12 +75,8 @@ pub fn bench<const PRETTY: bool>(depth: Option<i32>) {
 
     let depth = depth.unwrap_or(DEFAULT_DEPTH);
 
-    let tt = TranspositionTable::default();
-    let stop = AtomicBool::new(false);
-    let nodes = AtomicU64::new(0);
-    let tb_hits = AtomicU64::new(0);
-
-    let mut td = ThreadData::new(&tt, &stop, &nodes, &tb_hits);
+    let shared = Arc::new(SharedContext::default());
+    let mut td = ThreadData::new(shared);
 
     let time = Instant::now();
 
@@ -94,19 +86,21 @@ pub fn bench<const PRETTY: bool>(depth: Option<i32>) {
     for position in POSITIONS {
         let now = Instant::now();
 
+        td.shared.reset_counters();
+
         td.board = Board::from_fen(position).unwrap();
         td.time_manager = TimeManager::new(Limits::Depth(depth), 0, 0);
 
         search::start(&mut td, Report::None);
 
-        nodes += td.nodes.local();
+        nodes += td.nodes();
         index += 1;
 
         let seconds = now.elapsed().as_secs_f64();
-        let nps = td.nodes.local() as f64 / seconds;
+        let nps = td.nodes() as f64 / seconds;
 
         if PRETTY {
-            println!("{index:>3} {:>11} {seconds:>12.3}s {nps:>15.0} N/s", td.nodes.local());
+            println!("{index:>3} {:>11} {seconds:>12.3}s {nps:>15.0} N/s", td.nodes());
         }
     }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -86,7 +86,8 @@ fn go(
 
     threads.main_thread().time_manager = TimeManager::new(limits, board.fullmove_number(), move_overhead);
 
-    shared.reset_counters();
+    shared.nodes.reset();
+    shared.tb_hits.reset();
     shared.tt.increment_age();
     shared.stop.store(false, Ordering::Relaxed);
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,10 +1,10 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{atomic::Ordering, Arc};
 
 use crate::{
     board::Board,
     search::{self, Report},
     tb::tb_initilize,
-    thread::{pool::ScopeExt, ThreadData, ThreadPool},
+    thread::{pool::ScopeExt, SharedContext, ThreadData, ThreadPool},
     time::{Limits, TimeManager},
     tools,
     transposition::{TranspositionTable, DEFAULT_TT_SIZE},
@@ -12,13 +12,9 @@ use crate::{
 };
 
 pub fn message_loop() {
-    static STOP: AtomicBool = AtomicBool::new(false);
+    let shared = Arc::new(SharedContext::default());
 
-    let tt = TranspositionTable::default();
-    let nodes = AtomicU64::new(0);
-    let tb_hits = AtomicU64::new(0);
-
-    let mut threads = ThreadPool::new(&tt, &STOP, &nodes, &tb_hits);
+    let mut threads = ThreadPool::new(shared.clone());
     let mut frc = false;
     let mut move_overhead = 100;
     let mut report = Report::Full;
@@ -31,14 +27,14 @@ pub fn message_loop() {
             ["uci"] => uci(),
             ["isready"] => println!("readyok"),
 
-            ["go", tokens @ ..] => next_command = go(&mut threads, &STOP, report, move_overhead, tokens),
+            ["go", tokens @ ..] => next_command = go(&mut threads, &shared, report, move_overhead, tokens),
             ["position", tokens @ ..] => position(&mut threads, frc, tokens),
             ["setoption", tokens @ ..] => {
-                set_option(&mut threads, &mut report, &mut move_overhead, &mut frc, &tt, tokens)
+                set_option(&mut threads, &mut report, &mut move_overhead, &mut frc, &shared.tt, tokens)
             }
-            ["ucinewgame"] => reset(&mut threads, &tt),
+            ["ucinewgame"] => reset(&mut threads, &shared.tt),
 
-            ["stop"] => STOP.store(true, Ordering::Relaxed),
+            ["stop"] => shared.stop.store(true, Ordering::Relaxed),
             ["quit"] => break,
 
             // Non-UCI commands
@@ -83,17 +79,16 @@ fn reset(threads: &mut ThreadPool, tt: &TranspositionTable) {
 }
 
 fn go(
-    threads: &mut ThreadPool, stop: &'static AtomicBool, report: Report, move_overhead: u64, tokens: &[&str],
+    threads: &mut ThreadPool, shared: &Arc<SharedContext>, report: Report, move_overhead: u64, tokens: &[&str],
 ) -> Option<String> {
     let board = &threads.main_thread().board;
     let limits = parse_limits(board.side_to_move(), tokens);
 
     threads.main_thread().time_manager = TimeManager::new(limits, board.fullmove_number(), move_overhead);
-    threads.main_thread().tb_hits.clear_global();
-    threads.main_thread().nodes.clear_global();
-    threads.main_thread().tt.increment_age();
 
-    stop.store(false, Ordering::Relaxed);
+    shared.reset_counters();
+    shared.tt.increment_age();
+    shared.stop.store(false, Ordering::Relaxed);
 
     let listener = std::thread::scope(|scope| {
         let mut handlers = Vec::new();
@@ -104,27 +99,29 @@ fn go(
         handlers.push(scope.spawn_into(
             || {
                 search::start(t1, report);
-                stop.store(true, Ordering::Relaxed);
+                shared.stop.store(true, Ordering::Relaxed);
             },
             w1,
         ));
 
-        for (t, w) in rest.iter_mut().zip(rest_workers) {
+        for (index, (t, w)) in rest.iter_mut().zip(rest_workers).enumerate() {
             handlers.push(scope.spawn_into(
-                || {
+                move || {
                     t.time_manager = TimeManager::new(Limits::Infinite, 0, 0);
+                    t.id = index + 1;
                     search::start(t, Report::None);
                 },
                 w,
             ));
         }
 
-        let listener = std::thread::spawn(|| loop {
+        let shared = shared.clone();
+        let listener = std::thread::spawn(move || loop {
             let command = read_stdin();
             match command.as_str().trim() {
                 "isready" => println!("readyok"),
                 "stop" => {
-                    stop.store(true, Ordering::Relaxed);
+                    shared.stop.store(true, Ordering::Relaxed);
                     return None;
                 }
                 _ => return Some(command),


### PR DESCRIPTION
Elo   | 0.40 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 49756 W: 12704 L: 12647 D: 24405
Penta | [77, 5096, 14476, 5151, 78]
https://recklesschess.space/test/8845/

Bench: 3008332