### PR TITLE
Extend singular nodes more aggressively

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -622,8 +622,10 @@ fn search<NODE: NodeType>(
         }
 
         if score < singular_beta {
-            let double_margin = 2 + 272 * NODE::PV as i32;
-            let triple_margin = 57 + 313 * NODE::PV as i32 - 14 * correction_value.abs() / 128;
+            let double_margin =
+                -4 + 256 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
+            let triple_margin =
+                48 + 288 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
 
             extension = 1;
             extension += (score < singular_beta - double_margin) as i32;


### PR DESCRIPTION
STC
Elo   | -0.28 +- 2.42 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 20082 W: 4998 L: 5014 D: 10070
Penta | [49, 2378, 5192, 2384, 38]
https://recklesschess.space/test/10199/

LTC SMP
Elo   | 3.36 +- 2.42 (95%)
SPRT  | 40.0+0.40s Threads=7 Hash=512MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 16148 W: 3981 L: 3825 D: 8342
Penta | [0, 1566, 4786, 1722, 0]
https://recklesschess.space/test/10183/

Bench: 3870959