### PR TITLE
Move saturation point of bonus formulas to earlier

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -985,14 +985,14 @@ fn search<NODE: NodeType>(
     }
 
     if best_move.is_some() {
-        let noisy_bonus = (111 * depth - 54).min(861) - 77 * cut_node as i32;
-        let noisy_malus = (173 * initial_depth - 53).min(1257) - 23 * noisy_moves.len() as i32;
+        let noisy_bonus = (111 * depth).min(861) - 54 - 77 * cut_node as i32;
+        let noisy_malus = (173 * initial_depth).min(1257) - 53 - 23 * noisy_moves.len() as i32;
 
-        let quiet_bonus = (179 * depth - 75).min(1335) - 56 * cut_node as i32;
-        let quiet_malus = (156 * initial_depth - 44).min(1056) - 41 * quiet_moves.len() as i32;
+        let quiet_bonus = (179 * depth).min(1335) - 75 - 56 * cut_node as i32;
+        let quiet_malus = (156 * initial_depth).min(1056) - 44 - 41 * quiet_moves.len() as i32;
 
-        let cont_bonus = (115 * depth - 67).min(972) - 50 * cut_node as i32;
-        let cont_malus = (343 * initial_depth - 47).min(856) - 21 * quiet_moves.len() as i32;
+        let cont_bonus = (115 * depth).min(972) - 67 - 50 * cut_node as i32;
+        let cont_malus = (343 * initial_depth).min(856) - 47 - 21 * quiet_moves.len() as i32;
 
         if best_move.is_noisy() {
             td.noisy_history.update(


### PR DESCRIPTION
Elo   | 1.49 +- 1.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 74026 W: 18086 L: 17768 D: 38172
Penta | [19, 8197, 20265, 8511, 21]
https://recklesschess.space/test/10517/

Bench: 2983831
