### PR TITLE
Decouple and standardize SEE pruning thresholds

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -738,9 +738,9 @@ fn search<NODE: NodeType>(
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                -1746 * lmr_depth * lmr_depth / 128 - 33 * history / 1024 + 24
+                -16 * depth * depth + 50 * depth - 21 * history / 1024 + 25
             } else {
-                -86 * depth - 32 * history / 1024 + 42
+                -8 * depth * depth - 36 * depth - 33 * history / 1024 + 10
             };
 
             if !td.board.see(mv, threshold) {


### PR DESCRIPTION
Elo   | 1.53 +- 2.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 24986 W: 6051 L: 5941 D: 12994
Penta | [13, 2817, 6721, 2931, 11]
https://recklesschess.space/test/9966/

Bench: 3144096