### PR TITLE
Update default network to v48-f39439bf.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v47-73c00ea0.nnue";
+const NETWORK_NAME: &str = "v48-f39439bf.nnue";
 
 fn main() {
     generate_model_env();

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -41,7 +41,7 @@ mod simd {
     pub use scalar::*;
 }
 
-const NETWORK_SCALE: i32 = 400;
+const NETWORK_SCALE: i32 = 388;
 
 const INPUT_BUCKETS: usize = 10;
 


### PR DESCRIPTION
STC
Elo   | 4.14 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18294 W: 4775 L: 4557 D: 8962
Penta | [48, 2113, 4605, 2335, 46]
https://recklesschess.space/test/9567/

LTC
Elo   | 5.04 +- 2.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13300 W: 3347 L: 3154 D: 6799
Penta | [3, 1459, 3539, 1640, 9]
https://recklesschess.space/test/9568/

Bench: 3330397