### PR TITLE
Replace LMR table with deterministic ilog2 reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -669,7 +669,7 @@ fn search<NODE: NodeType>(
             td.noisy_history.get(td.board.threats(), td.board.moved_piece(mv), mv.to(), captured)
         };
 
-        let mut reduction = td.lmr.reduction(depth, move_count);
+        let mut reduction = (1200 + 264 * depth.ilog2() * move_count.ilog2()) as i32;
 
         if !improving {
             reduction += (461 - 321 * improvement / 128).min(1373);

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -14,7 +14,7 @@ use crate::{
     thread::pool::ScopeExt,
     time::{Limits, TimeManager},
     transposition::TranspositionTable,
-    types::{normalize_to_cp, Move, Score, MAX_MOVES, MAX_PLY},
+    types::{normalize_to_cp, Move, Score, MAX_PLY},
 };
 
 #[repr(align(64))]
@@ -172,7 +172,6 @@ pub struct ThreadData {
     pub major_corrhist: CorrectionHistory,
     pub non_pawn_corrhist: [CorrectionHistory; 2],
     pub continuation_corrhist: ContinuationCorrectionHistory,
-    pub lmr: LmrTable,
     pub best_move_changes: usize,
     pub optimism: [i32; 2],
     pub stopped: bool,
@@ -209,7 +208,6 @@ impl ThreadData {
             major_corrhist: CorrectionHistory::default(),
             non_pawn_corrhist: [CorrectionHistory::default(), CorrectionHistory::default()],
             continuation_corrhist: ContinuationCorrectionHistory::default(),
-            lmr: LmrTable::default(),
             best_move_changes: 0,
             optimism: [0; 2],
             stopped: false,
@@ -371,31 +369,6 @@ impl Default for PrincipalVariationTable {
             table: vec![[Move::NULL; MAX_PLY + 1]; MAX_PLY + 1].into_boxed_slice(),
             len: [0; MAX_PLY + 1],
         }
-    }
-}
-
-pub struct LmrTable {
-    table: Box<[[i32; MAX_MOVES + 1]]>,
-}
-
-impl LmrTable {
-    pub const fn reduction(&self, depth: i32, move_count: i32) -> i32 {
-        self.table[depth as usize][move_count as usize]
-    }
-}
-
-impl Default for LmrTable {
-    fn default() -> Self {
-        let mut table = vec![[0; MAX_MOVES + 1]; MAX_MOVES + 1].into_boxed_slice();
-
-        for depth in 1..MAX_MOVES {
-            for move_count in 1..MAX_MOVES {
-                let reduction = 970.0027 + 457.7087 * (depth as f32).ln() * (move_count as f32).ln();
-                table[depth][move_count] = reduction as i32;
-            }
-        }
-
-        Self { table }
     }
 }
 


### PR DESCRIPTION
Replaces the floating-point LMR table with cheap integer ilog2 reduction to avoid
the issue noted in the docs: "The precision of this function is non-deterministic.
This means it varies by platform, Rust version, and can even differ within the 
same execution from one invocation to the next.”.

Elo   | 0.26 +- 1.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 66872 W: 16659 L: 16609 D: 33604
Penta | [117, 7914, 17328, 7956, 121]
https://recklesschess.space/test/9376/

Bench: 3472986
