### PR TITLE
Skip quiescence LMP for likely checking moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1164,7 +1164,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
                 break;
             }
 
-            if move_count >= 3 {
+            if move_count >= 3 && !td.board.might_give_check_if_you_squint(mv) {
                 break;
             }
 


### PR DESCRIPTION
Elo   | 2.50 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33962 W: 8559 L: 8315 D: 17088
Penta | [62, 3970, 8684, 4192, 73]
https://recklesschess.space/test/9388/

Bench: 3755992
