### PR TITLE
Update default network to v50-441ec316.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v49-228d7e52.nnue";
+const NETWORK_NAME: &str = "v50-441ec316.nnue";
 
 fn main() {
     generate_model_env();

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -41,7 +41,7 @@ mod simd {
     pub use scalar::*;
 }
 
-const NETWORK_SCALE: i32 = 388;
+const NETWORK_SCALE: i32 = 380;
 
 const INPUT_BUCKETS: usize = 10;
 


### PR DESCRIPTION
STC
Elo   | 6.86 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9872 W: 2551 L: 2356 D: 4965
Penta | [22, 1095, 2515, 1274, 30]
https://recklesschess.space/test/9756/

LTC
Elo   | 5.11 +- 2.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12862 W: 3223 L: 3034 D: 6605
Penta | [3, 1400, 3437, 1587, 4]
https://recklesschess.space/test/9757/

STC DFRC
Elo   | 6.16 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10264 W: 1763 L: 1581 D: 6920
Penta | [31, 874, 3148, 1040, 39]
https://recklesschess.space/test/9758/