### PR TITLE
Introduce recapture extensions

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -31,6 +31,7 @@ struct InternalState {
     plies_from_null: i32,
     repetition: i32,
     captured: Option<Piece>,
+    recapture_square: Square,
     threats: Bitboard,
     pinned: [Bitboard; Color::NUM],
     checkers: Bitboard,
@@ -106,6 +107,10 @@ impl Board {
 
     pub fn prior_threats(&self) -> Bitboard {
         self.state_stack[self.state_stack.len() - 1].threats
+    }
+
+    pub const fn recapture_square(&self) -> Square {
+        self.state.recapture_square
     }
 
     pub const fn en_passant(&self) -> Square {

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -11,6 +11,7 @@ impl Board {
         self.state.plies_from_null = 0;
         self.state.repetition = 0;
         self.state.captured = None;
+        self.state.recapture_square = Square::None;
         self.state.checkers = Bitboard::default();
 
         self.update_threats();
@@ -48,6 +49,7 @@ impl Board {
         }
 
         self.state.captured = None;
+        self.state.recapture_square = Square::None;
 
         if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
             self.state.halfmove_clock = 0;
@@ -60,7 +62,9 @@ impl Board {
         if captured != Piece::None && !mv.is_castling() {
             self.remove_piece(captured, to);
             self.update_hash(captured, to);
+
             self.state.captured = Some(captured);
+            self.state.recapture_square = to;
         }
 
         if !mv.is_castling() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -702,6 +702,8 @@ fn search<NODE: NodeType>(
             } else if cut_node {
                 extension = -2;
             }
+        } else if NODE::PV && mv == tt_move && mv.is_noisy() && mv.to() == td.board.recapture_square() {
+            extension = 1;
         }
 
         let initial_nodes = td.nodes();


### PR DESCRIPTION
STC
Elo   | 6.41 +- 3.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10998 W: 2888 L: 2685 D: 5425
Penta | [21, 1266, 2726, 1461, 25]
https://recklesschess.space/test/8935/

LTC
Elo   | 6.08 +- 3.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8286 W: 2118 L: 1973 D: 4195
Penta | [3, 882, 2229, 1025, 4]
https://recklesschess.space/test/8937/

Bench: 3456664