### PR TITLE
Remove random component from evaluation

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -7,8 +7,6 @@ pub fn correct_eval(td: &ThreadData, raw_eval: i32, correction_value: i32) -> i3
 
     eval = (eval / 16) * 16;
 
-    eval += (td.board.hash() & 0x2) as i32 - 1;
-
     eval = eval * (200 - td.board.halfmove_clock() as i32) / 200;
 
     eval += correction_value;


### PR DESCRIPTION
Elo   | 0.65 +- 1.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 46148 W: 11360 L: 11274 D: 23514
Penta | [97, 5449, 11896, 5535, 97]
https://recklesschess.space/test/9551/

Bench: 3387898