### PR TITLE
Skip fail high adjustment at root nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1028,7 +1028,7 @@ fn search<NODE: NodeType>(
 
     tt_pv |= !NODE::ROOT && bound == Bound::Upper && move_count > 2 && td.stack[ply - 1].tt_pv;
 
-    if best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {
+    if !NODE::ROOT && best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {
         best_score = (best_score * depth + beta) / (depth + 1);
     }
 


### PR DESCRIPTION
Elo   | 1.53 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 74756 W: 18667 L: 18337 D: 37752
Penta | [116, 8735, 19367, 9023, 137]
https://recklesschess.space/test/9894/

Bench: 2834160