### PR TITLE
Use L2 prefetch hint for better cache behavior

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -229,11 +229,11 @@ impl TranspositionTable {
     pub fn prefetch(&self, hash: u64) {
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
+            use std::arch::x86_64::{_mm_prefetch, _MM_HINT_T1};
 
             let index = index(hash, self.len());
             let ptr = self.ptr().add(index).cast();
-            _mm_prefetch::<_MM_HINT_T0>(ptr);
+            _mm_prefetch::<_MM_HINT_T1>(ptr);
         }
 
         // No prefetching for non-x86_64 architectures


### PR DESCRIPTION
Elo   | 2.65 +- 1.91 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31240 W: 8073 L: 7835 D: 15332
Penta | [102, 3276, 8643, 3480, 119]
https://recklesschess.space/test/9353/

Bench: 4178897
