### PR TITLE
Simplify away evaluation grain

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -5,8 +5,6 @@ pub fn correct_eval(td: &ThreadData, raw_eval: i32, correction_value: i32) -> i3
         + td.optimism[td.board.side_to_move()] * (1536 + td.board.material()))
         / 27380;
 
-    eval = (eval / 16) * 16;
-
     eval = eval * (200 - td.board.halfmove_clock() as i32) / 200;
 
     eval += correction_value;


### PR DESCRIPTION
LTC
Elo   | 1.74 +- 2.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.03 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 23502 W: 5758 L: 5640 D: 12104
Penta | [5, 2544, 6539, 2654, 9]
https://recklesschess.space/test/10234/

Bench: 4794257