### PR TITLE
Prevent positive threshold in SEE pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -737,9 +737,9 @@ fn search<NODE: NodeType>(
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                -16 * depth * depth + 50 * depth - 21 * history / 1024 + 25
+                (-16 * depth * depth + 50 * depth - 21 * history / 1024 + 25).min(0)
             } else {
-                -8 * depth * depth - 36 * depth - 33 * history / 1024 + 10
+                (-8 * depth * depth - 36 * depth - 33 * history / 1024 + 10).min(0)
             };
 
             if !td.board.see(mv, threshold) {


### PR DESCRIPTION
Elo   | 2.17 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 43476 W: 10897 L: 10625 D: 21954
Penta | [90, 5043, 11207, 5301, 97]
https://recklesschess.space/test/10443/

Bench: 3715752
