### PR TITLE
Revert "Share continuation correction history between threads"

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -8,7 +8,6 @@ use crate::{
 type FromToHistory<T> = [[T; 64]; 64];
 type PieceToHistory<T> = [[T; 64]; 13];
 type ContinuationHistoryType = [[[[PieceToHistory<i16>; 64]; 13]; 2]; 2];
-type ContinuationCorrectionHistoryType = [[[[PieceToHistory<AtomicI16>; 64]; 13]; 2]; 2];
 
 fn apply_bonus<const MAX: i32>(entry: &mut i16, bonus: i32) {
     let bonus = bonus.clamp(-MAX, MAX);
@@ -160,33 +159,25 @@ impl Default for CorrectionHistory {
 
 pub struct ContinuationCorrectionHistory {
     // [in_check][capture][piece][to][piece][to]
-    entries: Box<ContinuationCorrectionHistoryType>,
+    entries: Box<ContinuationHistoryType>,
 }
 
 impl ContinuationCorrectionHistory {
     const MAX_HISTORY: i32 = 16222;
 
     pub fn subtable_ptr(
-        &self, in_check: bool, capture: bool, piece: Piece, to: Square,
-    ) -> *const PieceToHistory<AtomicI16> {
-        self.entries[in_check as usize][capture as usize][piece][to].as_ptr().cast()
+        &mut self, in_check: bool, capture: bool, piece: Piece, to: Square,
+    ) -> *mut PieceToHistory<i16> {
+        self.entries[in_check as usize][capture as usize][piece][to].as_mut_ptr().cast()
     }
 
-    pub fn get(&self, subtable_ptr: *const PieceToHistory<AtomicI16>, piece: Piece, to: Square) -> i32 {
-        unsafe { (&*subtable_ptr)[piece][to].load(Ordering::Relaxed) as i32 }
+    pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square) -> i32 {
+        unsafe { (&*subtable_ptr)[piece][to] as i32 }
     }
 
-    pub fn update(&self, subtable_ptr: *const PieceToHistory<AtomicI16>, piece: Piece, to: Square, bonus: i32) {
-        let entry = unsafe { &(&*subtable_ptr)[piece][to] };
-        let current = entry.load(Ordering::Relaxed) as i32;
-        let new = current + bonus - bonus.abs() * current / Self::MAX_HISTORY;
-        entry.store(new as i16, Ordering::Relaxed);
-    }
-
-    pub fn clear(&self) {
-        for atomic in self.entries.iter().flatten().flatten().flatten().flatten().flatten() {
-            atomic.store(0, Ordering::Relaxed);
-        }
+    pub fn update(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square, bonus: i32) {
+        let entry = &mut unsafe { &mut *subtable_ptr }[piece][to];
+        apply_bonus::<{ Self::MAX_HISTORY }>(entry, bonus);
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1282,8 +1282,16 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
         + corrhist.minor.get(stm, td.board.minor_key())
         + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
         + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
-        + corrhist.continuation.get(td.stack[ply - 2].contcorrhist, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to())
-        + corrhist.continuation.get(td.stack[ply - 4].contcorrhist, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to()))
+        + td.continuation_corrhist.get(
+            td.stack[ply - 2].contcorrhist,
+            td.stack[ply - 1].piece,
+            td.stack[ply - 1].mv.to(),
+        )
+        + td.continuation_corrhist.get(
+            td.stack[ply - 4].contcorrhist,
+            td.stack[ply - 1].piece,
+            td.stack[ply - 1].mv.to(),
+        ))
         / 88
 }
 
@@ -1299,7 +1307,7 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
     corrhist.non_pawn[Color::Black].update(stm, td.board.non_pawn_key(Color::Black), bonus);
 
     if td.stack[ply - 1].mv.is_some() && td.stack[ply - 2].mv.is_some() {
-        corrhist.continuation.update(
+        td.continuation_corrhist.update(
             td.stack[ply - 2].contcorrhist,
             td.stack[ply - 1].piece,
             td.stack[ply - 1].mv.to(),
@@ -1308,7 +1316,7 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
     }
 
     if td.stack[ply - 1].mv.is_some() && td.stack[ply - 4].mv.is_some() {
-        corrhist.continuation.update(
+        td.continuation_corrhist.update(
             td.stack[ply - 4].contcorrhist,
             td.stack[ply - 1].piece,
             td.stack[ply - 1].mv.to(),
@@ -1332,7 +1340,7 @@ fn make_move(td: &mut ThreadData, ply: isize, mv: Move) {
     td.stack[ply].conthist =
         td.continuation_history.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
     td.stack[ply].contcorrhist =
-        td.corrhist().continuation.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
+        td.continuation_corrhist.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
 
     td.shared.nodes.increment(td.id);
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,14 +1,10 @@
-use std::{
-    ops::{Index, IndexMut},
-    sync::atomic::AtomicI16,
-};
+use std::ops::{Index, IndexMut};
 
 use crate::types::{Move, Piece, Score, MAX_PLY};
 
 pub struct Stack {
     data: [StackEntry; MAX_PLY + 16],
-    sentinel1: [[i16; 64]; 13],
-    sentinel2: [[AtomicI16; 64]; 13],
+    sentinel: [[i16; 64]; 13],
 }
 
 impl Stack {
@@ -21,13 +17,13 @@ impl Default for Stack {
     fn default() -> Self {
         let mut stack = Self {
             data: [StackEntry::default(); MAX_PLY + 16],
-            sentinel1: [[0; 64]; 13],
-            sentinel2: core::array::from_fn(|_| core::array::from_fn(|_| AtomicI16::new(0))),
+            sentinel: [[0; 64]; 13],
         };
 
+        let ptr = &mut stack.sentinel as *mut _;
         for entry in stack.data.iter_mut() {
-            entry.conthist = stack.sentinel1.as_mut_ptr().cast();
-            entry.contcorrhist = stack.sentinel2.as_mut_ptr().cast();
+            entry.conthist = ptr;
+            entry.contcorrhist = ptr;
         }
         stack
     }
@@ -45,7 +41,7 @@ pub struct StackEntry {
     pub move_count: i32,
     pub reduction: i32,
     pub conthist: *mut [[i16; 64]; 13],
-    pub contcorrhist: *const [[AtomicI16; 64]; 13],
+    pub contcorrhist: *mut [[i16; 64]; 13],
 }
 
 unsafe impl Send for StackEntry {}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -91,7 +91,6 @@ pub struct SharedCorrectionHistory {
     pub pawn: CorrectionHistory,
     pub minor: CorrectionHistory,
     pub non_pawn: [CorrectionHistory; 2],
-    pub continuation: ContinuationCorrectionHistory,
 }
 
 unsafe impl NumaValue for SharedCorrectionHistory {}
@@ -135,6 +134,7 @@ pub struct ThreadData {
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
     pub continuation_history: ContinuationHistory,
+    pub continuation_corrhist: ContinuationCorrectionHistory,
     pub best_move_changes: usize,
     pub optimism: [i32; 2],
     pub stopped: bool,
@@ -166,6 +166,7 @@ impl ThreadData {
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
             continuation_history: ContinuationHistory::default(),
+            continuation_corrhist: ContinuationCorrectionHistory::default(),
             best_move_changes: 0,
             optimism: [0; 2],
             stopped: false,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -125,7 +125,6 @@ fn reset(threads: &mut ThreadPool, shared: &Arc<SharedContext>) {
         corrhist.minor.clear();
         corrhist.non_pawn[Color::White].clear();
         corrhist.non_pawn[Color::Black].clear();
-        corrhist.continuation.clear();
     }
 }
 


### PR DESCRIPTION
Thanks to @anematode for pointing out that with the shared
continuation correction history, one could get a lot of false sharing.

Thanks to @vondele for testing.

Patch:
info depth 38 seldepth 61 multipv 1 score cp 17 nodes 3641669149 time 17008 nps 214110350 hashfull 103 tbhits 0

Main:
info depth 38 seldepth 61 multipv 1 score cp 10 nodes 4445645420 time 22861 nps 194460210 hashfull 125 tbhits 0

Bench: 3715752