### PR TITLE
Use atomics to manage transposition table state

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -1,4 +1,4 @@
-use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
 
 use crate::types::{is_decisive, is_loss, is_valid, is_win, Move, Score};
 
@@ -98,9 +98,9 @@ struct Cluster {
 
 /// The transposition table is used to cache previously performed search results.
 pub struct TranspositionTable {
-    ptr: UnsafeCell<*mut Cluster>,
-    len: UnsafeCell<usize>,
-    age: UnsafeCell<u8>,
+    ptr: AtomicPtr<Cluster>,
+    len: AtomicUsize,
+    age: AtomicU8,
 }
 
 unsafe impl Sync for TranspositionTable {}
@@ -108,10 +108,8 @@ unsafe impl Sync for TranspositionTable {}
 impl TranspositionTable {
     /// Clears the transposition table. This will remove all entries but keep the allocated memory.
     pub fn clear(&self, threads: usize) {
-        unsafe {
-            parallel_clear(threads, self.ptr(), self.len());
-            *self.age.get() = 0;
-        }
+        unsafe { parallel_clear(threads, self.ptr(), self.len()) };
+        self.age.store(0, Ordering::Relaxed);
     }
 
     /// Resizes the transposition table to the specified size in megabytes. This will clear all entries.
@@ -120,11 +118,9 @@ impl TranspositionTable {
 
         let (new_ptr, new_len) = unsafe { allocate(threads, megabytes) };
 
-        unsafe {
-            *self.ptr.get() = new_ptr;
-            *self.len.get() = new_len;
-            *self.age.get() = 0;
-        }
+        self.ptr.store(new_ptr, Ordering::Relaxed);
+        self.len.store(new_len, Ordering::Relaxed);
+        self.age.store(0, Ordering::Relaxed);
     }
 
     /// Returns the approximate load factor of the transposition table in permille (on a scale of `0` to `1000`).
@@ -143,9 +139,7 @@ impl TranspositionTable {
     }
 
     pub fn increment_age(&self) {
-        unsafe {
-            *self.age.get() = (self.age() + 1) & AGE_MASK;
-        }
+        self.age.store((self.age() + 1) & AGE_MASK, Ordering::Relaxed);
     }
 
     pub fn read(&self, hash: u64, halfmove_clock: u8, ply: usize) -> (Option<Entry>, *const InternalEntry) {
@@ -244,15 +238,15 @@ impl TranspositionTable {
     }
 
     fn age(&self) -> u8 {
-        unsafe { *self.age.get() }
+        self.age.load(Ordering::Relaxed)
     }
 
     fn ptr(&self) -> *mut Cluster {
-        unsafe { *self.ptr.get() }
+        self.ptr.load(Ordering::Relaxed)
     }
 
     fn len(&self) -> usize {
-        unsafe { *self.len.get() }
+        self.len.load(Ordering::Relaxed)
     }
 }
 
@@ -310,9 +304,9 @@ impl Default for TranspositionTable {
     fn default() -> Self {
         let (ptr, len) = unsafe { allocate(1, DEFAULT_TT_SIZE) };
         Self {
-            ptr: UnsafeCell::new(ptr),
-            len: UnsafeCell::new(len),
-            age: UnsafeCell::new(0),
+            ptr: AtomicPtr::new(ptr),
+            len: AtomicUsize::new(len),
+            age: AtomicU8::new(0),
         }
     }
 }


### PR DESCRIPTION
Use relaxed atomic loads/stores to remove unsafe code with no runtime overhead.

Elo   | 6.19 +- 4.93 (95%)
SPRT  | 4.0+0.04s Threads=7 Hash=256MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 4774 W: 1251 L: 1166 D: 2357
Penta | [3, 540, 1220, 617, 7]
https://recklesschess.space/test/8875/

Bench: 3008332
