### PR TITLE
Use weighted average for iterative deepening fail lows

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -113,7 +113,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
             match score {
                 s if s <= alpha => {
-                    beta = (alpha + beta) / 2;
+                    beta = (3 * alpha + beta) / 4;
                     alpha = (score - delta).max(-Score::INFINITE);
                     reduction = 0;
                     delta += delta * 30 / 128;


### PR DESCRIPTION
Elo   | 2.17 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 42898 W: 10852 L: 10584 D: 21462
Penta | [64, 5061, 10952, 5287, 85]
https://recklesschess.space/test/9149/

Bench: 3160751
