### PR TITLE
Simplify away exact bound condition from early TT cutoffs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -271,7 +271,7 @@ fn search<NODE: NodeType>(
 
         if !NODE::PV
             && !excluded
-            && tt_depth > depth - (tt_score <= beta) as i32 - (tt_bound == Bound::Exact) as i32
+            && tt_depth > depth - (tt_score < beta) as i32
             && is_valid(tt_score)
             && match tt_bound {
                 Bound::Upper => tt_score <= alpha && (!cut_node || depth > 5),


### PR DESCRIPTION
Elo   | 1.67 +- 2.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 24274 W: 6127 L: 6010 D: 12137
Penta | [33, 2889, 6194, 2970, 51]
https://recklesschess.space/test/8995/

Bench: 3879389
