### PR TITLE
LTC SMP session 74k games

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,9 +1,9 @@
 use crate::{thread::ThreadData, types::Score};
 
 pub fn correct_eval(td: &ThreadData, raw_eval: i32, correction_value: i32) -> i32 {
-    let mut eval = (raw_eval * (21366 + td.board.material())
-        + td.optimism[td.board.side_to_move()] * (1747 + td.board.material()))
-        / 27395;
+    let mut eval = (raw_eval * (21372 + td.board.material())
+        + td.optimism[td.board.side_to_move()] * (1536 + td.board.material()))
+        / 27380;
 
     eval = (eval / 16) * 16;
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -85,7 +85,7 @@ impl MovePicker {
                     continue;
                 }
 
-                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 36 + 119);
+                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 43 + 108);
                 if !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;


### PR DESCRIPTION
STC
Elo   | 10.89 +- 4.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 5872 W: 1565 L: 1381 D: 2926
Penta | [7, 629, 1490, 793, 17]
https://recklesschess.space/test/9734/

LTC
Elo   | 7.82 +- 3.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7994 W: 2021 L: 1841 D: 4132
Penta | [2, 803, 2207, 983, 2]
https://recklesschess.space/test/9732/

LTC SMP
Elo   | 2.41 +- 1.90 (95%)
SPRT  | 40.0+0.40s Threads=4 Hash=256MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 26804 W: 6498 L: 6312 D: 13994
Penta | [1, 2706, 7802, 2892, 1]
https://recklesschess.space/test/9736/

Bench: 3181538