### PR TITLE
Adjust NMP margin based on confidence of estimated score

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -523,7 +523,7 @@ fn search<NODE: NodeType>(
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
-        let r = (6582 + 273 * depth + 4 * (estimated_score - beta).clamp(0, 1024)) / 1024;
+        let r = (5140 + 273 * depth + 4 * (estimated_score - beta).clamp(0, 1024)) / 1024;
 
         td.stack[ply].conthist = td.stack.sentinel().conthist;
         td.stack[ply].contcorrhist = td.stack.sentinel().contcorrhist;


### PR DESCRIPTION
Passed STC:
```
Elo   | 2.91 +- 2.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27976 W: 7124 L: 6890 D: 13962
Penta | [82, 3209, 7166, 3455, 76]
```
https://recklesschess.space/test/10313/

Passed LTC:
```
Elo   | 1.54 +- 1.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 71456 W: 17645 L: 17328 D: 36483
Penta | [28, 7994, 19370, 8305, 31]
```
https://recklesschess.space/test/10314/

Bench 4938905