### PR TITLE
Simplify away probcut depth guard

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -563,7 +563,6 @@ fn search<NODE: NodeType>(
     let probcut_beta = beta + 257 - 75 * improving as i32;
 
     if cut_node
-        && depth >= 3
         && !is_decisive(beta)
         && (!is_valid(tt_score) || tt_score >= probcut_beta && !is_decisive(tt_score))
         && !tt_move.is_quiet()


### PR DESCRIPTION
STC
Elo   | 2.48 +- 2.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 19026 W: 4825 L: 4689 D: 9512
Penta | [35, 2157, 4984, 2311, 26]
https://recklesschess.space/test/10092/

LTC
Elo   | 1.19 +- 1.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 30008 W: 7236 L: 7133 D: 15639
Penta | [9, 3276, 8328, 3385, 6]
https://recklesschess.space/test/10097/

Bench: 3504025