### PR TITLE
Adjust thread limit based on available logical CPU cores

### DIFF
--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -15,6 +15,15 @@ pub struct ThreadPool {
 }
 
 impl ThreadPool {
+    pub fn available_threads() -> usize {
+        const MINIMUM_THREADS: usize = 512;
+
+        match std::thread::available_parallelism() {
+            Ok(threads) => (4 * threads.get()).max(MINIMUM_THREADS),
+            Err(_) => MINIMUM_THREADS,
+        }
+    }
+
     pub fn new(shared: Arc<SharedContext>) -> Self {
         let workers = make_worker_threads(1);
         let data = make_thread_data(shared, &workers);

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -93,7 +93,7 @@ fn uci() {
     println!("id name Reckless {}", env!("ENGINE_VERSION"));
     println!("id author Arseniy Surkov, Shahin M. Shahin, and Styx");
     println!("option name Hash type spin default {DEFAULT_TT_SIZE} min 1 max 262144");
-    println!("option name Threads type spin default 1 min 1 max 512");
+    println!("option name Threads type spin default 1 min 1 max {}", ThreadPool::available_threads());
     println!("option name MoveOverhead type spin default 100 min 0 max 2000");
     println!("option name Minimal type check default false");
     println!("option name Clear Hash type button");


### PR DESCRIPTION
Changes the fixed 512-thread limit to four times the number of logical
CPU cores with a minimum of 512 to ensure high-end machines can 
make full use of their available CPUs.

Elo   | -0.21 +- 1.75 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.12 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 36334 W: 9253 L: 9275 D: 17806
Penta | [132, 3842, 10230, 3842, 121]
https://recklesschess.space/test/9422/

Bench: 4535508
