### PR TITLE
Use NMP constants found using Bayesian optimization

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -473,14 +473,14 @@ fn search<NODE: NodeType>(
         && !potential_singularity
         && eval >= beta
         && eval >= static_eval
-        && static_eval >= beta - 16 * depth + 158 * tt_pv as i32 - 106 * improvement / 1024 + 213
+        && static_eval >= beta - 12 * depth + 158 * tt_pv as i32 - 106 * improvement / 1024 + 233
         && ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
         && !is_loss(beta)
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
-        let r = (5756 + 321 * depth) / 1024;
+        let r = (6308 + 321 * depth) / 1024;
 
         td.stack[ply].conthist = std::ptr::null_mut();
         td.stack[ply].contcorrhist = std::ptr::null_mut();


### PR DESCRIPTION
STC
Elo   | 2.60 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32354 W: 8319 L: 8077 D: 15958
Penta | [63, 3763, 8290, 3991, 70]
https://recklesschess.space/test/8930/

LTC
Elo   | 2.77 +- 2.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.38 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23040 W: 5839 L: 5655 D: 11546
Penta | [9, 2640, 6039, 2822, 10]
https://recklesschess.space/test/8931/

Bench: 3606713