### PR TITLE
Simplify history update formulas on TT cutoffs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -288,8 +288,8 @@ fn search<NODE: NodeType>(
             }
         {
             if tt_move.is_quiet() && tt_score >= beta && td.stack[ply - 1].move_count < 4 {
-                let quiet_bonus = (141 * depth - 72).min(1544) + 68 * !cut_node as i32;
-                let conthist_bonus = (99 * depth - 61).min(1509) + 65 * !cut_node as i32;
+                let quiet_bonus = (141 * depth - 72).min(1544);
+                let conthist_bonus = (99 * depth - 61).min(1509);
 
                 td.quiet_history.update(td.board.threats(), td.board.side_to_move(), tt_move, quiet_bonus);
                 update_continuation_histories(td, ply, td.board.moved_piece(tt_move), tt_move.to(), conthist_bonus);


### PR DESCRIPTION
Elo   | 0.43 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 56136 W: 14122 L: 14053 D: 27961
Penta | [111, 6672, 14430, 6747, 108]
https://recklesschess.space/test/9272/

Bench: 3860998