### PR TITLE
Use current depth in razoring for consistency

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -475,7 +475,7 @@ fn search<NODE: NodeType>(
     let improving = improvement > 0;
 
     // Razoring
-    if !NODE::PV && !in_check && eval < alpha - 278 - 257 * initial_depth * initial_depth {
+    if !NODE::PV && !in_check && eval < alpha - 278 - 257 * depth * depth {
         return qsearch::<NonPV>(td, alpha, beta, ply);
     }
 


### PR DESCRIPTION
Elo   | -0.18 +- 0.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 130716 W: 32575 L: 32643 D: 65498
Penta | [262, 15549, 33816, 15457, 274]
https://recklesschess.space/test/9367/

Bench: 3933541
