### PR TITLE
Skip bad noisy futility pruning on direct checks

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -721,7 +721,12 @@ fn search<NODE: NodeType>(
                 + 83 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 1024
                 + 24;
 
-            if !in_check && depth < 12 && move_picker.stage() == Stage::BadNoisy && noisy_futility_value <= alpha {
+            if !in_check
+                && depth < 12
+                && move_picker.stage() == Stage::BadNoisy
+                && noisy_futility_value <= alpha
+                && !td.board.might_give_check_if_you_squint(mv)
+            {
                 if !is_decisive(best_score) && best_score <= noisy_futility_value {
                     best_score = noisy_futility_value;
                 }


### PR DESCRIPTION
Elo   | 1.85 +- 1.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 54760 W: 13644 L: 13352 D: 27764
Penta | [73, 6402, 14170, 6630, 105]
https://recklesschess.space/test/10077/

Bench: 3893725