### PR TITLE
Apply root delta reductions to pruning also

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -669,6 +669,10 @@ fn search<NODE: NodeType>(
 
         let mut reduction = (1300 + 286 * depth.ilog2() * move_count.ilog2()) as i32;
 
+        if NODE::PV {
+            reduction -= 439 + 404 * (beta - alpha) / td.root_delta;
+        }
+
         if !improving {
             reduction += (446 - 304 * improvement / 128).min(1288);
         }
@@ -752,10 +756,6 @@ fn search<NODE: NodeType>(
                 reduction -= 365;
                 reduction -= 672 * (is_valid(tt_score) && tt_score > alpha) as i32;
                 reduction -= 803 * (is_valid(tt_score) && tt_depth >= depth) as i32;
-            }
-
-            if NODE::PV {
-                reduction -= 439 + 404 * (beta - alpha) / td.root_delta;
             }
 
             if mv.is_noisy() && mv.to() == td.board.recapture_square() {


### PR DESCRIPTION
Elo   | 1.38 +- 1.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 93428 W: 23195 L: 22823 D: 47410
Penta | [148, 11011, 24037, 11357, 161]
https://recklesschess.space/test/9574/

Bench: 3146895