### PR TITLE
Introduce PCM for noisy moves as well

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -110,6 +110,10 @@ impl Board {
         self.state_stack[self.state_stack.len() - 1].threats
     }
 
+    pub const fn captured_piece(&self) -> Option<Piece> {
+        self.state.captured
+    }
+
     pub const fn recapture_square(&self) -> Square {
         self.state.recapture_square
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1030,6 +1030,17 @@ fn search<NODE: NodeType>(
                 let bonus = (166 * initial_depth - 37).min(1268);
                 td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
             }
+        } else if pcm_move.is_noisy() {
+            let captured = td.board.captured_piece().unwrap_or_default().piece_type();
+            let bonus = 57;
+
+            td.noisy_history.update(
+                td.board.prior_threats(),
+                td.board.piece_on(pcm_move.to()),
+                pcm_move.to(),
+                captured,
+                bonus,
+            );
         }
     }
 

--- a/src/types/piece.rs
+++ b/src/types/piece.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::Color;
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Debug)]
 #[repr(u8)]
 pub enum Piece {
     WhitePawn,
@@ -20,6 +20,7 @@ pub enum Piece {
     BlackQueen,
     WhiteKing,
     BlackKing,
+    #[default]
     None,
 }
 


### PR DESCRIPTION
idea is we will generally boost the good capture bestmoves, but in the child node we can know when to appreciate a little bit more the capture that forced us to search all of this moves and yet we didn't find a good reply.

Elo   | 1.29 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 110686 W: 27804 L: 27394 D: 55488
Penta | [238, 12869, 28698, 13321, 217]
https://recklesschess.space/test/10230/

Bench: 4212403