### PR TITLE
Defer correction histories dequantization

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -156,7 +156,7 @@ impl ContinuationCorrectionHistory {
     }
 
     pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square) -> i32 {
-        (unsafe { &*subtable_ptr }[piece][to] as i32)
+        unsafe { (&*subtable_ptr)[piece][to] as i32 }
     }
 
     pub fn update(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square, bonus: i32) {

--- a/src/history.rs
+++ b/src/history.rs
@@ -126,7 +126,7 @@ impl CorrectionHistory {
     const MASK: usize = Self::SIZE - 1;
 
     pub fn get(&self, stm: Color, key: u64) -> i32 {
-        (self.entries[stm][key as usize & Self::MASK] as i32) / 82
+        self.entries[stm][key as usize & Self::MASK] as i32
     }
 
     pub fn update(&mut self, stm: Color, key: u64, bonus: i32) {
@@ -156,7 +156,7 @@ impl ContinuationCorrectionHistory {
     }
 
     pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square) -> i32 {
-        (unsafe { &*subtable_ptr }[piece][to] as i32) / 105
+        (unsafe { &*subtable_ptr }[piece][to] as i32)
     }
 
     pub fn update(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square, bonus: i32) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1233,7 +1233,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 fn correction_value(td: &ThreadData, ply: isize) -> i32 {
     let stm = td.board.side_to_move();
 
-    td.pawn_corrhist.get(stm, td.board.pawn_key())
+    (td.pawn_corrhist.get(stm, td.board.pawn_key())
         + td.minor_corrhist.get(stm, td.board.minor_key())
         + td.major_corrhist.get(stm, td.board.major_key())
         + td.non_pawn_corrhist[Color::White].get(stm, td.board.non_pawn_key(Color::White))
@@ -1247,7 +1247,8 @@ fn correction_value(td: &ThreadData, ply: isize) -> i32 {
             td.stack[ply - 4].contcorrhist,
             td.stack[ply - 1].piece,
             td.stack[ply - 1].mv.to(),
-        )
+        ))
+        / 90
 }
 
 fn corrected_eval(eval: i32, correction_value: i32, hmr: u8) -> i32 {


### PR DESCRIPTION
Elo   | 1.89 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 51950 W: 13160 L: 12878 D: 25912
Penta | [97, 6078, 13331, 6384, 85]
https://recklesschess.space/test/9371/

Bench: 3822028
