### PR TITLE
Align multi-cut pruning with other fail high score adjustments

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -589,7 +589,7 @@ fn search<NODE: NodeType>(
                 depth += 1;
             }
         } else if score >= beta && !is_decisive(score) {
-            return score;
+            return (score * singular_depth + beta) / (singular_depth + 1);
         } else if tt_score >= beta {
             extension = -2;
         } else if cut_node {


### PR DESCRIPTION
Elo   | 4.29 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16772 W: 4323 L: 4116 D: 8333
Penta | [29, 1859, 4406, 2060, 32]
https://recklesschess.space/test/9194/

Elo   | 4.54 +- 3.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10414 W: 2628 L: 2492 D: 5294
Penta | [2, 1147, 2774, 1281, 3]
https://recklesschess.space/test/9195/

Bench: 3527731
