### PR TITLE
Decouple raw evaluation from adjustments

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -28,6 +28,7 @@ struct InternalState {
     en_passant: Square,
     castling: Castling,
     halfmove_clock: u8,
+    material: i32,
     plies_from_null: i32,
     repetition: i32,
     captured: Option<Piece>,
@@ -123,6 +124,10 @@ impl Board {
 
     pub const fn halfmove_clock(&self) -> u8 {
         self.state.halfmove_clock
+    }
+
+    pub const fn material(&self) -> i32 {
+        self.state.material
     }
 
     pub const fn in_check(&self) -> bool {

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -1,5 +1,8 @@
 use super::Board;
-use crate::types::{Bitboard, Move, MoveKind, Piece, PieceType, Square, ZOBRIST};
+use crate::{
+    parameters::PIECE_VALUES,
+    types::{Bitboard, Move, MoveKind, Piece, PieceType, Square, ZOBRIST},
+};
 
 impl Board {
     pub fn make_null_move(&mut self) {
@@ -63,6 +66,7 @@ impl Board {
             self.remove_piece(captured, to);
             self.update_hash(captured, to);
 
+            self.state.material -= PIECE_VALUES[captured.piece_type()];
             self.state.captured = Some(captured);
             self.state.recapture_square = to;
         }
@@ -85,6 +89,8 @@ impl Board {
 
                 self.remove_piece(captured, to ^ 8);
                 self.update_hash(captured, to ^ 8);
+
+                self.state.material -= PIECE_VALUES[captured.piece_type()];
             }
             MoveKind::Castling => {
                 let (rook_from, rook_to) = self.get_castling_rook(to);
@@ -107,6 +113,8 @@ impl Board {
 
                 self.update_hash(piece, to);
                 self.update_hash(promotion, to);
+
+                self.state.material += PIECE_VALUES[promotion.piece_type()] - PIECE_VALUES[PieceType::Pawn];
             }
             _ => (),
         }

--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -1,6 +1,7 @@
 use super::Board;
 use crate::{
     lookup::between,
+    parameters::PIECE_VALUES,
     types::{CastlingKind, Color, Piece, PieceType, Square},
 };
 
@@ -40,6 +41,7 @@ impl Board {
                 let square = Square::from_rank_file(rank as u8, file);
 
                 board.add_piece(piece, square);
+                board.state.material += PIECE_VALUES[piece.piece_type()];
                 file += 1;
             }
         }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,5 +1,0 @@
-use crate::thread::ThreadData;
-
-pub fn evaluate(td: &mut ThreadData) -> i32 {
-    td.nnue.evaluate(&td.board)
-}

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -1,26 +1,5 @@
-use crate::{
-    board::Board,
-    parameters::PIECE_VALUES,
-    thread::ThreadData,
-    types::{PieceType, Score},
-};
+use crate::thread::ThreadData;
 
-/// Calculates the raw evaluation of the current position from the perspective of the side to move before corrections.
 pub fn evaluate(td: &mut ThreadData) -> i32 {
-    let mut raw_eval = td.nnue.evaluate(&td.board);
-
-    let material = material(&td.board);
-
-    raw_eval = (raw_eval * (21366 + material) + td.optimism[td.board.side_to_move()] * (1747 + material)) / 27395;
-
-    raw_eval = (raw_eval / 16) * 16 - 1 + (td.board.hash() & 0x2) as i32;
-
-    raw_eval.clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1)
-}
-
-fn material(board: &Board) -> i32 {
-    [PieceType::Pawn, PieceType::Knight, PieceType::Bishop, PieceType::Rook, PieceType::Queen]
-        .iter()
-        .map(|&pt| board.pieces(pt).len() as i32 * PIECE_VALUES[pt])
-        .sum::<i32>()
+    td.nnue.evaluate(&td.board)
 }

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,0 +1,17 @@
+use crate::{thread::ThreadData, types::Score};
+
+pub fn correct_eval(td: &ThreadData, raw_eval: i32, correction_value: i32) -> i32 {
+    let mut eval = (raw_eval * (21366 + td.board.material())
+        + td.optimism[td.board.side_to_move()] * (1747 + td.board.material()))
+        / 27395;
+
+    eval = (eval / 16) * 16;
+
+    eval += (td.board.hash() & 0x2) as i32 - 1;
+
+    eval = eval * (200 - td.board.halfmove_clock() as i32) / 200;
+
+    eval += correction_value;
+
+    eval.clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::if_same_then_else)]
 
 mod board;
-mod evaluate;
+mod evaluation;
 mod history;
 mod lookup;
 mod misc;

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,4 @@
 use crate::{
-    board::Board,
     evaluate::evaluate,
     movepick::{MovePicker, Stage},
     parameters::PIECE_VALUES,
@@ -8,7 +7,7 @@ use crate::{
     transposition::{Bound, TtDepth},
     types::{
         is_decisive, is_loss, is_valid, is_win, mate_in, mated_in, tb_loss_in, tb_win_in, ArrayVec, Color, Move, Piece,
-        PieceType, Score, Square, MAX_PLY,
+        Score, Square, MAX_PLY,
     },
 };
 
@@ -1244,15 +1243,8 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
         / 90
 }
 
-fn material(board: &Board) -> i32 {
-    [PieceType::Pawn, PieceType::Knight, PieceType::Bishop, PieceType::Rook, PieceType::Queen]
-        .iter()
-        .map(|&pt| board.pieces(pt).len() as i32 * PIECE_VALUES[pt])
-        .sum::<i32>()
-}
-
 fn corrected_eval(td: &ThreadData, raw_eval: i32, correction_value: i32, hmr: u8) -> i32 {
-    let material = material(&td.board);
+    let material = td.board.material();
 
     let mut eval = (raw_eval * (21366 + material) + td.optimism[td.board.side_to_move()] * (1747 + material)) / 27395;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::{
-    evaluate::evaluate,
+    evaluation::correct_eval,
     movepick::{MovePicker, Stage},
     parameters::PIECE_VALUES,
     tb::{tb_probe, tb_rank_rootmoves, tb_size, GameOutcome},
@@ -274,7 +274,7 @@ fn search<NODE: NodeType>(
         }
 
         if ply as usize >= MAX_PLY - 1 {
-            return if in_check { Score::DRAW } else { evaluate(td) };
+            return if in_check { Score::DRAW } else { td.nnue.evaluate(&td.board) };
         }
 
         // Mate Distance Pruning (MDP)
@@ -383,11 +383,11 @@ fn search<NODE: NodeType>(
         raw_eval = Score::NONE;
         eval = td.stack[ply].eval;
     } else if let Some(entry) = &entry {
-        raw_eval = if is_valid(entry.raw_eval) { entry.raw_eval } else { evaluate(td) };
-        eval = corrected_eval(td, raw_eval, correction_value, td.board.halfmove_clock());
+        raw_eval = if is_valid(entry.raw_eval) { entry.raw_eval } else { td.nnue.evaluate(&td.board) };
+        eval = correct_eval(td, raw_eval, correction_value);
     } else {
-        raw_eval = evaluate(td);
-        eval = corrected_eval(td, raw_eval, correction_value, td.board.halfmove_clock());
+        raw_eval = td.nnue.evaluate(&td.board);
+        eval = correct_eval(td, raw_eval, correction_value);
 
         td.shared.tt.write(hash, TtDepth::SOME, raw_eval, Score::NONE, Bound::None, Move::NULL, ply, tt_pv, false);
     }
@@ -1062,7 +1062,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     }
 
     if ply as usize >= MAX_PLY - 1 {
-        return if in_check { Score::DRAW } else { evaluate(td) };
+        return if in_check { Score::DRAW } else { td.nnue.evaluate(&td.board) };
     }
 
     let hash = td.board.hash();
@@ -1097,9 +1097,9 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     if !in_check {
         raw_eval = match &entry {
             Some(entry) if is_valid(entry.raw_eval) => entry.raw_eval,
-            _ => evaluate(td),
+            _ => td.nnue.evaluate(&td.board),
         };
-        best_score = corrected_eval(td, raw_eval, eval_correction(td, ply), td.board.halfmove_clock());
+        best_score = correct_eval(td, raw_eval, eval_correction(td, ply));
 
         if is_valid(tt_score)
             && (!NODE::PV || !is_decisive(tt_score))
@@ -1241,16 +1241,6 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
             td.stack[ply - 1].mv.to(),
         ))
         / 90
-}
-
-fn corrected_eval(td: &ThreadData, raw_eval: i32, correction_value: i32, hmr: u8) -> i32 {
-    let material = td.board.material();
-
-    let mut eval = (raw_eval * (21366 + material) + td.optimism[td.board.side_to_move()] * (1747 + material)) / 27395;
-
-    eval = (eval / 16) * 16 - 1 + (td.board.hash() & 0x2) as i32;
-
-    (eval * (200 - hmr as i32) / 200 + correction_value).clamp(-Score::TB_WIN_IN_MAX + 1, Score::TB_WIN_IN_MAX - 1)
 }
 
 fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: isize) {


### PR DESCRIPTION
Elo   | 2.23 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 21142 W: 5345 L: 5209 D: 10588
Penta | [31, 2484, 5417, 2596, 43]
https://recklesschess.space/test/9459/

Bench: 4085577