### PR TITLE
Update NNUE architecture to `(79856 + 768x10 -> 384)x2 -> 16 -> 32 -> 1`

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -10,8 +10,8 @@ mod attacks;
 mod magics;
 mod maps;
 
-const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/raw/main";
-const NETWORK_NAME: &str = "v46-e44f9d34.nnue";
+const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
+const NETWORK_NAME: &str = "v47-73c00ea0.nnue";
 
 fn main() {
     generate_model_env();

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,7 +1,7 @@
 use crate::{
     lookup::{
-        between, bishop_attacks, cuckoo, cuckoo_a, cuckoo_b, h1, h2, king_attacks, knight_attacks, pawn_attacks,
-        queen_attacks, rook_attacks,
+        attacks, between, bishop_attacks, cuckoo, cuckoo_a, cuckoo_b, h1, h2, king_attacks, knight_attacks,
+        pawn_attacks, queen_attacks, rook_attacks,
     },
     types::{ArrayVec, Bitboard, Castling, CastlingKind, Color, Move, Piece, PieceType, Square, ZOBRIST},
 };
@@ -453,15 +453,7 @@ impl Board {
     /// en passant, or checks delivered via castling.
     pub fn might_give_check_if_you_squint(&self, mv: Move) -> bool {
         let occupancies = self.occupancies() ^ mv.from().to_bb() ^ mv.to().to_bb();
-        let direct_attacks = match self.moved_piece(mv).piece_type() {
-            PieceType::Pawn => pawn_attacks(mv.to(), self.side_to_move),
-            PieceType::Knight => knight_attacks(mv.to()),
-            PieceType::Bishop => bishop_attacks(mv.to(), occupancies),
-            PieceType::Rook => rook_attacks(mv.to(), occupancies),
-            PieceType::Queen => queen_attacks(mv.to(), occupancies),
-            _ => Bitboard::default(),
-        };
-
+        let direct_attacks = attacks(self.moved_piece(mv), mv.to(), occupancies);
         direct_attacks.contains(self.their(PieceType::King).lsb())
     }
 

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -34,7 +34,7 @@ impl Board {
     ///
     /// This method assumes the move has been validated as pseudo-legal and legal
     /// per `Board::is_pseudo_legal` and `Board::is_legal`.
-    pub fn make_move(&mut self, mv: Move) {
+    pub fn make_move<F: FnMut(&Board, Piece, Square, bool)>(&mut self, mv: Move, mut on_piece_change: F) {
         let from = mv.from();
         let to = mv.to();
         let piece = self.piece_on(from);
@@ -64,6 +64,8 @@ impl Board {
         let captured = self.piece_on(to);
         if captured != Piece::None && !mv.is_castling() {
             self.remove_piece(captured, to);
+            on_piece_change(self, captured, to, false);
+
             self.update_hash(captured, to);
 
             self.state.material -= PIECE_VALUES[captured.piece_type()];
@@ -73,7 +75,10 @@ impl Board {
 
         if !mv.is_castling() {
             self.remove_piece(piece, from);
+            on_piece_change(self, piece, from, false);
+
             self.add_piece(piece, to);
+            on_piece_change(self, piece, to, true);
         }
 
         self.update_hash(piece, from);
@@ -88,6 +93,8 @@ impl Board {
                 let captured = Piece::new(!stm, PieceType::Pawn);
 
                 self.remove_piece(captured, to ^ 8);
+                on_piece_change(self, captured, to ^ 8, false);
+
                 self.update_hash(captured, to ^ 8);
 
                 self.state.material -= PIECE_VALUES[captured.piece_type()];
@@ -97,10 +104,16 @@ impl Board {
                 let rook = Piece::new(stm, PieceType::Rook);
 
                 self.remove_piece(rook, rook_from);
+                on_piece_change(self, rook, rook_from, false);
+
                 self.remove_piece(piece, from);
+                on_piece_change(self, piece, from, false);
 
                 self.add_piece(rook, rook_to);
+                on_piece_change(self, rook, rook_to, true);
+
                 self.add_piece(piece, to);
+                on_piece_change(self, piece, to, true);
 
                 self.update_hash(rook, rook_from);
                 self.update_hash(rook, rook_to);
@@ -109,7 +122,10 @@ impl Board {
                 let promotion = Piece::new(stm, mv.promotion_piece().unwrap());
 
                 self.remove_piece(piece, to);
+                on_piece_change(self, piece, to, false);
+
                 self.add_piece(promotion, to);
+                on_piece_change(self, promotion, to, true);
 
                 self.update_hash(piece, to);
                 self.update_hash(promotion, to);

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -29,7 +29,7 @@ fn perft(board: &mut Board, depth: usize) -> u32 {
         let mv = entry.mv;
 
         if board.is_legal(mv) {
-            board.make_move(mv);
+            board.make_move(mv, |_, _, _, _| ());
             nodes += if depth > 1 { perft(board, depth - 1) } else { 1 };
             board.undo_move(mv);
         }

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -108,6 +108,18 @@ pub fn ray_pass(a: Square, b: Square) -> Bitboard {
     unsafe { RAY_PASS[a as usize][b as usize] }
 }
 
+pub fn attacks(piece: Piece, square: Square, occupancies: Bitboard) -> Bitboard {
+    match piece.piece_type() {
+        PieceType::Pawn => pawn_attacks(square, piece.piece_color()),
+        PieceType::Knight => knight_attacks(square),
+        PieceType::Bishop => bishop_attacks(square, occupancies),
+        PieceType::Rook => rook_attacks(square, occupancies),
+        PieceType::Queen => queen_attacks(square, occupancies),
+        PieceType::King => king_attacks(square),
+        _ => Bitboard(0),
+    }
+}
+
 pub fn pawn_attacks(square: Square, color: Color) -> Bitboard {
     unsafe {
         match color {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod bindings;
 
 fn main() {
     lookup::init();
+    nnue::initialize();
 
     match std::env::args().nth(1).as_deref() {
         Some("bench") => tools::bench::<false>(None),

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -43,7 +43,7 @@ const NETWORK_SCALE: i32 = 400;
 
 const INPUT_BUCKETS: usize = 10;
 
-const L1_SIZE: usize = 256;
+const L1_SIZE: usize = 384;
 const L2_SIZE: usize = 16;
 const L3_SIZE: usize = 32;
 

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -1,11 +1,14 @@
 use crate::{
     board::Board,
-    types::{Color, Move, PieceType, MAX_PLY},
+    lookup::{bishop_attacks, king_attacks, knight_attacks, pawn_attacks, queen_attacks, ray_pass, rook_attacks},
+    nnue::accumulator::{ThreatAccumulator, ThreatDelta},
+    types::{Color, Move, Piece, PieceType, Square, MAX_PLY},
 };
 
-use accumulator::{Accumulator, AccumulatorCache};
+use accumulator::{AccumulatorCache, PstAccumulator};
 
 mod accumulator;
+mod threats;
 
 mod forward {
     #[cfg(target_feature = "avx2")]
@@ -40,8 +43,7 @@ const NETWORK_SCALE: i32 = 400;
 
 const INPUT_BUCKETS: usize = 10;
 
-const FT_SIZE: usize = 768;
-const L1_SIZE: usize = 1024;
+const L1_SIZE: usize = 256;
 const L2_SIZE: usize = 16;
 const L3_SIZE: usize = 32;
 
@@ -77,7 +79,8 @@ struct SparseEntry {
 #[derive(Clone)]
 pub struct Network {
     index: usize,
-    stack: Box<[Accumulator]>,
+    pst_stack: Box<[PstAccumulator]>,
+    threat_stack: Box<[ThreatAccumulator]>,
     cache: AccumulatorCache,
     nnz_table: Box<[SparseEntry]>,
 }
@@ -87,10 +90,61 @@ impl Network {
         debug_assert!(mv.is_some());
 
         self.index += 1;
-        self.stack[self.index].accurate = [false; 2];
-        self.stack[self.index].delta.mv = mv;
-        self.stack[self.index].delta.piece = board.piece_on(mv.from());
-        self.stack[self.index].delta.captured = board.piece_on(mv.to());
+
+        self.pst_stack[self.index].accurate = [false; 2];
+        self.pst_stack[self.index].delta.mv = mv;
+        self.pst_stack[self.index].delta.piece = board.piece_on(mv.from());
+        self.pst_stack[self.index].delta.captured = board.piece_on(mv.to());
+
+        self.threat_stack[self.index].accurate = [false; 2];
+        self.threat_stack[self.index].delta.clear();
+    }
+
+    pub fn push_threats(&mut self, board: &Board, piece: Piece, square: Square, add: bool) {
+        let deltas = &mut self.threat_stack[self.index].delta;
+
+        let attacked = match piece.piece_type() {
+            PieceType::Pawn => pawn_attacks(square, piece.piece_color()),
+            PieceType::Knight => knight_attacks(square),
+            PieceType::Bishop => bishop_attacks(square, board.occupancies()),
+            PieceType::Rook => rook_attacks(square, board.occupancies()),
+            PieceType::Queen => queen_attacks(square, board.occupancies()),
+            PieceType::King => king_attacks(square),
+            _ => unreachable!(),
+        } & board.occupancies();
+
+        for to in attacked {
+            let attacked = board.piece_on(to);
+            deltas.push(ThreatDelta::new(piece, square, attacked, to, add));
+        }
+
+        let rook_attacks = rook_attacks(square, board.occupancies());
+        let bishop_attacks = bishop_attacks(square, board.occupancies());
+        let queen_attacks = rook_attacks | bishop_attacks;
+
+        let diagonal = (board.pieces(PieceType::Bishop) | board.pieces(PieceType::Queen)) & bishop_attacks;
+        let orthogonal = (board.pieces(PieceType::Rook) | board.pieces(PieceType::Queen)) & rook_attacks;
+
+        for from in diagonal | orthogonal {
+            let sliding_piece = board.piece_on(from);
+            let threatened = ray_pass(from, square) & board.occupancies() & queen_attacks;
+
+            if let Some(to) = threatened.into_iter().next() {
+                deltas.push(ThreatDelta::new(sliding_piece, from, board.piece_on(to), to, !add));
+            }
+
+            deltas.push(ThreatDelta::new(sliding_piece, from, piece, square, add));
+        }
+
+        let black_pawns = board.of(PieceType::Pawn, Color::Black) & pawn_attacks(square, Color::White);
+        let white_pawns = board.of(PieceType::Pawn, Color::White) & pawn_attacks(square, Color::Black);
+
+        let knights = board.pieces(PieceType::Knight) & knight_attacks(square);
+        let kings = board.pieces(PieceType::King) & king_attacks(square);
+
+        for from in black_pawns | white_pawns | knights | kings {
+            deltas.push(ThreatDelta::new(board.piece_on(from), from, piece, square, add));
+        }
     }
 
     pub fn pop(&mut self) {
@@ -98,70 +152,104 @@ impl Network {
     }
 
     pub fn full_refresh(&mut self, board: &Board) {
-        self.refresh(board, Color::White);
-        self.refresh(board, Color::Black);
+        self.pst_stack[self.index].refresh(board, Color::White, &mut self.cache);
+        self.pst_stack[self.index].refresh(board, Color::Black, &mut self.cache);
+
+        self.threat_stack[self.index].refresh(board, Color::White);
+        self.threat_stack[self.index].refresh(board, Color::Black);
     }
 
     pub fn evaluate(&mut self, board: &Board) -> i32 {
-        debug_assert!(self.stack[0].accurate == [true; 2]);
+        debug_assert!(self.pst_stack[0].accurate == [true; 2]);
+        debug_assert!(self.threat_stack[0].accurate == [true; 2]);
 
         for pov in [Color::White, Color::Black] {
-            if self.stack[self.index].accurate[pov] {
+            if self.pst_stack[self.index].accurate[pov] && self.threat_stack[self.index].accurate[pov] {
                 continue;
             }
 
-            if self.can_update(pov) {
-                self.update_accumulator(board, pov);
-            } else {
-                self.refresh(board, pov);
+            match self.can_update_pst(pov) {
+                Some(index) => self.update_pst_accumulator(index, board, pov),
+                None => self.pst_stack[self.index].refresh(board, pov, &mut self.cache),
+            }
+
+            match self.can_update_threats(pov) {
+                Some(index) => self.update_threat_accumulator(index, board, pov),
+                None => self.threat_stack[self.index].refresh(board, pov),
             }
         }
 
         self.output_transformer(board)
     }
 
-    fn refresh(&mut self, board: &Board, pov: Color) {
-        self.stack[self.index].refresh(board, pov, &mut self.cache);
-    }
-
-    fn update_accumulator(&mut self, board: &Board, pov: Color) {
+    fn update_pst_accumulator(&mut self, accurate: usize, board: &Board, pov: Color) {
         let king = board.king_square(pov);
-        let index = (0..self.index).rfind(|&i| self.stack[i].accurate[pov]).unwrap();
 
-        for i in index..self.index {
-            if let (prev, [current, ..]) = self.stack.split_at_mut(i + 1) {
+        for i in accurate..self.index {
+            if let (prev, [current, ..]) = self.pst_stack.split_at_mut(i + 1) {
                 current.update(&prev[i], board, king, pov);
             }
         }
     }
 
-    fn can_update(&self, pov: Color) -> bool {
-        for i in (0..=self.index).rev() {
-            let delta = &self.stack[i].delta;
+    fn update_threat_accumulator(&mut self, accurate: usize, board: &Board, pov: Color) {
+        let king = board.king_square(pov);
 
-            let (from, to) = match delta.piece.piece_color() {
-                Color::White => (delta.mv.from(), delta.mv.to()),
-                Color::Black => (delta.mv.from() ^ 56, delta.mv.to() ^ 56),
-            };
+        for i in accurate..self.index {
+            if let (prev, [current, ..]) = self.threat_stack.split_at_mut(i + 1) {
+                current.update(&prev[i], king, pov);
+            }
+        }
+    }
+
+    fn can_update_pst(&self, pov: Color) -> Option<usize> {
+        for i in (0..=self.index).rev() {
+            if self.pst_stack[i].accurate[pov] {
+                return Some(i);
+            }
+
+            let delta = &self.pst_stack[i].delta;
+
+            let from = delta.mv.from() ^ (56 * (delta.piece.piece_color() as u8));
+            let to = delta.mv.to() ^ (56 * (delta.piece.piece_color() as u8));
 
             if delta.piece.piece_type() == PieceType::King
                 && delta.piece.piece_color() == pov
                 && ((from.file() >= 4) != (to.file() >= 4) || BUCKETS[from] != BUCKETS[to])
             {
-                return false;
-            }
-
-            if self.stack[i].accurate[pov] {
-                return true;
+                return None;
             }
         }
 
-        false
+        None
+    }
+
+    fn can_update_threats(&self, pov: Color) -> Option<usize> {
+        for i in (0..=self.index).rev() {
+            if self.threat_stack[i].accurate[pov] {
+                return Some(i);
+            }
+
+            let delta = &self.pst_stack[i].delta;
+
+            let from = delta.mv.from() ^ (56 * (delta.piece.piece_color() as u8));
+            let to = delta.mv.to() ^ (56 * (delta.piece.piece_color() as u8));
+
+            if delta.piece.piece_type() == PieceType::King
+                && delta.piece.piece_color() == pov
+                && (from.file() >= 4) != (to.file() >= 4)
+            {
+                return None;
+            }
+        }
+
+        None
     }
 
     fn output_transformer(&self, board: &Board) -> i32 {
         unsafe {
-            let ft_out = forward::activate_ft(&self.stack[self.index], board.side_to_move());
+            let ft_out =
+                forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
 
             let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count]);
@@ -192,7 +280,8 @@ impl Default for Network {
 
         Self {
             index: 0,
-            stack: vec![Accumulator::new(); MAX_PLY].into_boxed_slice(),
+            pst_stack: vec![PstAccumulator::new(); MAX_PLY].into_boxed_slice(),
+            threat_stack: vec![ThreatAccumulator::new(); MAX_PLY].into_boxed_slice(),
             cache: AccumulatorCache::default(),
             nnz_table: nnz_table.into_boxed_slice(),
         }
@@ -201,7 +290,8 @@ impl Default for Network {
 
 #[repr(C)]
 struct Parameters {
-    ft_weights: Aligned<[[i16; L1_SIZE]; INPUT_BUCKETS * FT_SIZE]>,
+    ft_threat_weights: Aligned<[[i16; L1_SIZE]; 79856]>,
+    ft_piece_weights: Aligned<[[i16; L1_SIZE]; INPUT_BUCKETS * 768]>,
     ft_biases: Aligned<[i16; L1_SIZE]>,
     l1_weights: Aligned<[i8; L2_SIZE * L1_SIZE]>,
     l1_biases: Aligned<[f32; L2_SIZE]>,

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -290,7 +290,7 @@ impl Default for Network {
 
 #[repr(C)]
 struct Parameters {
-    ft_threat_weights: Aligned<[[i16; L1_SIZE]; 79856]>,
+    ft_threat_weights: Aligned<[[i8; L1_SIZE]; 79856]>,
     ft_piece_weights: Aligned<[[i16; L1_SIZE]; INPUT_BUCKETS * 768]>,
     ft_biases: Aligned<[i16; L1_SIZE]>,
     l1_weights: Aligned<[i8; L2_SIZE * L1_SIZE]>,

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -296,7 +296,7 @@ impl ThreatAccumulator {
                     let offset = offsets::END * (piece.piece_color() != pov) as usize + index;
 
                     for i in 0..L1_SIZE {
-                        self.values[pov][i] += PARAMETERS.ft_threat_weights[offset][i];
+                        self.values[pov][i] += PARAMETERS.ft_threat_weights[offset][i] as i16;
                     }
                 }
             }
@@ -319,11 +319,11 @@ impl ThreatAccumulator {
 
                 if add {
                     for i in 0..L1_SIZE {
-                        self.values[pov][i] += PARAMETERS.ft_threat_weights[offset][i];
+                        self.values[pov][i] += PARAMETERS.ft_threat_weights[offset][i] as i16;
                     }
                 } else {
                     for i in 0..L1_SIZE {
-                        self.values[pov][i] -= PARAMETERS.ft_threat_weights[offset][i];
+                        self.values[pov][i] -= PARAMETERS.ft_threat_weights[offset][i] as i16;
                     }
                 }
             }

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -183,7 +183,7 @@ impl PstAccumulator {
 }
 
 unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<usize, 32>, subs: ArrayVec<usize, 32>) {
-    const REGISTERS: usize = 8;
+    const REGISTERS: usize = 6;
 
     let mut registers: [_; REGISTERS] = std::mem::zeroed();
 

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -187,22 +187,21 @@ impl PstAccumulator {
 }
 
 unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<usize, 32>, subs: ArrayVec<usize, 32>) {
-    const REGISTERS: usize = 16;
+    const REGISTERS: usize = 8;
 
     let mut registers: [_; REGISTERS] = std::mem::zeroed();
 
     for offset in (0..L1_SIZE).step_by(REGISTERS * simd::I16_LANES) {
         let output = entry.values.as_mut_ptr().add(offset);
-        let registers_len = (L1_SIZE.saturating_sub(offset) + simd::I16_LANES - 1) / simd::I16_LANES;
 
-        for (i, register) in registers.iter_mut().take(registers_len).enumerate() {
+        for (i, register) in registers.iter_mut().enumerate() {
             *register = *output.add(i * simd::I16_LANES).cast();
         }
 
         for &add in adds.iter() {
             let weights = PARAMETERS.ft_piece_weights[add].as_ptr().add(offset);
 
-            for (i, register) in registers.iter_mut().take(registers_len).enumerate() {
+            for (i, register) in registers.iter_mut().enumerate() {
                 *register = simd::add_i16(*register, *weights.add(i * simd::I16_LANES).cast());
             }
         }
@@ -210,12 +209,12 @@ unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<usize, 32>, subs:
         for &sub in subs.iter() {
             let weights = PARAMETERS.ft_piece_weights[sub].as_ptr().add(offset);
 
-            for (i, register) in registers.iter_mut().take(registers_len).enumerate() {
+            for (i, register) in registers.iter_mut().enumerate() {
                 *register = simd::sub_i16(*register, *weights.add(i * simd::I16_LANES).cast());
             }
         }
 
-        for (i, register) in registers.into_iter().take(registers_len).enumerate() {
+        for (i, register) in registers.into_iter().enumerate() {
             *output.add(i * simd::I16_LANES).cast() = register;
         }
     }

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -308,6 +308,9 @@ impl ThreatAccumulator {
     pub fn update(&mut self, prev: &Self, king: Square, pov: Color) {
         self.values[pov] = prev.values[pov];
 
+        let mut adds = ArrayVec::<usize, 256>::new();
+        let mut subs = ArrayVec::<usize, 256>::new();
+
         for &ThreatDelta { piece, attacked, from, to, add } in self.delta.iter() {
             let from = from as usize ^ (56 * (pov as usize)) ^ (7 * ((king.file() >= 4) as usize));
             let to = to as usize ^ (56 * (pov as usize)) ^ (7 * ((king.file() >= 4) as usize));
@@ -315,20 +318,69 @@ impl ThreatAccumulator {
             let target = 6 * (attacked.piece_color() != pov) as usize + attacked.piece_type() as usize;
 
             if let Some(index) = threat_index(piece, from, to, target, pov) {
-                let offset = offsets::END * (piece.piece_color() != pov) as usize + index;
+                let feature = offsets::END * (piece.piece_color() != pov) as usize + index;
 
                 if add {
-                    for i in 0..L1_SIZE {
-                        self.values[pov][i] += PARAMETERS.ft_threat_weights[offset][i] as i16;
-                    }
+                    adds.push(feature);
                 } else {
-                    for i in 0..L1_SIZE {
-                        self.values[pov][i] -= PARAMETERS.ft_threat_weights[offset][i] as i16;
-                    }
+                    subs.push(feature);
                 }
             }
         }
 
+        while !adds.is_empty() && !subs.is_empty() {
+            let add = adds.pop().unwrap();
+            let sub = subs.pop().unwrap();
+
+            unsafe { add1_sub1(&mut self.values[pov], add, sub) }
+        }
+
+        for &add in adds.iter() {
+            unsafe { add1(&mut self.values[pov], add) }
+        }
+
+        for &sub in subs.iter() {
+            unsafe { sub1(&mut self.values[pov], sub) }
+        }
+
         self.accurate[pov] = true;
+    }
+}
+
+unsafe fn add1_sub1(output: &mut [i16], add1: usize, sub1: usize) {
+    let vacc = output.as_mut_ptr();
+    let vadd1 = PARAMETERS.ft_threat_weights[add1].as_ptr();
+    let vsub1 = PARAMETERS.ft_threat_weights[sub1].as_ptr();
+
+    for i in (0..L1_SIZE).step_by(simd::I16_LANES) {
+        let mut v = *vacc.add(i).cast();
+        v = simd::add_i16(v, simd::convert_i8_i16(*vadd1.add(i).cast()));
+        v = simd::sub_i16(v, simd::convert_i8_i16(*vsub1.add(i).cast()));
+
+        *vacc.add(i).cast() = v;
+    }
+}
+
+unsafe fn add1(output: &mut [i16], add1: usize) {
+    let vacc = output.as_mut_ptr();
+    let vadd1 = PARAMETERS.ft_threat_weights[add1].as_ptr();
+
+    for i in (0..L1_SIZE).step_by(simd::I16_LANES) {
+        let mut v = *vacc.add(i).cast();
+        v = simd::add_i16(v, simd::convert_i8_i16(*vadd1.add(i).cast()));
+
+        *vacc.add(i).cast() = v;
+    }
+}
+
+unsafe fn sub1(output: &mut [i16], sub1: usize) {
+    let vacc = output.as_mut_ptr();
+    let vsub1 = PARAMETERS.ft_threat_weights[sub1].as_ptr();
+
+    for i in (0..L1_SIZE).step_by(simd::I16_LANES) {
+        let mut v = *vacc.add(i).cast();
+        v = simd::sub_i16(v, simd::convert_i8_i16(*vsub1.add(i).cast()));
+
+        *vacc.add(i).cast() = v;
     }
 }

--- a/src/nnue/simd/avx2.rs
+++ b/src/nnue/simd/avx2.rs
@@ -36,6 +36,10 @@ pub unsafe fn mul_high_i16(a: __m256i, b: __m256i) -> __m256i {
     _mm256_mulhi_epi16(a, b)
 }
 
+pub unsafe fn convert_i8_i16(a: __m128i) -> __m256i {
+    _mm256_cvtepi8_epi16(a)
+}
+
 pub unsafe fn packus(a: __m256i, b: __m256i) -> __m256i {
     _mm256_packus_epi16(a, b)
 }

--- a/src/nnue/simd/avx512.rs
+++ b/src/nnue/simd/avx512.rs
@@ -36,6 +36,10 @@ pub unsafe fn mul_high_i16(a: __m512i, b: __m512i) -> __m512i {
     _mm512_mulhi_epi16(a, b)
 }
 
+pub unsafe fn convert_i8_i16(a: __m256i) -> __m512i {
+    _mm512_cvtepi8_epi16(a)
+}
+
 pub unsafe fn packus(a: __m512i, b: __m512i) -> __m512i {
     _mm512_packus_epi16(a, b)
 }

--- a/src/nnue/simd/scalar.rs
+++ b/src/nnue/simd/scalar.rs
@@ -7,3 +7,7 @@ pub fn add_i16(a: i16, b: i16) -> i16 {
 pub fn sub_i16(a: i16, b: i16) -> i16 {
     a - b
 }
+
+pub fn convert_i8_i16(a: i8) -> i16 {
+    a as i16
+}

--- a/src/nnue/threats.rs
+++ b/src/nnue/threats.rs
@@ -56,10 +56,10 @@ pub fn initialize() {
 
             let mut count = 0;
 
-            for square in 0..Square::NUM {
-                unsafe { PIECE_OFFSET_LOOKUP[piece][square] = count };
+            for (square, entry) in unsafe { PIECE_OFFSET_LOOKUP[piece].iter_mut().enumerate() } {
+                *entry = count;
 
-                if piece_type != PieceType::Pawn || (square >= 8 && square < 56) {
+                if piece_type != PieceType::Pawn || (8..56).contains(&square) {
                     count += attacks(piece, Square::new(square as u8), Bitboard(0)).len() as i32;
                 }
             }
@@ -92,10 +92,11 @@ pub fn initialize() {
     }
 
     for piece in Piece::ALL {
-        for from in 0..Square::NUM {
-            for to in 0..Square::NUM {
-                let attacks = attacks(piece, Square::new(from as u8), Bitboard(0));
-                unsafe { ATTACK_INDEX_LOOKUP[piece][from][to] = (Bitboard((1 << to) - 1) & attacks).len() as u8 };
+        for (from, row) in unsafe { ATTACK_INDEX_LOOKUP[piece].iter_mut().enumerate() } {
+            let attacks = attacks(piece, Square::new(from as u8), Bitboard(0));
+
+            for (to, entry) in row.iter_mut().enumerate() {
+                *entry = (Bitboard((1u64 << to) - 1) & attacks).len() as u8;
             }
         }
     }

--- a/src/nnue/threats.rs
+++ b/src/nnue/threats.rs
@@ -1,0 +1,193 @@
+use crate::types::{Color, Piece, PieceType};
+
+pub fn threat_index(piece: Piece, from: usize, to: usize, target: usize, pov: Color) -> Option<usize> {
+    match piece.piece_type() {
+        PieceType::Pawn => map_pawn_threat(from, to, target, piece.piece_color() != pov),
+        PieceType::Knight => map_knight_threat(from, to, target),
+        PieceType::Bishop => map_bishop_threat(from, to, target),
+        PieceType::Rook => map_rook_threat(from, to, target),
+        PieceType::Queen => map_queen_threat(from, to, target),
+        PieceType::King => map_king_threat(from, to, target),
+        _ => unreachable!(),
+    }
+}
+
+fn below(from: usize, to: usize, table: &[u64; 64]) -> usize {
+    (table[from] & ((1 << to) - 1)).count_ones() as usize
+}
+
+fn target_is(target: usize, piece: PieceType) -> bool {
+    target % 6 == piece as usize
+}
+
+fn map_pawn_threat(from: usize, to: usize, target: usize, enemy: bool) -> Option<usize> {
+    const MAP: [i32; 12] = [0, 1, -1, 2, -1, -1, 3, 4, -1, 5, -1, -1];
+
+    if MAP[target] < 0 || (enemy && to > from && target_is(target, PieceType::Pawn)) {
+        return None;
+    }
+
+    let id = if to.abs_diff(from) == [9, 7][(to > from) as usize] { 0 } else { 1 };
+    let attack = 2 * (from % 8) + id - 1;
+    let threat = offsets::PAWN + MAP[target] as usize * indexes::PAWN + (from / 8 - 1) * 14 + attack;
+    Some(threat)
+}
+
+fn map_knight_threat(from: usize, to: usize, target: usize) -> Option<usize> {
+    if to > from && target_is(target, PieceType::Knight) {
+        return None;
+    }
+
+    let index = indexes::KNIGHT[from] + below(from, to, &attacks::KNIGHT);
+    let threat = offsets::KNIGHT + target * indexes::KNIGHT[64] + index;
+    Some(threat)
+}
+
+fn map_bishop_threat(from: usize, to: usize, target: usize) -> Option<usize> {
+    const MAP: [i32; 12] = [0, 1, 2, 3, -1, 4, 5, 6, 7, 8, -1, 9];
+
+    if MAP[target] < 0 || to > from && target_is(target, PieceType::Bishop) {
+        return None;
+    }
+
+    let index = indexes::BISHOP[from] + below(from, to, &attacks::BISHOP);
+    let threat = offsets::BISHOP + MAP[target] as usize * indexes::BISHOP[64] + index;
+    Some(threat)
+}
+
+fn map_rook_threat(from: usize, to: usize, target: usize) -> Option<usize> {
+    const MAP: [i32; 12] = [0, 1, 2, 3, -1, 4, 5, 6, 7, 8, -1, 9];
+
+    if MAP[target] < 0 || to > from && target_is(target, PieceType::Rook) {
+        return None;
+    }
+
+    let index = indexes::ROOK[from] + below(from, to, &attacks::ROOK);
+    let threat = offsets::ROOK + MAP[target] as usize * indexes::ROOK[64] + index;
+    Some(threat)
+}
+
+fn map_queen_threat(from: usize, to: usize, target: usize) -> Option<usize> {
+    if to > from && target_is(target, PieceType::Queen) {
+        return None;
+    }
+
+    let index = indexes::QUEEN[from] + below(from, to, &attacks::QUEEN);
+    let threat = offsets::QUEEN + target * indexes::QUEEN[64] + index;
+    Some(threat)
+}
+
+fn map_king_threat(from: usize, to: usize, target: usize) -> Option<usize> {
+    const MAP: [i32; 12] = [0, 1, 2, 3, -1, -1, 4, 5, 6, 7, -1, -1];
+
+    if MAP[target] < 0 {
+        return None;
+    }
+
+    let index = indexes::KING[from] + below(from, to, &attacks::KING);
+    let threat = offsets::KING + MAP[target] as usize * indexes::KING[64] + index;
+    Some(threat)
+}
+
+pub mod offsets {
+    use super::indexes;
+
+    pub const PAWN: usize = 0;
+    pub const KNIGHT: usize = PAWN + 6 * indexes::PAWN;
+    pub const BISHOP: usize = KNIGHT + 12 * indexes::KNIGHT[64];
+    pub const ROOK: usize = BISHOP + 10 * indexes::BISHOP[64];
+    pub const QUEEN: usize = ROOK + 10 * indexes::ROOK[64];
+    pub const KING: usize = QUEEN + 12 * indexes::QUEEN[64];
+    pub const END: usize = KING + 8 * indexes::KING[64];
+}
+
+mod indexes {
+    use super::attacks;
+
+    macro_rules! init_add_assign {
+        (|$sq:ident, $init:expr, $size:literal | $($rest:tt)+) => {{
+            let mut $sq = 0;
+            let mut res = [{$($rest)+}; $size + 1];
+            let mut val = $init;
+            while $sq < $size {
+                res[$sq] = val;
+                val += {$($rest)+};
+                $sq += 1;
+            }
+
+            res[$size] = val;
+
+            res
+        }};
+    }
+
+    pub const PAWN: usize = 84;
+    pub const KNIGHT: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::KNIGHT[sq].count_ones() as usize);
+    pub const BISHOP: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::BISHOP[sq].count_ones() as usize);
+    pub const ROOK: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::ROOK[sq].count_ones() as usize);
+    pub const QUEEN: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::QUEEN[sq].count_ones() as usize);
+    pub const KING: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::KING[sq].count_ones() as usize);
+}
+
+mod attacks {
+    macro_rules! init {
+        (|$sq:ident, $size:literal | $($rest:tt)+) => {{
+            let mut $sq = 0;
+            let mut res = [{$($rest)+}; $size];
+            while $sq < $size {
+                res[$sq] = {$($rest)+};
+                $sq += 1;
+            }
+            res
+        }};
+    }
+
+    const A: u64 = 0x0101_0101_0101_0101;
+    const H: u64 = A << 7;
+
+    const DIAGS: [u64; 15] = [
+        0x0100_0000_0000_0000,
+        0x0201_0000_0000_0000,
+        0x0402_0100_0000_0000,
+        0x0804_0201_0000_0000,
+        0x1008_0402_0100_0000,
+        0x2010_0804_0201_0000,
+        0x4020_1008_0402_0100,
+        0x8040_2010_0804_0201,
+        0x0080_4020_1008_0402,
+        0x0000_8040_2010_0804,
+        0x0000_0080_4020_1008,
+        0x0000_0000_8040_2010,
+        0x0000_0000_0080_4020,
+        0x0000_0000_0000_8040,
+        0x0000_0000_0000_0080,
+    ];
+
+    pub const KNIGHT: [u64; 64] = init!(|sq, 64| {
+        let n = 1 << sq;
+        let h1 = ((n >> 1) & 0x7f7f_7f7f_7f7f_7f7f) | ((n << 1) & 0xfefe_fefe_fefe_fefe);
+        let h2 = ((n >> 2) & 0x3f3f_3f3f_3f3f_3f3f) | ((n << 2) & 0xfcfc_fcfc_fcfc_fcfc);
+        (h1 << 16) | (h1 >> 16) | (h2 << 8) | (h2 >> 8)
+    });
+
+    pub const BISHOP: [u64; 64] = init!(|sq, 64| {
+        let rank = sq / 8;
+        let file = sq % 8;
+        DIAGS[file + rank].swap_bytes() ^ DIAGS[7 + file - rank]
+    });
+
+    pub const ROOK: [u64; 64] = init!(|sq, 64| {
+        let rank = sq / 8;
+        let file = sq % 8;
+        (0xFF << (rank * 8)) ^ (A << file)
+    });
+
+    pub const QUEEN: [u64; 64] = init!(|sq, 64| BISHOP[sq] | ROOK[sq]);
+
+    pub const KING: [u64; 64] = init!(|sq, 64| {
+        let mut k = 1 << sq;
+        k |= (k << 8) | (k >> 8);
+        k |= ((k & !A) >> 1) | ((k & !H) << 1);
+        k ^ (1 << sq)
+    });
+}

--- a/src/nnue/threats.rs
+++ b/src/nnue/threats.rs
@@ -1,193 +1,127 @@
-use crate::types::{Color, Piece, PieceType};
+use crate::{
+    lookup::attacks,
+    types::{Bitboard, Color, Piece, PieceType, Square},
+};
 
-pub fn threat_index(piece: Piece, from: usize, to: usize, target: usize, pov: Color) -> Option<usize> {
-    match piece.piece_type() {
-        PieceType::Pawn => map_pawn_threat(from, to, target, piece.piece_color() != pov),
-        PieceType::Knight => map_knight_threat(from, to, target),
-        PieceType::Bishop => map_bishop_threat(from, to, target),
-        PieceType::Rook => map_rook_threat(from, to, target),
-        PieceType::Queen => map_queen_threat(from, to, target),
-        PieceType::King => map_king_threat(from, to, target),
-        _ => unreachable!(),
+#[derive(Copy, Clone)]
+struct PiecePair {
+    // Bit layout:
+    // - bits 8..31: base index contribution for this piece-pair
+    // - bits 0..1 : exclusion flags (semi/excluded)
+    inner: u32,
+}
+
+impl PiecePair {
+    fn new(excluded: bool, semi_excluded: bool, base: i32) -> Self {
+        Self {
+            inner: ((semi_excluded && !excluded) as u32) | ((excluded as u32) << 1) | ((base as u32) << 8),
+        }
+    }
+
+    fn base(&self) -> usize {
+        (self.inner >> 8) as usize
+    }
+
+    fn excluded(&self, attacking: Square, attacked: Square) -> bool {
+        let below = ((attacking as u8) < (attacked as u8)) as u8;
+        ((self.inner as u8 + below) & 2) != 0
     }
 }
 
-fn below(from: usize, to: usize, table: &[u64; 64]) -> usize {
-    (table[from] & ((1 << to) - 1)).count_ones() as usize
-}
+static mut PIECE_PAIR_LOOKUP: [[PiecePair; 12]; 12] = [[PiecePair { inner: 0 }; 12]; 12];
+static mut PIECE_OFFSET_LOOKUP: [[i32; 64]; 12] = [[0; 64]; 12];
+static mut ATTACK_INDEX_LOOKUP: [[[u8; 64]; 64]; 12] = [[[0; 64]; 64]; 12];
 
-fn target_is(target: usize, piece: PieceType) -> bool {
-    target % 6 == piece as usize
-}
-
-fn map_pawn_threat(from: usize, to: usize, target: usize, enemy: bool) -> Option<usize> {
-    const MAP: [i32; 12] = [0, 1, -1, 2, -1, -1, 3, 4, -1, 5, -1, -1];
-
-    if MAP[target] < 0 || (enemy && to > from && target_is(target, PieceType::Pawn)) {
-        return None;
-    }
-
-    let id = if to.abs_diff(from) == [9, 7][(to > from) as usize] { 0 } else { 1 };
-    let attack = 2 * (from % 8) + id - 1;
-    let threat = offsets::PAWN + MAP[target] as usize * indexes::PAWN + (from / 8 - 1) * 14 + attack;
-    Some(threat)
-}
-
-fn map_knight_threat(from: usize, to: usize, target: usize) -> Option<usize> {
-    if to > from && target_is(target, PieceType::Knight) {
-        return None;
-    }
-
-    let index = indexes::KNIGHT[from] + below(from, to, &attacks::KNIGHT);
-    let threat = offsets::KNIGHT + target * indexes::KNIGHT[64] + index;
-    Some(threat)
-}
-
-fn map_bishop_threat(from: usize, to: usize, target: usize) -> Option<usize> {
-    const MAP: [i32; 12] = [0, 1, 2, 3, -1, 4, 5, 6, 7, 8, -1, 9];
-
-    if MAP[target] < 0 || to > from && target_is(target, PieceType::Bishop) {
-        return None;
-    }
-
-    let index = indexes::BISHOP[from] + below(from, to, &attacks::BISHOP);
-    let threat = offsets::BISHOP + MAP[target] as usize * indexes::BISHOP[64] + index;
-    Some(threat)
-}
-
-fn map_rook_threat(from: usize, to: usize, target: usize) -> Option<usize> {
-    const MAP: [i32; 12] = [0, 1, 2, 3, -1, 4, 5, 6, 7, 8, -1, 9];
-
-    if MAP[target] < 0 || to > from && target_is(target, PieceType::Rook) {
-        return None;
-    }
-
-    let index = indexes::ROOK[from] + below(from, to, &attacks::ROOK);
-    let threat = offsets::ROOK + MAP[target] as usize * indexes::ROOK[64] + index;
-    Some(threat)
-}
-
-fn map_queen_threat(from: usize, to: usize, target: usize) -> Option<usize> {
-    if to > from && target_is(target, PieceType::Queen) {
-        return None;
-    }
-
-    let index = indexes::QUEEN[from] + below(from, to, &attacks::QUEEN);
-    let threat = offsets::QUEEN + target * indexes::QUEEN[64] + index;
-    Some(threat)
-}
-
-fn map_king_threat(from: usize, to: usize, target: usize) -> Option<usize> {
-    const MAP: [i32; 12] = [0, 1, 2, 3, -1, -1, 4, 5, 6, 7, -1, -1];
-
-    if MAP[target] < 0 {
-        return None;
-    }
-
-    let index = indexes::KING[from] + below(from, to, &attacks::KING);
-    let threat = offsets::KING + MAP[target] as usize * indexes::KING[64] + index;
-    Some(threat)
-}
-
-pub mod offsets {
-    use super::indexes;
-
-    pub const PAWN: usize = 0;
-    pub const KNIGHT: usize = PAWN + 6 * indexes::PAWN;
-    pub const BISHOP: usize = KNIGHT + 12 * indexes::KNIGHT[64];
-    pub const ROOK: usize = BISHOP + 10 * indexes::BISHOP[64];
-    pub const QUEEN: usize = ROOK + 10 * indexes::ROOK[64];
-    pub const KING: usize = QUEEN + 12 * indexes::QUEEN[64];
-    pub const END: usize = KING + 8 * indexes::KING[64];
-}
-
-mod indexes {
-    use super::attacks;
-
-    macro_rules! init_add_assign {
-        (|$sq:ident, $init:expr, $size:literal | $($rest:tt)+) => {{
-            let mut $sq = 0;
-            let mut res = [{$($rest)+}; $size + 1];
-            let mut val = $init;
-            while $sq < $size {
-                res[$sq] = val;
-                val += {$($rest)+};
-                $sq += 1;
-            }
-
-            res[$size] = val;
-
-            res
-        }};
-    }
-
-    pub const PAWN: usize = 84;
-    pub const KNIGHT: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::KNIGHT[sq].count_ones() as usize);
-    pub const BISHOP: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::BISHOP[sq].count_ones() as usize);
-    pub const ROOK: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::ROOK[sq].count_ones() as usize);
-    pub const QUEEN: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::QUEEN[sq].count_ones() as usize);
-    pub const KING: [usize; 65] = init_add_assign!(|sq, 0, 64| attacks::KING[sq].count_ones() as usize);
-}
-
-mod attacks {
-    macro_rules! init {
-        (|$sq:ident, $size:literal | $($rest:tt)+) => {{
-            let mut $sq = 0;
-            let mut res = [{$($rest)+}; $size];
-            while $sq < $size {
-                res[$sq] = {$($rest)+};
-                $sq += 1;
-            }
-            res
-        }};
-    }
-
-    const A: u64 = 0x0101_0101_0101_0101;
-    const H: u64 = A << 7;
-
-    const DIAGS: [u64; 15] = [
-        0x0100_0000_0000_0000,
-        0x0201_0000_0000_0000,
-        0x0402_0100_0000_0000,
-        0x0804_0201_0000_0000,
-        0x1008_0402_0100_0000,
-        0x2010_0804_0201_0000,
-        0x4020_1008_0402_0100,
-        0x8040_2010_0804_0201,
-        0x0080_4020_1008_0402,
-        0x0000_8040_2010_0804,
-        0x0000_0080_4020_1008,
-        0x0000_0000_8040_2010,
-        0x0000_0000_0080_4020,
-        0x0000_0000_0000_8040,
-        0x0000_0000_0000_0080,
+pub fn initialize() {
+    #[rustfmt::skip]
+    const PIECE_INTERACTION_MAP: [[i32; 6]; 6] = [
+        [0,  1, -1,  2, -1, -1],
+        [0,  1,  2,  3,  4,  5],
+        [0,  1,  2,  3, -1,  4],
+        [0,  1,  2,  3, -1,  4],
+        [0,  1,  2,  3,  4,  5],
+        [0,  1,  2,  3, -1, -1],
     ];
 
-    pub const KNIGHT: [u64; 64] = init!(|sq, 64| {
-        let n = 1 << sq;
-        let h1 = ((n >> 1) & 0x7f7f_7f7f_7f7f_7f7f) | ((n << 1) & 0xfefe_fefe_fefe_fefe);
-        let h2 = ((n >> 2) & 0x3f3f_3f3f_3f3f_3f3f) | ((n << 2) & 0xfcfc_fcfc_fcfc_fcfc);
-        (h1 << 16) | (h1 >> 16) | (h2 << 8) | (h2 >> 8)
-    });
+    const PIECE_TARGET_COUNT: [i32; 6] = [6, 12, 10, 10, 12, 8];
 
-    pub const BISHOP: [u64; 64] = init!(|sq, 64| {
-        let rank = sq / 8;
-        let file = sq % 8;
-        DIAGS[file + rank].swap_bytes() ^ DIAGS[7 + file - rank]
-    });
+    let mut offset = 0;
+    let mut piece_offset = [0; Piece::NUM];
+    let mut offset_table = [0; Piece::NUM];
 
-    pub const ROOK: [u64; 64] = init!(|sq, 64| {
-        let rank = sq / 8;
-        let file = sq % 8;
-        (0xFF << (rank * 8)) ^ (A << file)
-    });
+    for piece_color in [Color::White, Color::Black] {
+        for piece_type in 0..PieceType::NUM {
+            let piece_type = PieceType::new(piece_type);
+            let piece = Piece::new(piece_color, piece_type);
 
-    pub const QUEEN: [u64; 64] = init!(|sq, 64| BISHOP[sq] | ROOK[sq]);
+            let mut count = 0;
 
-    pub const KING: [u64; 64] = init!(|sq, 64| {
-        let mut k = 1 << sq;
-        k |= (k << 8) | (k >> 8);
-        k |= ((k & !A) >> 1) | ((k & !H) << 1);
-        k ^ (1 << sq)
-    });
+            for square in 0..Square::NUM {
+                unsafe { PIECE_OFFSET_LOOKUP[piece][square] = count };
+
+                if piece_type != PieceType::Pawn || (square >= 8 && square < 56) {
+                    count += attacks(piece, Square::new(square as u8), Bitboard(0)).len() as i32;
+                }
+            }
+
+            piece_offset[piece] = count;
+            offset_table[piece] = offset;
+
+            offset += PIECE_TARGET_COUNT[piece_type] * count;
+        }
+    }
+
+    for attacking in Piece::ALL {
+        for attacked in Piece::ALL {
+            let attacking_piece = attacking.piece_type();
+            let attacking_color = attacking.piece_color();
+
+            let attacked_piece = attacked.piece_type();
+            let attacked_color = attacked.piece_color();
+
+            let map = PIECE_INTERACTION_MAP[attacking_piece][attacked_piece];
+            let base = offset_table[attacking]
+                + ((attacked_color as i32) * (PIECE_TARGET_COUNT[attacking_piece] / 2) + map) * piece_offset[attacking];
+
+            let enemy = attacking_color != attacked_color;
+            let semi_excluded = attacking_piece == attacked_piece && (enemy || attacking_piece != PieceType::Pawn);
+            let excluded = map < 0;
+
+            unsafe { PIECE_PAIR_LOOKUP[attacking][attacked] = PiecePair::new(excluded, semi_excluded, base) };
+        }
+    }
+
+    for piece in Piece::ALL {
+        for from in 0..Square::NUM {
+            for to in 0..Square::NUM {
+                let attacks = attacks(piece, Square::new(from as u8), Bitboard(0));
+                unsafe { ATTACK_INDEX_LOOKUP[piece][from][to] = (Bitboard((1 << to) - 1) & attacks).len() as u8 };
+            }
+        }
+    }
+}
+
+pub fn threat_index(
+    piece: Piece, mut from: Square, attacked: Piece, mut to: Square, mirrored: bool, pov: Color,
+) -> Option<usize> {
+    let flip = (7 * (mirrored as u8)) ^ (56 * (pov as u8));
+
+    from ^= flip;
+    to ^= flip;
+
+    let attacking = Piece::new(Color::new((piece.piece_color() as u8) ^ (pov as u8)), piece.piece_type());
+    let attacked = Piece::new(Color::new((attacked.piece_color() as u8) ^ (pov as u8)), attacked.piece_type());
+
+    unsafe {
+        let pair = PIECE_PAIR_LOOKUP[attacking][attacked];
+        if pair.excluded(from, to) {
+            return None;
+        }
+
+        let index = pair.base()
+            + PIECE_OFFSET_LOOKUP[attacking][from] as usize
+            + ATTACK_INDEX_LOOKUP[attacking][from][to] as usize;
+
+        Some(index)
+    }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1293,7 +1293,7 @@ fn make_move(td: &mut ThreadData, ply: isize, mv: Move) {
     td.shared.nodes.increment(td.id);
 
     td.nnue.push(mv, &td.board);
-    td.board.make_move(mv);
+    td.board.make_move(mv, |board, piece, square, add| td.nnue.push_threats(board, piece, square, add));
 
     td.shared.tt.prefetch(td.board.hash());
 }

--- a/src/tools/perft.rs
+++ b/src/tools/perft.rs
@@ -25,7 +25,7 @@ pub fn perft(depth: usize, board: &mut Board) {
             continue;
         }
 
-        board.make_move(mv);
+        board.make_move(mv, |_, _, _, _| ());
 
         let count = perft_internal(depth - 1, board);
         nodes += count;
@@ -63,7 +63,7 @@ fn perft_internal(depth: usize, board: &mut Board) -> u64 {
         if depth == 1 {
             nodes += 1;
         } else {
-            board.make_move(mv);
+            board.make_move(mv, |_, _, _, _| ());
             nodes += perft_internal(depth - 1, board);
             board.undo_move(mv);
         }

--- a/src/types/arrayvec.rs
+++ b/src/types/arrayvec.rs
@@ -42,6 +42,10 @@ impl<T: Copy, const N: usize> ArrayVec<T, N> {
         unsafe { Some(std::ptr::read(self.data[self.len].as_ptr())) }
     }
 
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
     pub fn swap_remove(&mut self, index: usize) -> T {
         unsafe {
             let value = std::ptr::read(self.data[index].as_ptr());

--- a/src/types/color.rs
+++ b/src/types/color.rs
@@ -12,6 +12,12 @@ pub enum Color {
 
 impl Color {
     pub const NUM: usize = 2;
+
+    pub const fn new(value: u8) -> Self {
+        debug_assert!(value < Self::NUM as u8);
+
+        unsafe { std::mem::transmute(value) }
+    }
 }
 
 impl Not for Color {

--- a/src/types/piece.rs
+++ b/src/types/piece.rs
@@ -26,6 +26,21 @@ pub enum Piece {
 impl Piece {
     pub const NUM: usize = 12;
 
+    pub const ALL: [Piece; Self::NUM] = [
+        Piece::WhitePawn,
+        Piece::BlackPawn,
+        Piece::WhiteKnight,
+        Piece::BlackKnight,
+        Piece::WhiteBishop,
+        Piece::BlackBishop,
+        Piece::WhiteRook,
+        Piece::BlackRook,
+        Piece::WhiteQueen,
+        Piece::BlackQueen,
+        Piece::WhiteKing,
+        Piece::BlackKing,
+    ];
+
     pub const fn new(color: Color, piece_type: PieceType) -> Self {
         unsafe { std::mem::transmute(((piece_type as u8) << 1) | color as u8) }
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -254,7 +254,7 @@ fn position(threads: &mut ThreadPool, settings: &Settings, mut tokens: &[&str]) 
 fn make_uci_move(board: &mut Board, uci_move: &str) {
     let moves = board.generate_all_moves();
     if let Some(mv) = moves.iter().map(|entry| entry.mv).find(|mv| mv.to_uci(board) == uci_move) {
-        board.make_move(mv);
+        board.make_move(mv, |_, _, _, _| ());
         board.advance_fullmove_counter();
     }
 }


### PR DESCRIPTION
This PR introduces the threat inputs feature set, which models all piece pairs, where one
piece attacks or defends the other one. This feature set extends the existing king-bucketed (x10)
piece-square-based inputs (2x6x64). To offset the additional computational cost, the L1 size
has been reduced to 384.

It goes without saying that other engines have done extensive work iterating on this idea.

Acknowledgments:

- @jw1912 and @Viren6 of Monty for introducing the threat inputs feature set
- @Yoshie2000 of PlentyChess for inspiring this implementation and providing a proof-of-concept in a top A/B engine
- The SF team for numerous optimizations and implementation details in this area

Fixed nodes
```
Elo   | 53.39 +- 2.35 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40174 W: 16226 L: 10101 D: 13847
Penta | [598, 3074, 8182, 6071, 2162]
https://recklesschess.space/test/9468/
```

STC
```
Elo   | 4.23 +- 2.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18460 W: 4956 L: 4731 D: 8773
Penta | [60, 2213, 4512, 2332, 113]
https://recklesschess.space/test/9517/
```

LTC
```
Elo   | 6.90 +- 3.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9166 W: 2407 L: 2225 D: 4534
Penta | [4, 970, 2455, 1148, 6]
https://recklesschess.space/test/9518/
```

DFRC STC
```
Elo   | 6.78 +- 3.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10658 W: 2798 L: 2590 D: 5270
Penta | [56, 1223, 2606, 1345, 99]
https://recklesschess.space/test/9523/
```

Bench: 3588139