### PR TITLE
Guarantee safe reads on counters

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,8 +1,7 @@
 use std::{
-    cell::UnsafeCell,
     ops::Index,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -19,40 +18,41 @@ use crate::{
 };
 
 #[repr(align(64))]
-#[derive(Copy, Clone)]
-struct AlignedU64 {
-    inner: u64,
+struct AlignedAtomicU64 {
+    inner: AtomicU64,
 }
 
 pub struct Counter<const SIZE: usize> {
-    shards: UnsafeCell<[AlignedU64; SIZE]>,
+    shards: [AlignedAtomicU64; SIZE],
 }
 
 unsafe impl<const SIZE: usize> Sync for Counter<SIZE> {}
 
 impl<const SIZE: usize> Counter<SIZE> {
     pub fn aggregate(&self) -> u64 {
-        unsafe { &*self.shards.get() }.iter().map(|shard| shard.inner).sum()
+        self.shards.iter().map(|shard| shard.inner.load(Ordering::Relaxed)).sum()
     }
 
     pub fn get(&self, id: usize) -> u64 {
-        unsafe { (*self.shards.get())[id].inner }
+        self.shards[id].inner.load(Ordering::Relaxed)
     }
 
     pub fn increment(&self, id: usize) {
-        unsafe { (*self.shards.get())[id].inner += 1 };
+        self.shards[id].inner.store(self.shards[id].inner.load(Ordering::Relaxed) + 1, Ordering::Relaxed);
     }
 
     pub fn reset(&self) {
-        for shard in unsafe { &mut *self.shards.get() } {
-            shard.inner = 0;
+        for shard in &self.shards {
+            shard.inner.store(0, Ordering::Relaxed);
         }
     }
 }
 
 impl<const SIZE: usize> Default for Counter<SIZE> {
     fn default() -> Self {
-        Self { shards: UnsafeCell::new([AlignedU64 { inner: 0 }; SIZE]) }
+        Self {
+            shards: std::array::from_fn(|_| AlignedAtomicU64 { inner: AtomicU64::default() }),
+        }
     }
 }
 


### PR DESCRIPTION
In #556 (Replace atomics with unsynchronized counters), atomic operations were
replaced with direct `UnsafeCell` access. This doesn't affect writes, since they are
exclusive, but reads may have data races in exchange for speed.

The fix replaces the original `fetch_add`, which generates a costly `LOCK ADD`
instruction, with relaxed `load` and `store` that emit regular `MOV` instructions,
resolving the performance issue in the first place

Thanks to @KierenP and @Sp00ph for looking into this.

Elo   | -0.30 +- 0.91 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 136020 W: 35082 L: 35201 D: 65737
Penta | [489, 14691, 37755, 14600, 475]
https://recklesschess.space/test/8868/

Bench: 3008332