### PR TITLE
Recapture extension in LMR as well

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -761,6 +761,10 @@ fn search<NODE: NodeType>(
                 reduction -= 395 + 515 * (beta - alpha) / td.root_delta;
             }
 
+            if NODE::PV && mv.is_noisy() && mv.to() == td.board.recapture_square() {
+                reduction -= 1024;
+            }
+
             if !tt_pv && cut_node {
                 reduction += 1772;
                 reduction += 1078 * tt_move.is_null() as i32;


### PR DESCRIPTION
Elo   | 1.01 +- 0.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 231818 W: 58542 L: 57868 D: 115408
Penta | [437, 27385, 59626, 27989, 472]
https://recklesschess.space/test/9349/

Bench: 4314517