### PR TITLE
Simplify and decouple IIR from move loop pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -604,11 +604,6 @@ fn search<NODE: NodeType>(
         }
     }
 
-    // Internal Iterative Reductions (IIR)
-    if depth >= 3 + 3 * cut_node as i32 && tt_move.is_null() && (NODE::PV || cut_node) {
-        depth -= 1;
-    }
-
     // Singular Extensions (SE)
     let mut extension = 0;
 
@@ -745,6 +740,11 @@ fn search<NODE: NodeType>(
 
         let mut new_depth = if move_count == 1 { depth + extension - 1 } else { depth - 1 };
         let mut score = Score::ZERO;
+
+        // Internal Iterative Reductions (IIR)
+        if new_depth >= 3 + 3 * cut_node as i32 && tt_move.is_null() && (NODE::PV || cut_node) {
+            new_depth -= 1;
+        }
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count > 1 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -742,7 +742,7 @@ fn search<NODE: NodeType>(
         let mut score = Score::ZERO;
 
         // Internal Iterative Reductions (IIR)
-        if new_depth >= 3 + 3 * cut_node as i32 && tt_move.is_null() && (NODE::PV || cut_node) {
+        if (NODE::PV || cut_node) && new_depth >= 5 && tt_move.is_null() {
             new_depth -= 1;
         }
 


### PR DESCRIPTION
STC
Elo   | 0.14 +- 1.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 68504 W: 16916 L: 16889 D: 34699
Penta | [149, 8037, 17812, 8146, 108]
https://recklesschess.space/test/10180/

LTC
Elo   | 0.16 +- 1.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 63858 W: 15387 L: 15357 D: 33114
Penta | [20, 7179, 17496, 7219, 15]
https://recklesschess.space/test/10181/

Bench: 3697200