### PR TITLE
More FDS reductions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -838,7 +838,7 @@ fn search<NODE: NodeType>(
                 reduction -= 3028;
             }
 
-            let reduced_depth = new_depth - (reduction >= 3072) as i32;
+            let reduced_depth = new_depth - (reduction >= 3072) as i32 - (reduction >= 5454 && new_depth >= 3) as i32;
 
             td.stack[ply].reduction = 1024 * ((initial_depth - 1) - new_depth);
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);


### PR DESCRIPTION
Elo   | 2.76 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29408 W: 7327 L: 7093 D: 14988
Penta | [43, 3435, 7529, 3639, 58]
https://recklesschess.space/test/9573/

Bench: 3712564