### PR TITLE
Apply recapture LMR to non-PV nodes as well

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -761,7 +761,7 @@ fn search<NODE: NodeType>(
                 reduction -= 395 + 515 * (beta - alpha) / td.root_delta;
             }
 
-            if NODE::PV && mv.is_noisy() && mv.to() == td.board.recapture_square() {
+            if mv.is_noisy() && mv.to() == td.board.recapture_square() {
                 reduction -= 1024;
             }
 


### PR DESCRIPTION
Elo   | 0.08 +- 1.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 82218 W: 20662 L: 20642 D: 40914
Penta | [169, 9803, 21129, 9855, 153]
https://recklesschess.space/test/9392/

Bench: 4073791