### PR TITLE
Add log terms and tune LMR and FDS base reductions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -761,9 +761,13 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count > 1 {
-            let mut reduction = 240 * (move_count.ilog2() * depth.ilog2()) as i32
-                + 28 * move_count.ilog2() as i32
-                + 28 * depth.ilog2() as i32;
+            let mut reduction = 240 * (move_count.ilog2() * depth.ilog2()) as i32;
+
+            reduction += 28 * move_count.ilog2() as i32;
+            reduction += 28 * depth.ilog2() as i32;
+
+            reduction -= 68 * move_count;
+            reduction -= 3326 * correction_value.abs() / 1024;
 
             if is_quiet {
                 reduction += 2031;
@@ -773,9 +777,6 @@ fn search<NODE: NodeType>(
                 reduction -= 102 * history / 1024;
                 reduction -= 50 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
-
-            reduction -= 3326 * correction_value.abs() / 1024;
-            reduction -= 68 * move_count;
 
             if NODE::PV {
                 reduction -= 425 + 453 * (beta - alpha) / td.root_delta;
@@ -839,9 +840,13 @@ fn search<NODE: NodeType>(
         }
         // Full Depth Search (FDS)
         else if !NODE::PV || move_count > 1 {
-            let mut reduction = 246 * (move_count.ilog2() * depth.ilog2()) as i32
-                + 25 * move_count.ilog2() as i32
-                + 25 * depth.ilog2() as i32;
+            let mut reduction = 246 * (move_count.ilog2() * depth.ilog2()) as i32;
+
+            reduction += 25 * move_count.ilog2() as i32;
+            reduction += 25 * depth.ilog2() as i32;
+
+            reduction -= 55 * move_count;
+            reduction -= 2484 * correction_value.abs() / 1024;
 
             if is_quiet {
                 reduction += 1634;
@@ -851,9 +856,6 @@ fn search<NODE: NodeType>(
                 reduction -= 65 * history / 1024;
                 reduction -= 47 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
-
-            reduction -= 2484 * correction_value.abs() / 1024;
-            reduction -= 55 * move_count;
 
             if tt_pv {
                 reduction -= 747;

--- a/src/search.rs
+++ b/src/search.rs
@@ -761,13 +761,15 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count > 1 {
-            let mut reduction = 285 * (depth.ilog2() * move_count.ilog2()) as i32;
+            let mut reduction = 240 * (move_count.ilog2() * depth.ilog2()) as i32
+                + 28 * move_count.ilog2() as i32
+                + 28 * depth.ilog2() as i32;
 
             if is_quiet {
-                reduction += 1808;
+                reduction += 2031;
                 reduction -= 152 * history / 1024;
             } else {
-                reduction += 1564;
+                reduction += 1563;
                 reduction -= 102 * history / 1024;
                 reduction -= 50 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
@@ -837,13 +839,15 @@ fn search<NODE: NodeType>(
         }
         // Full Depth Search (FDS)
         else if !NODE::PV || move_count > 1 {
-            let mut reduction = 285 * (depth.ilog2() * move_count.ilog2()) as i32;
+            let mut reduction = 246 * (move_count.ilog2() * depth.ilog2()) as i32
+                + 25 * move_count.ilog2() as i32
+                + 25 * depth.ilog2() as i32;
 
             if is_quiet {
-                reduction += 1615;
+                reduction += 1634;
                 reduction -= 154 * history / 1024;
             } else {
-                reduction += 1444;
+                reduction += 1423;
                 reduction -= 65 * history / 1024;
                 reduction -= 47 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }


### PR DESCRIPTION
STC
Elo   | 2.47 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36684 W: 9367 L: 9106 D: 18211
Penta | [64, 4239, 9496, 4458, 85]
https://recklesschess.space/test/10271/

LTC
Elo   | 1.66 +- 1.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 58310 W: 14207 L: 13928 D: 30175
Penta | [14, 6356, 16153, 6601, 31]
https://recklesschess.space/test/10274/

Bench: 4113422
