### PR TITLE
Update default network to v49-228d7e52.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v48-f39439bf.nnue";
+const NETWORK_NAME: &str = "v49-228d7e52.nnue";
 
 fn main() {
     generate_model_env();

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -45,7 +45,7 @@ const NETWORK_SCALE: i32 = 388;
 
 const INPUT_BUCKETS: usize = 10;
 
-const L1_SIZE: usize = 384;
+const L1_SIZE: usize = 512;
 const L2_SIZE: usize = 16;
 const L3_SIZE: usize = 32;
 

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -182,7 +182,7 @@ impl PstAccumulator {
     }
 }
 
-const REGISTERS: usize = 6;
+const REGISTERS: usize = 8;
 const _: () = assert!(L1_SIZE % (REGISTERS * simd::I16_LANES) == 0);
 
 unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<usize, 32>, subs: ArrayVec<usize, 32>) {


### PR DESCRIPTION
Fixed nodes
Elo   | 15.63 +- 2.22 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40424 W: 13444 L: 11627 D: 15353
Penta | [815, 4180, 8798, 5211, 1208]
https://recklesschess.space/test/9744/

VLTC
Elo   | 2.73 +- 2.10 (95%)
SPRT  | 120.0+1.20s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 23066 W: 5684 L: 5503 D: 11879
Penta | [5, 2434, 6469, 2625, 0]
https://recklesschess.space/test/9748/

Bench: 3253200