### PR TITLE
Simplify SEE pruning threshold

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -692,7 +692,7 @@ fn search<NODE: NodeType>(
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                -20 * lmr_depth * lmr_depth - 31 * history / 1024 + 5 * lmr_depth * (static_eval < alpha) as i32 + 16
+                -20 * lmr_depth * lmr_depth - 31 * history / 1024 + 23
             } else {
                 -102 * depth - 45 * history / 1024 + 46
             };


### PR DESCRIPTION
Elo   | 0.36 +- 1.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 59330 W: 14872 L: 14810 D: 29648
Penta | [106, 7088, 15245, 7090, 136]
https://recklesschess.space/test/9273/

Bench: 3985749