### PR TITLE
Disable do-deeper/do-shallower at root nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -812,8 +812,10 @@ fn search<NODE: NodeType>(
             current_search_count += 1;
 
             if score > alpha && new_depth > reduced_depth {
-                new_depth += (score > best_score + 43 + 482 * depth / 128) as i32;
-                new_depth -= (score < best_score + new_depth) as i32;
+                if !NODE::ROOT {
+                    new_depth += (score > best_score + 43 + 482 * depth / 128) as i32;
+                    new_depth -= (score < best_score + new_depth) as i32;
+                }
 
                 if new_depth > reduced_depth {
                     score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node, ply + 1);


### PR DESCRIPTION
Elo   | 1.08 +- 0.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 170958 W: 42633 L: 42103 D: 86222
Penta | [271, 19235, 45971, 19697, 305]
https://recklesschess.space/test/9892/

Bench: 2831413