### PR TITLE
Make probcut searching adaptive

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -582,11 +582,10 @@ fn search<NODE: NodeType>(
 
             let mut score = -qsearch::<NonPV>(td, -probcut_beta, -probcut_beta + 1, ply + 1);
 
-            let mut probcut_depth = (depth - 4 - ((score - probcut_beta - 50) / 300).max(0).min(3)).max(0);
+            let mut probcut_depth = (depth - 4 - ((score - probcut_beta - 50) / 300).clamp(0, 3)).max(0);
             let og_probcut_depth = (depth - 4).max(0);
-            let raised_probcut_beta = (probcut_beta + (og_probcut_depth - probcut_depth) * 300)
-                .min(Score::INFINITE)
-                .max(-Score::INFINITE + 1);
+            let raised_probcut_beta =
+                (probcut_beta + (og_probcut_depth - probcut_depth) * 300).clamp(-Score::INFINITE + 1, Score::INFINITE);
 
             if score >= probcut_beta && probcut_depth > 0 {
                 score =


### PR DESCRIPTION
If the qsearch result is extremely promising, we search at a lower depth due to the increased confidence (but increase the margins in turn). If the search fails, we revert to standard probcut searching.

Passed STC:
```
Elo   | 5.06 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14002 W: 3609 L: 3405 D: 6988
Penta | [36, 1582, 3549, 1810, 24]
```
https://recklesschess.space/test/10262/

Passed LTC:
```
Elo   | 3.43 +- 2.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20590 W: 5096 L: 4893 D: 10601
Penta | [5, 2217, 5647, 2422, 4]
```
https://recklesschess.space/test/10278/

Bench: 4480232