### PR TITLE
Skip one depth for ttpv when checking for singular move

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -476,8 +476,11 @@ fn search<NODE: NodeType>(
         depth -= 1;
     }
 
-    let potential_singularity =
-        depth >= 5 && tt_depth >= depth - 3 && tt_bound != Bound::Upper && is_valid(tt_score) && !is_decisive(tt_score);
+    let potential_singularity = depth >= 5 + tt_pv as i32
+        && tt_depth >= depth - 3
+        && tt_bound != Bound::Upper
+        && is_valid(tt_score)
+        && !is_decisive(tt_score);
 
     let mut improvement = 0;
 


### PR DESCRIPTION
Elo   | 1.55 +- 1.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 73992 W: 18567 L: 18236 D: 37189
Penta | [150, 8604, 19155, 8939, 148]
https://recklesschess.space/test/10474/

Elo   | 1.07 +- 0.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 159154 W: 38988 L: 38500 D: 81666
Penta | [44, 17704, 43586, 18206, 37]
https://recklesschess.space/test/10475/

Bench: 2987194