### PR TITLE
Speed up finding the best move list entry

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -147,7 +147,17 @@ impl MovePicker {
     }
 
     fn find_best_score_index(&self) -> usize {
-        self.list.iter().enumerate().max_by_key(|&(_, entry)| entry.score).map_or(0, |(i, _)| i)
+        let mut best_index = 0;
+        let mut best_score = i32::MIN;
+
+        for (index, entry) in self.list.iter().enumerate() {
+            if entry.score >= best_score {
+                best_index = index;
+                best_score = entry.score;
+            }
+        }
+
+        best_index
     }
 
     fn score_noisy(&mut self, td: &ThreadData) {


### PR DESCRIPTION
Elo   | 1.32 +- 1.06 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 100792 W: 26036 L: 25654 D: 49102
Penta | [366, 10621, 28060, 10963, 386]
https://recklesschess.space/test/9173/

Bench: 3706995
