### PR TITLE
Refactor stack sentinel ownership to be per-instance

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -4,7 +4,7 @@ use crate::types::{Move, Piece, Score, MAX_PLY};
 
 pub struct Stack {
     data: [StackEntry; MAX_PLY + 16],
-    sentinel: Box<[[i16; 64]; 13]>,
+    sentinel: [[i16; 64]; 13],
 }
 
 impl Stack {
@@ -17,10 +17,10 @@ impl Default for Stack {
     fn default() -> Self {
         let mut stack = Self {
             data: [StackEntry::default(); MAX_PLY + 16],
-            sentinel: Box::new([[0i16; 64]; 13]),
+            sentinel: [[0; 64]; 13],
         };
 
-        let ptr = &mut *stack.sentinel as *mut _;
+        let ptr = &mut stack.sentinel as *mut _;
         for entry in stack.data.iter_mut() {
             entry.conthist = ptr;
             entry.contcorrhist = ptr;


### PR DESCRIPTION
Make the sentinel per-stack to avoid unnecessary cross-domain NUMA access

Elo   | 0.57 +- 1.56 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 45956 W: 11859 L: 11783 D: 22314
Penta | [164, 4841, 12902, 4897, 174]
https://recklesschess.space/test/10296/

Bench: 4480232