### PR TITLE
Simplify 3rd continuation history to align with move picker

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1240,7 +1240,7 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
 }
 
 fn update_continuation_histories(td: &mut ThreadData, ply: isize, piece: Piece, sq: Square, bonus: i32) {
-    for offset in [1, 2, 3, 4, 6] {
+    for offset in [1, 2, 4, 6] {
         let entry = &td.stack[ply - offset];
         if entry.mv.is_some() {
             td.continuation_history.update(entry.conthist, piece, sq, bonus);


### PR DESCRIPTION
Elo   | 1.80 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 23574 W: 5998 L: 5876 D: 11700
Penta | [37, 2804, 5991, 2910, 45]
https://recklesschess.space/test/9164/

Bench: 3706995
