### PR TITLE
Simplify quiescence search recapture guard

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1123,8 +1123,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_count = 0;
     let mut move_picker = MovePicker::new_qsearch();
 
-    let previous_square = if td.stack[ply - 1].mv.is_some() { td.stack[ply - 1].mv.to() } else { Square::None };
-
     while let Some(mv) = move_picker.next::<NODE>(td, !in_check, ply) {
         if !td.board.is_legal(mv) {
             continue;
@@ -1132,7 +1130,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
         move_count += 1;
 
-        if !is_loss(best_score) && mv.to() != previous_square {
+        if !is_loss(best_score) && mv.to() != td.board.recapture_square() {
             if move_picker.stage() == Stage::BadNoisy {
                 break;
             }


### PR DESCRIPTION
Elo   | -0.39 +- 0.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 161726 W: 40608 L: 40791 D: 80327
Penta | [346, 19373, 41573, 19260, 311]
https://recklesschess.space/test/8949/

Bench: 3842239