### PR TITLE
Speed up stack indexing by allowing negative ply values

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -229,7 +229,7 @@ impl Board {
     }
 
     /// Checks if the position is a known draw by the fifty-move rule or repetition.
-    pub fn is_draw(&self, ply: usize) -> bool {
+    pub fn is_draw(&self, ply: isize) -> bool {
         self.draw_by_fifty_move_rule() || self.draw_by_repetition(ply as i32)
     }
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -62,7 +62,7 @@ impl MovePicker {
         self.stage
     }
 
-    pub fn next<NODE: NodeType>(&mut self, td: &ThreadData, skip_quiets: bool, ply: usize) -> Option<Move> {
+    pub fn next<NODE: NodeType>(&mut self, td: &ThreadData, skip_quiets: bool, ply: isize) -> Option<Move> {
         if self.stage == Stage::HashMove {
             self.stage = Stage::GenerateNoisy;
 
@@ -169,7 +169,7 @@ impl MovePicker {
         }
     }
 
-    fn score_quiet(&mut self, td: &ThreadData, ply: usize) {
+    fn score_quiet(&mut self, td: &ThreadData, ply: isize) {
         let threats = td.board.threats();
         let side = td.board.side_to_move();
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -221,14 +221,8 @@ impl ThreadData {
         self.shared.nodes.get(self.id)
     }
 
-    pub fn conthist(&self, ply: usize, index: usize, mv: Move) -> i32 {
-        if ply < index || self.stack[ply - index].mv.is_null() {
-            return 0;
-        }
-
-        let piece = self.board.piece_on(mv.from());
-        let sq = mv.to();
-        self.continuation_history.get(self.stack[ply - index].conthist, piece, sq)
+    pub fn conthist(&self, ply: isize, index: isize, mv: Move) -> i32 {
+        self.continuation_history.get(self.stack[ply - index].conthist, self.board.piece_on(mv.from()), mv.to())
     }
 
     pub fn print_uci_info(&self, depth: i32) {

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -142,7 +142,7 @@ impl TranspositionTable {
         self.age.store((self.age() + 1) & AGE_MASK, Ordering::Relaxed);
     }
 
-    pub fn read(&self, hash: u64, halfmove_clock: u8, ply: usize) -> Option<Entry> {
+    pub fn read(&self, hash: u64, halfmove_clock: u8, ply: isize) -> Option<Entry> {
         let cluster = {
             let index = index(hash, self.len());
             unsafe { &*self.ptr().add(index) }
@@ -170,7 +170,7 @@ impl TranspositionTable {
 
     #[allow(clippy::too_many_arguments)]
     pub fn write(
-        &self, hash: u64, depth: i32, eval: i32, mut score: i32, bound: Bound, mv: Move, ply: usize, pv: bool,
+        &self, hash: u64, depth: i32, eval: i32, mut score: i32, bound: Bound, mv: Move, ply: isize, pv: bool,
     ) {
         // Used for checking if an entry exists
         debug_assert!(depth != TtDepth::NONE);
@@ -265,7 +265,7 @@ const fn verification_key(hash: u64) -> u16 {
 }
 
 /// Adjust mate distance from "plies from the root" to "plies from the current position".
-const fn score_from_tt(score: i32, ply: usize, halfmove_clock: u8) -> i32 {
+const fn score_from_tt(score: i32, ply: isize, halfmove_clock: u8) -> i32 {
     if score == Score::NONE {
         return Score::NONE;
     }

--- a/src/types/score.rs
+++ b/src/types/score.rs
@@ -18,19 +18,19 @@ impl Score {
     pub const TB_WIN_IN_MAX: i32 = Self::TB_WIN - MAX_PLY as i32;
 }
 
-pub const fn mated_in(ply: usize) -> i32 {
+pub const fn mated_in(ply: isize) -> i32 {
     -Score::MATE + ply as i32
 }
 
-pub const fn mate_in(ply: usize) -> i32 {
+pub const fn mate_in(ply: isize) -> i32 {
     Score::MATE - ply as i32
 }
 
-pub const fn tb_loss_in(ply: usize) -> i32 {
+pub const fn tb_loss_in(ply: isize) -> i32 {
     -Score::TB_WIN + ply as i32
 }
 
-pub const fn tb_win_in(ply: usize) -> i32 {
+pub const fn tb_win_in(ply: isize) -> i32 {
     Score::TB_WIN - ply as i32
 }
 


### PR DESCRIPTION
Elo   | 5.62 +- 3.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11384 W: 2960 L: 2776 D: 5648
Penta | [19, 1126, 3221, 1304, 22]
https://recklesschess.space/test/9002/

Bench: 3763414
