### PR TITLE
Simplify away null move pruning conditions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -493,8 +493,6 @@ fn search<NODE: NodeType>(
         && !in_check
         && !excluded
         && !potential_singularity
-        && estimated_score >= beta
-        && estimated_score >= eval
         && eval >= beta - 11 * depth + 140 * tt_pv as i32 - 113 * improvement / 1024 + 252
         && ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()


### PR DESCRIPTION
Elo   | 0.01 +- 1.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 91980 W: 23063 L: 23061 D: 45856
Penta | [183, 10974, 23686, 10952, 195]
https://recklesschess.space/test/9402/

Bench: 3888357