### PR TITLE
Simplify noisy move ordering weights

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -164,8 +164,8 @@ impl MovePicker {
             let captured =
                 if entry.mv.is_en_passant() { PieceType::Pawn } else { td.board.piece_on(mv.to()).piece_type() };
 
-            entry.score = 2007 * PIECE_VALUES[captured] / 128
-                + 1061 * td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured) / 1024;
+            entry.score = 16 * PIECE_VALUES[captured]
+                + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
         }
     }
 


### PR DESCRIPTION
Elo   | 0.39 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 53534 W: 13607 L: 13547 D: 26380
Penta | [88, 6332, 13879, 6368, 100]
https://recklesschess.space/test/8917/

Bench: 2732343
