### PR TITLE
Simplify delta calculation in iterative deepening

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -122,7 +122,7 @@ pub fn start(td: &mut ThreadData, report: Report) {
                     alpha = (beta - delta).max(alpha);
                     beta = (score + delta).min(Score::INFINITE);
                     reduction += 1;
-                    delta += delta * (50 + 10 * reduction) / 128;
+                    delta += delta * 64 / 128;
                 }
                 _ => {
                     average = if average == Score::NONE { score } else { (average + score) / 2 };


### PR DESCRIPTION
Elo   | 0.93 +- 1.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 37584 W: 9469 L: 9368 D: 18747
Penta | [65, 4480, 9620, 4543, 84]
https://recklesschess.space/test/9271/

Bench: 3423120