### PR TITLE
Improve matefinding

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -469,7 +469,7 @@ fn search<NODE: NodeType>(
     let improving = improvement > 0;
 
     // Razoring
-    if !NODE::PV && !in_check && estimated_score < alpha - 278 - 257 * depth * depth {
+    if !NODE::PV && !in_check && estimated_score < alpha - 278 - 257 * depth * depth && alpha < 2048 {
         return qsearch::<NonPV>(td, alpha, beta, ply);
     }
 


### PR DESCRIPTION
Using main on matetrack.epd with --nodes 1000000
Engine ID:     Reckless 0.9.0-dev-1928fb99
Total FENs:    6554
Found mates:   3168
Best mates:    2145

Using patch on matetrack.epd with --nodes 1000000
Engine ID:     Reckless 0.9.0-dev-14341ed1
Total FENs:    6554
Found mates:   3314
Best mates:    2269

Elo   | 0.09 +- 1.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 81688 W: 20549 L: 20527 D: 40612
Penta | [140, 8552, 23413, 8624, 115]
https://recklesschess.space/test/9408/

Bench: 4535508
