### PR TITLE
Minimize RFP error rate

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -452,7 +452,10 @@ fn search<NODE: NodeType>(
         && !excluded
         && is_valid(eval)
         && eval >= beta
-        && eval >= beta + 10 * depth * depth + 30 * depth - (75 * improving as i32) + correction_value.abs() / 2
+        && eval
+            >= beta + 10 * depth * depth + 30 * depth - (75 * improving as i32)
+                + correction_value.abs() / 2
+                + 32 * (depth == 1) as i32
         && !is_loss(beta)
         && !is_win(eval)
     {


### PR DESCRIPTION
81% of wrong RFP cutoffs are basically depth 1

Elo   | 1.31 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 110890 W: 28129 L: 27711 D: 55050
Penta | [215, 13128, 28340, 13548, 214]
https://recklesschess.space/test/9207/

Elo   | 1.19 +- 2.73 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 0.35 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14326 W: 3476 L: 3427 D: 7423
Penta | [6, 1600, 3899, 1655, 3]
https://recklesschess.space/test/9210/

Bench: 3887662