### PR TITLE
Do less singular extensions for former PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -566,7 +566,7 @@ fn search<NODE: NodeType>(
     if !NODE::ROOT && !excluded && potential_singularity && ply < 2 * td.root_depth as isize {
         debug_assert!(is_valid(tt_score));
 
-        let singular_beta = tt_score - depth;
+        let singular_beta = tt_score - depth - depth * (tt_pv && !NODE::PV) as i32;
         let singular_depth = (depth - 1) / 2;
 
         td.stack[ply].excluded = tt_move;


### PR DESCRIPTION
Credits to @Vizvezdenec for the idea

Elo   | 2.79 +- 1.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27116 W: 6771 L: 6553 D: 13792
Penta | [9, 2996, 7328, 3218, 7]
https://recklesschess.space/test/9138/

Bench: 3506941