### PR TITLE
Introduce randomized draw value

### DIFF
--- a/src/tb.rs
+++ b/src/tb.rs
@@ -175,7 +175,7 @@ pub fn tb_rank_rootmoves(td: &mut ThreadData) {
             td.root_in_tb = true;
 
             // Keep probing in search if DTZ is not available and we are winning
-            td.stop_probing_tb = td.root_moves[0].score < Score::DRAW;
+            td.stop_probing_tb = td.root_moves[0].score < Score::ZERO;
         }
     }
 }

--- a/src/types/score.rs
+++ b/src/types/score.rs
@@ -1,12 +1,11 @@
 use super::{PieceType, MAX_PLY};
-use crate::board::Board;
+use crate::{board::Board, thread::ThreadData};
 
 pub struct Score;
 
 #[rustfmt::skip]
 impl Score {
     pub const ZERO: i32 = 0;
-    pub const DRAW: i32 = 0;
 
     pub const NONE:     i32 = 32002;
     pub const INFINITE: i32 = 32001;
@@ -16,6 +15,10 @@ impl Score {
 
     pub const TB_WIN:        i32 = Self::MATE_IN_MAX - 1;
     pub const TB_WIN_IN_MAX: i32 = Self::TB_WIN - MAX_PLY as i32;
+}
+
+pub fn draw(td: &ThreadData) -> i32 {
+    (td.board.hash() & 0x2) as i32 - 1
 }
 
 pub const fn mated_in(ply: isize) -> i32 {


### PR DESCRIPTION
Passed non-regression LTC [-3, 0] with LLR=11.02
Elo   | 0.94 +- 0.91 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.51 (-2.25, 2.89) [0.00, 3.00]
Games | N: 127492 W: 31202 L: 30857 D: 65433
Penta | [38, 14088, 35142, 14447, 31]
https://recklesschess.space/test/10224/

Bench: 4286294