### PR TITLE
Simplify major correction history away

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -23,7 +23,6 @@ struct InternalState {
     key: u64,
     pawn_key: u64,
     minor_key: u64,
-    major_key: u64,
     non_pawn_keys: [u64; Color::NUM],
     en_passant: Square,
     castling: Castling,
@@ -84,10 +83,6 @@ impl Board {
 
     pub const fn minor_key(&self) -> u64 {
         self.state.minor_key
-    }
-
-    pub const fn major_key(&self) -> u64 {
-        self.state.major_key
     }
 
     pub const fn non_pawn_key(&self, color: Color) -> u64 {
@@ -226,13 +221,8 @@ impl Board {
         } else {
             self.state.non_pawn_keys[piece.piece_color()] ^= key;
 
-            if [PieceType::Knight, PieceType::Bishop].contains(&piece.piece_type()) {
+            if [PieceType::Knight, PieceType::Bishop, PieceType::King].contains(&piece.piece_type()) {
                 self.state.minor_key ^= key;
-            } else if [PieceType::Rook, PieceType::Queen].contains(&piece.piece_type()) {
-                self.state.major_key ^= key;
-            } else {
-                self.state.minor_key ^= key;
-                self.state.major_key ^= key;
             }
         }
     }
@@ -526,7 +516,6 @@ impl Board {
         self.state.key = 0;
         self.state.pawn_key = 0;
         self.state.minor_key = 0;
-        self.state.major_key = 0;
         self.state.non_pawn_keys = [0; Color::NUM];
 
         for piece in 0..Piece::NUM {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1280,7 +1280,6 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
 
     (corrhist.pawn.get(stm, td.board.pawn_key())
         + corrhist.minor.get(stm, td.board.minor_key())
-        + corrhist.major.get(stm, td.board.major_key())
         + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
         + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
         + td.continuation_corrhist.get(
@@ -1303,7 +1302,6 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
 
     corrhist.pawn.update(stm, td.board.pawn_key(), bonus);
     corrhist.minor.update(stm, td.board.minor_key(), bonus);
-    corrhist.major.update(stm, td.board.major_key(), bonus);
 
     corrhist.non_pawn[Color::White].update(stm, td.board.non_pawn_key(Color::White), bonus);
     corrhist.non_pawn[Color::Black].update(stm, td.board.non_pawn_key(Color::Black), bonus);

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -90,7 +90,6 @@ impl Default for Status {
 pub struct SharedCorrectionHistory {
     pub pawn: CorrectionHistory,
     pub minor: CorrectionHistory,
-    pub major: CorrectionHistory,
     pub non_pawn: [CorrectionHistory; 2],
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -123,7 +123,6 @@ fn reset(threads: &mut ThreadPool, shared: &Arc<SharedContext>) {
     for corrhist in unsafe { shared.replicator.get_all() } {
         corrhist.pawn.clear();
         corrhist.minor.clear();
-        corrhist.major.clear();
         corrhist.non_pawn[Color::White].clear();
         corrhist.non_pawn[Color::Black].clear();
     }


### PR DESCRIPTION
STC
Elo   | 1.38 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 29478 W: 7410 L: 7293 D: 14775
Penta | [62, 3454, 7592, 3567, 64]
https://recklesschess.space/test/10371/

LTC
Elo   | 0.44 +- 1.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.07 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 51100 W: 12549 L: 12484 D: 26067
Penta | [7, 5893, 13687, 5954, 9]
https://recklesschess.space/test/10378/

Bench: 3895940