### PR TITLE
Spend less time on recaptures

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -31,6 +31,7 @@ struct InternalState {
     plies_from_null: i32,
     repetition: i32,
     captured: Option<Piece>,
+    recapture_square: Square,
     threats: Bitboard,
     pinned: [Bitboard; Color::NUM],
     checkers: Bitboard,
@@ -106,6 +107,10 @@ impl Board {
 
     pub fn prior_threats(&self) -> Bitboard {
         self.state_stack[self.state_stack.len() - 1].threats
+    }
+
+    pub const fn recapture_square(&self) -> Square {
+        self.state.recapture_square
     }
 
     pub const fn en_passant(&self) -> Square {

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -11,6 +11,7 @@ impl Board {
         self.state.plies_from_null = 0;
         self.state.repetition = 0;
         self.state.captured = None;
+        self.state.recapture_square = Square::None;
         self.state.checkers = Bitboard::default();
 
         self.update_threats();
@@ -48,6 +49,7 @@ impl Board {
         }
 
         self.state.captured = None;
+        self.state.recapture_square = Square::None;
 
         if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
             self.state.halfmove_clock = 0;
@@ -60,7 +62,9 @@ impl Board {
         if captured != Piece::None && !mv.is_castling() {
             self.remove_piece(captured, to);
             self.update_hash(captured, to);
+
             self.state.captured = Some(captured);
+            self.state.recapture_square = to;
         }
 
         if !mv.is_castling() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -173,7 +173,9 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
             let score_trend = (0.8 + 0.05 * (td.previous_best_score - td.root_moves[0].score) as f32).clamp(0.80, 1.45);
 
-            nodes_factor * pv_stability * eval_stability * score_trend
+            let recapture_factor = if td.root_moves[0].mv.to() == td.board.recapture_square() { 0.9 } else { 1.0 };
+
+            nodes_factor * pv_stability * eval_stability * score_trend * recapture_factor
         };
 
         if td.time_manager.soft_limit(td, multiplier) {


### PR DESCRIPTION
STC
Elo   | 4.48 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15056 W: 3846 L: 3652 D: 7558
Penta | [20, 1539, 4228, 1709, 32]
https://recklesschess.space/test/8936/

LTC
Elo   | 4.91 +- 3.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 9830 W: 2509 L: 2370 D: 4951
Penta | [3, 918, 2933, 1059, 2]
https://recklesschess.space/test/8938/

Bench: 3456664
