### PR TITLE
Simplify away low impact FDS reduction rules

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -798,12 +798,7 @@ fn search<NODE: NodeType>(
 
             if tt_pv {
                 reduction -= 750;
-                reduction -= 537 * (is_valid(tt_score) && tt_score > alpha) as i32;
                 reduction -= 1081 * (is_valid(tt_score) && tt_depth >= depth) as i32;
-            }
-
-            if NODE::PV {
-                reduction -= 491 + 780 * (beta - alpha) / td.root_delta;
             }
 
             if !tt_pv && cut_node {
@@ -811,16 +806,8 @@ fn search<NODE: NodeType>(
                 reduction += 1048 * tt_move.is_null() as i32;
             }
 
-            if td.board.in_check() || !td.board.has_non_pawns() {
-                reduction -= 744;
-            }
-
             if td.stack[ply + 1].cutoff_count > 2 {
                 reduction += 1438;
-            }
-
-            if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
-                reduction += 849;
             }
 
             if depth == 2 {


### PR DESCRIPTION
STC
Elo   | 3.05 +- 2.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 15604 W: 3974 L: 3837 D: 7793
Penta | [26, 1816, 3989, 1937, 34]
https://recklesschess.space/test/8941/

LTC
Elo   | 0.80 +- 2.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 24870 W: 6076 L: 6019 D: 12775
Penta | [8, 2858, 6642, 2923, 4]
https://recklesschess.space/test/8947/

Bench: 3666261