### PR TITLE
Skip more evasions in quiescence search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1167,7 +1167,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_count = 0;
     let mut move_picker = MovePicker::new_qsearch();
 
-    while let Some(mv) = move_picker.next::<NODE>(td, !in_check, ply) {
+    while let Some(mv) = move_picker.next::<NODE>(td, !in_check || !is_loss(best_score), ply) {
         if !td.board.is_legal(mv) {
             continue;
         }
@@ -1180,10 +1180,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
 
             if move_count >= 3 && !td.board.might_give_check_if_you_squint(mv) {
-                break;
-            }
-
-            if in_check && mv.is_quiet() {
                 break;
             }
 


### PR DESCRIPTION
Elo   | 1.23 +- 0.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 122662 W: 30701 L: 30267 D: 61694
Penta | [243, 13844, 32760, 14204, 280]
https://recklesschess.space/test/10004/

Bench: 3171549