### PR TITLE
Simplify replacement slot selection in transposition table

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -148,7 +148,7 @@ impl TranspositionTable {
         }
     }
 
-    pub fn read(&self, hash: u64, halfmove_clock: u8, ply: usize) -> (Option<Entry>, *const InternalEntry) {
+    pub fn read(&self, hash: u64, halfmove_clock: u8, ply: usize) -> Option<Entry> {
         let cluster = {
             let index = index(hash, self.len());
             unsafe { &*self.ptr().add(index) }
@@ -167,42 +167,45 @@ impl TranspositionTable {
                     mv: entry.mv,
                 };
 
-                return (Some(hit), std::ptr::from_ref(entry));
+                return Some(hit);
             }
         }
 
-        let tt_age = self.age();
-
-        let mut replacement_slot = cluster.entries.as_ptr();
-        let mut lowest_quality = i32::MAX;
-
-        for candidate in &cluster.entries {
-            if candidate.depth as i32 == TtDepth::NONE {
-                replacement_slot = std::ptr::from_ref(candidate);
-                return (None, replacement_slot);
-            }
-
-            let quality = candidate.depth as i32 - 4 * candidate.relative_age(tt_age);
-            if quality < lowest_quality {
-                replacement_slot = std::ptr::from_ref(candidate);
-                lowest_quality = quality;
-            }
-        }
-
-        (None, replacement_slot)
+        None
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn write(
-        &self, ptr: *const InternalEntry, hash: u64, depth: i32, eval: i32, mut score: i32, bound: Bound, mv: Move,
-        ply: usize, pv: bool,
+        &self, hash: u64, depth: i32, eval: i32, mut score: i32, bound: Bound, mv: Move, ply: usize, pv: bool,
     ) {
         // Used for checking if an entry exists
         debug_assert!(depth != TtDepth::NONE);
 
-        let entry = unsafe { &mut *ptr.cast_mut() };
+        let cluster = {
+            let index = index(hash, self.len());
+            unsafe { &mut *self.ptr().add(index) }
+        };
+
         let key = verification_key(hash);
         let tt_age = self.age();
+
+        let mut replacement_slot = None;
+        let mut lowest_quality = i32::MAX;
+
+        for candidate in &mut cluster.entries {
+            if candidate.key == key || candidate.depth as i32 == TtDepth::NONE {
+                replacement_slot = Some(candidate);
+                break;
+            }
+
+            let quality = candidate.depth as i32 - 4 * candidate.relative_age(tt_age);
+            if quality < lowest_quality {
+                replacement_slot = Some(candidate);
+                lowest_quality = quality;
+            }
+        }
+
+        let entry = replacement_slot.unwrap();
 
         if !(entry.key == key && mv.is_null()) {
             entry.mv = mv;


### PR DESCRIPTION
Delay selecting a replacement slot within a cluster on read until a write,
choosing the slot based on the most up-to-date information about entries.

This also avoids the need for raw pointers and unsafe code, simplifying
the transposition table interface.

Elo   | 0.93 +- 2.68 (95%)
SPRT  | 4.0+0.04s Threads=7 Hash=256MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 16018 W: 4060 L: 4017 D: 7941
Penta | [20, 1876, 4176, 1915, 22]
https://recklesschess.space/test/8879/

Bench: 3008332
