### PR TITLE
Share continuation correction history between threads

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1283,16 +1283,8 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
         + corrhist.major.get(stm, td.board.major_key())
         + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
         + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
-        + td.continuation_corrhist.get(
-            td.stack[ply - 2].contcorrhist,
-            td.stack[ply - 1].piece,
-            td.stack[ply - 1].mv.to(),
-        )
-        + td.continuation_corrhist.get(
-            td.stack[ply - 4].contcorrhist,
-            td.stack[ply - 1].piece,
-            td.stack[ply - 1].mv.to(),
-        ))
+        + corrhist.continuation.get(td.stack[ply - 2].contcorrhist, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to())
+        + corrhist.continuation.get(td.stack[ply - 4].contcorrhist, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to()))
         / 88
 }
 
@@ -1309,7 +1301,7 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
     corrhist.non_pawn[Color::Black].update(stm, td.board.non_pawn_key(Color::Black), bonus);
 
     if td.stack[ply - 1].mv.is_some() && td.stack[ply - 2].mv.is_some() {
-        td.continuation_corrhist.update(
+        corrhist.continuation.update(
             td.stack[ply - 2].contcorrhist,
             td.stack[ply - 1].piece,
             td.stack[ply - 1].mv.to(),
@@ -1318,7 +1310,7 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
     }
 
     if td.stack[ply - 1].mv.is_some() && td.stack[ply - 4].mv.is_some() {
-        td.continuation_corrhist.update(
+        corrhist.continuation.update(
             td.stack[ply - 4].contcorrhist,
             td.stack[ply - 1].piece,
             td.stack[ply - 1].mv.to(),
@@ -1342,7 +1334,7 @@ fn make_move(td: &mut ThreadData, ply: isize, mv: Move) {
     td.stack[ply].conthist =
         td.continuation_history.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
     td.stack[ply].contcorrhist =
-        td.continuation_corrhist.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
+        td.corrhist().continuation.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
 
     td.shared.nodes.increment(td.id);
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -92,6 +92,7 @@ pub struct SharedCorrectionHistory {
     pub minor: CorrectionHistory,
     pub major: CorrectionHistory,
     pub non_pawn: [CorrectionHistory; 2],
+    pub continuation: ContinuationCorrectionHistory,
 }
 
 unsafe impl NumaValue for SharedCorrectionHistory {}
@@ -135,7 +136,6 @@ pub struct ThreadData {
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
     pub continuation_history: ContinuationHistory,
-    pub continuation_corrhist: ContinuationCorrectionHistory,
     pub best_move_changes: usize,
     pub optimism: [i32; 2],
     pub stopped: bool,
@@ -167,7 +167,6 @@ impl ThreadData {
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
             continuation_history: ContinuationHistory::default(),
-            continuation_corrhist: ContinuationCorrectionHistory::default(),
             best_move_changes: 0,
             optimism: [0; 2],
             stopped: false,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -126,6 +126,7 @@ fn reset(threads: &mut ThreadPool, shared: &Arc<SharedContext>) {
         corrhist.major.clear();
         corrhist.non_pawn[Color::White].clear();
         corrhist.non_pawn[Color::Black].clear();
+        corrhist.continuation.clear();
     }
 }
 


### PR DESCRIPTION
Use all correction histories in the shared domain.

Passes non-regression [-1.75, 0.25] LLR: 3.8322
Elo   | 1.24 +- 1.25 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=256MB
LLR   | 1.29 (-2.25, 2.89) [0.00, 4.00]
Games | N: 69972 W: 17700 L: 17451 D: 34821
Penta | [54, 7852, 18918, 8115, 47]
https://recklesschess.space/test/10356/

Bench: 4587115