### PR TITLE
Introduce PCM updates to TT early cutoffs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -327,6 +327,27 @@ fn search<NODE: NodeType>(
                 update_continuation_histories(td, ply, td.board.moved_piece(tt_move), tt_move.to(), conthist_bonus);
             }
 
+            if tt_score <= alpha && td.stack[ply - 1].move_count > 8 {
+                let pcm_move = td.stack[ply - 1].mv;
+                if pcm_move.is_quiet() {
+                    let mut factor = 90;
+                    factor += 158 * (initial_depth > 5) as i32;
+                    factor += 125 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
+                    factor +=
+                        327 * (is_valid(td.stack[ply - 1].eval) && tt_score <= -td.stack[ply - 1].eval - 97) as i32;
+
+                    let scaled_bonus = factor * (164 * initial_depth - 40).min(2143) / 128;
+
+                    td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
+
+                    let entry = &td.stack[ply - 2];
+                    if entry.mv.is_some() {
+                        let bonus = (152 * initial_depth - 39).min(1486);
+                        td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
+                    }
+                }
+            }
+
             if td.board.halfmove_clock() < 90 {
                 return tt_score;
             }


### PR DESCRIPTION
Elo   | 2.28 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38936 W: 9854 L: 9599 D: 19483
Penta | [80, 4541, 9964, 4810, 73]
https://recklesschess.space/test/9576/

Bench: 3652331