### PR TITLE
LTC SMP SPSA session 56k games

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,9 +1,9 @@
 use crate::{thread::ThreadData, types::Score};
 
 pub fn correct_eval(td: &ThreadData, raw_eval: i32, correction_value: i32) -> i32 {
-    let mut eval = (raw_eval * (21372 + td.board.material())
-        + td.optimism[td.board.side_to_move()] * (1536 + td.board.material()))
-        / 27380;
+    let mut eval = (raw_eval * (21061 + td.board.material())
+        + td.optimism[td.board.side_to_move()] * (1519 + td.board.material()))
+        / 26556;
 
     eval = eval * (200 - td.board.halfmove_clock() as i32) / 200;
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -20,8 +20,8 @@ struct QuietHistoryEntry {
 }
 
 impl QuietHistoryEntry {
-    const MAX_FACTORIZER: i32 = 1940;
-    const MAX_BUCKET: i32 = 6029;
+    const MAX_FACTORIZER: i32 = 1852;
+    const MAX_BUCKET: i32 = 6324;
 
     pub fn bucket(&self, threats: Bitboard, mv: Move) -> i16 {
         let from_threatened = threats.contains(mv.from()) as usize;
@@ -74,8 +74,8 @@ struct NoisyHistoryEntry {
 }
 
 impl NoisyHistoryEntry {
-    const MAX_FACTORIZER: i32 = 4449;
-    const MAX_BUCKET: i32 = 8148;
+    const MAX_FACTORIZER: i32 = 4524;
+    const MAX_BUCKET: i32 = 7826;
 
     pub fn bucket(&self, threats: Bitboard, sq: Square, captured: PieceType) -> i16 {
         let threatened = threats.contains(sq) as usize;
@@ -127,7 +127,7 @@ pub struct CorrectionHistory {
 unsafe impl NumaValue for CorrectionHistory {}
 
 impl CorrectionHistory {
-    const MAX_HISTORY: i32 = 14734;
+    const MAX_HISTORY: i32 = 14605;
 
     const SIZE: usize = 65536;
     const MASK: usize = Self::SIZE - 1;
@@ -163,7 +163,7 @@ pub struct ContinuationCorrectionHistory {
 }
 
 impl ContinuationCorrectionHistory {
-    const MAX_HISTORY: i32 = 16222;
+    const MAX_HISTORY: i32 = 16282;
 
     pub fn subtable_ptr(
         &mut self, in_check: bool, capture: bool, piece: Piece, to: Square,
@@ -193,7 +193,7 @@ pub struct ContinuationHistory {
 }
 
 impl ContinuationHistory {
-    const MAX_HISTORY: i32 = 15324;
+    const MAX_HISTORY: i32 = 15168;
 
     pub fn subtable_ptr(
         &mut self, in_check: bool, capture: bool, piece: Piece, to: Square,

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -85,7 +85,7 @@ impl MovePicker {
                     continue;
                 }
 
-                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 43 + 108);
+                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 46 + 109);
                 if !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;
@@ -191,11 +191,12 @@ impl MovePicker {
                 continue;
             }
 
-            entry.score = td.quiet_history.get(threats, side, mv)
-                + td.conthist(ply, 1, mv)
-                + td.conthist(ply, 2, mv)
-                + td.conthist(ply, 4, mv)
-                + td.conthist(ply, 6, mv);
+            entry.score = (994 * td.quiet_history.get(threats, side, mv)
+                + 1049 * td.conthist(ply, 1, mv)
+                + 990 * td.conthist(ply, 2, mv)
+                + 969 * td.conthist(ply, 4, mv)
+                + 1088 * td.conthist(ply, 6, mv))
+                / 1024;
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -111,12 +111,12 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
             // Aspiration Windows
             if depth >= 2 {
-                delta += average[td.pv_index] * average[td.pv_index] / 23682;
+                delta += average[td.pv_index] * average[td.pv_index] / 23660;
 
                 alpha = (average[td.pv_index] - delta).max(-Score::INFINITE);
                 beta = (average[td.pv_index] + delta).min(Score::INFINITE);
 
-                td.optimism[td.board.side_to_move()] = 158 * average[td.pv_index] / (average[td.pv_index].abs() + 191);
+                td.optimism[td.board.side_to_move()] = 169 * average[td.pv_index] / (average[td.pv_index].abs() + 187);
                 td.optimism[!td.board.side_to_move()] = -td.optimism[td.board.side_to_move()];
             }
 
@@ -138,13 +138,13 @@ pub fn start(td: &mut ThreadData, report: Report) {
                         beta = (3 * alpha + beta) / 4;
                         alpha = (score - delta).max(-Score::INFINITE);
                         reduction = 0;
-                        delta += 26 * delta / 128;
+                        delta += 27 * delta / 128;
                     }
                     s if s >= beta => {
                         alpha = (beta - delta).max(alpha);
                         beta = (score + delta).min(Score::INFINITE);
                         reduction += 1;
-                        delta += 61 * delta / 128;
+                        delta += 63 * delta / 128;
                     }
                     _ => {
                         average[td.pv_index] = if average[td.pv_index] == Score::NONE {
@@ -320,8 +320,8 @@ fn search<NODE: NodeType>(
             }
         {
             if tt_move.is_quiet() && tt_score >= beta && td.stack[ply - 1].move_count < 4 {
-                let quiet_bonus = (190 * depth - 80).min(1830);
-                let cont_bonus = (109 * depth - 56).min(1337);
+                let quiet_bonus = (185 * depth - 81).min(1806);
+                let cont_bonus = (108 * depth - 56).min(1365);
 
                 td.quiet_history.update(td.board.threats(), td.board.side_to_move(), tt_move, quiet_bonus);
                 update_continuation_histories(td, ply, td.board.moved_piece(tt_move), tt_move.to(), cont_bonus);
@@ -330,19 +330,19 @@ fn search<NODE: NodeType>(
             if tt_score <= alpha && td.stack[ply - 1].move_count > 8 {
                 let pcm_move = td.stack[ply - 1].mv;
                 if pcm_move.is_quiet() {
-                    let mut factor = 94;
-                    factor += 183 * (initial_depth > 5) as i32;
-                    factor += 132 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
+                    let mut factor = 93;
+                    factor += 190 * (initial_depth > 5) as i32;
+                    factor += 135 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
                     factor +=
-                        240 * (is_valid(td.stack[ply - 1].eval) && tt_score <= -td.stack[ply - 1].eval - 95) as i32;
+                        202 * (is_valid(td.stack[ply - 1].eval) && tt_score <= -td.stack[ply - 1].eval - 94) as i32;
 
-                    let scaled_bonus = factor * (163 * initial_depth - 44).min(2389) / 128;
+                    let scaled_bonus = factor * (171 * initial_depth - 42).min(2310) / 128;
 
                     td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
 
                     let entry = &td.stack[ply - 2];
                     if entry.mv.is_some() {
-                        let bonus = (122 * initial_depth - 34).min(1723);
+                        let bonus = (115 * initial_depth - 34).min(1776);
                         td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
                     }
                 }
@@ -452,14 +452,14 @@ fn search<NODE: NodeType>(
 
     // Quiet move ordering using eval difference
     if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].mv.is_quiet() && is_valid(td.stack[ply - 1].eval) {
-        let value = 865 * (-(eval + td.stack[ply - 1].eval)) / 128;
-        let bonus = value.clamp(-119, 325);
+        let value = 819 * (-(eval + td.stack[ply - 1].eval)) / 128;
+        let bonus = value.clamp(-124, 312);
 
         td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), td.stack[ply - 1].mv, bonus);
     }
 
     // Hindsight reductions
-    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].reduction >= 2325 && eval + td.stack[ply - 1].eval < 0
+    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].reduction >= 2247 && eval + td.stack[ply - 1].eval < 1
     {
         depth += 1;
     }
@@ -469,9 +469,9 @@ fn search<NODE: NodeType>(
         && !in_check
         && !excluded
         && depth >= 2
-        && td.stack[ply - 1].reduction >= 758
+        && td.stack[ply - 1].reduction >= 756
         && is_valid(td.stack[ply - 1].eval)
-        && eval + td.stack[ply - 1].eval > 62
+        && eval + td.stack[ply - 1].eval > 59
     {
         depth -= 1;
     }
@@ -493,7 +493,7 @@ fn search<NODE: NodeType>(
     let improving = improvement > 0;
 
     // Razoring
-    if !NODE::PV && !in_check && estimated_score < alpha - 281 - 271 * depth * depth && alpha < 2048 {
+    if !NODE::PV && !in_check && estimated_score < alpha - 299 - 252 * depth * depth && alpha < 2048 {
         return qsearch::<NonPV>(td, alpha, beta, ply);
     }
 
@@ -503,9 +503,9 @@ fn search<NODE: NodeType>(
         && is_valid(estimated_score)
         && estimated_score >= beta
         && estimated_score
-            >= beta + 1085 * depth * depth / 128 + 25 * depth - (79 * improving as i32)
-                + 500 * correction_value.abs() / 1024
-                + 35 * (depth == 1) as i32
+            >= beta + 1125 * depth * depth / 128 + 26 * depth - (77 * improving as i32)
+                + 519 * correction_value.abs() / 1024
+                + 32 * (depth == 1) as i32
         && !is_loss(beta)
         && !is_win(estimated_score)
     {
@@ -519,14 +519,14 @@ fn search<NODE: NodeType>(
         && !potential_singularity
         && estimated_score >= beta
         && estimated_score >= eval
-        && eval >= beta - 10 * depth + 128 * tt_pv as i32 - 133 * improvement / 1024 + 274
+        && eval >= beta - 9 * depth + 126 * tt_pv as i32 - 128 * improvement / 1024 + 286
         && ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
         && !is_loss(beta)
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
-        let r = (5140 + 273 * depth + 4 * (estimated_score - beta).clamp(0, 1024)) / 1024;
+        let r = (5154 + 271 * depth + 535 * (estimated_score - beta).clamp(0, 1073) / 128) / 1024;
 
         td.stack[ply].conthist = td.stack.sentinel().conthist;
         td.stack[ply].contcorrhist = td.stack.sentinel().contcorrhist;
@@ -563,7 +563,7 @@ fn search<NODE: NodeType>(
     }
 
     // ProbCut
-    let mut probcut_beta = beta + 257 - 75 * improving as i32;
+    let mut probcut_beta = beta + 269 - 72 * improving as i32;
 
     if cut_node
         && !is_decisive(beta)
@@ -585,10 +585,10 @@ fn search<NODE: NodeType>(
 
             let mut score = -qsearch::<NonPV>(td, -probcut_beta, -probcut_beta + 1, ply + 1);
 
-            let mut probcut_depth = (depth - 4 - ((score - probcut_beta - 50) / 300).clamp(0, 3)).max(0);
+            let mut probcut_depth = (depth - 4 - ((score - probcut_beta - 50) / 295).clamp(0, 3)).max(0);
             let og_probcut_depth = (depth - 4).max(0);
             let raised_probcut_beta =
-                (probcut_beta + (og_probcut_depth - probcut_depth) * 300).clamp(-Score::INFINITE + 1, Score::INFINITE);
+                (probcut_beta + (og_probcut_depth - probcut_depth) * 282).clamp(-Score::INFINITE + 1, Score::INFINITE);
 
             if score >= probcut_beta && probcut_depth > 0 {
                 score =
@@ -702,14 +702,14 @@ fn search<NODE: NodeType>(
             // Late Move Pruning (LMP)
             skip_quiets |= !in_check
                 && move_count
-                    >= if improving || eval >= beta + 19 {
-                        (3219 + 1093 * initial_depth * initial_depth) / 1024
+                    >= if improving || eval >= beta + 20 {
+                        (3127 + 1089 * initial_depth * initial_depth) / 1024
                     } else {
-                        (1252 + 320 * initial_depth * initial_depth) / 1024
+                        (1320 + 315 * initial_depth * initial_depth) / 1024
                     };
 
             // Futility Pruning (FP)
-            let futility_value = eval + 94 * depth + 61 * history / 1024 + 87 * (eval >= alpha) as i32 - 116;
+            let futility_value = eval + 88 * depth + 63 * history / 1024 + 88 * (eval >= alpha) as i32 - 114;
 
             if !in_check && is_quiet && depth < 14 && futility_value <= alpha && !td.board.is_direct_check(mv) {
                 if !is_decisive(best_score) && best_score <= futility_value {
@@ -721,10 +721,10 @@ fn search<NODE: NodeType>(
 
             // Bad Noisy Futility Pruning (BNFP)
             let noisy_futility_value = eval
-                + 68 * depth
-                + 68 * history / 1024
-                + 83 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 1024
-                + 24;
+                + 71 * depth
+                + 69 * history / 1024
+                + 81 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 1024
+                + 25;
 
             if !in_check
                 && depth < 12
@@ -740,9 +740,9 @@ fn search<NODE: NodeType>(
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                (-16 * depth * depth + 50 * depth - 21 * history / 1024 + 25).min(0)
+                (-16 * depth * depth + 52 * depth - 21 * history / 1024 + 22).min(0)
             } else {
-                (-8 * depth * depth - 36 * depth - 33 * history / 1024 + 10).min(0)
+                (-8 * depth * depth - 36 * depth - 32 * history / 1024 + 11).min(0)
             };
 
             if !td.board.see(mv, threshold) {
@@ -764,60 +764,60 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count > 1 {
-            let mut reduction = 240 * (move_count.ilog2() * depth.ilog2()) as i32;
+            let mut reduction = 237 * (move_count.ilog2() * depth.ilog2()) as i32;
 
-            reduction += 28 * move_count.ilog2() as i32;
-            reduction += 28 * depth.ilog2() as i32;
+            reduction += 29 * move_count.ilog2() as i32;
+            reduction += 29 * depth.ilog2() as i32;
 
-            reduction -= 68 * move_count;
-            reduction -= 3326 * correction_value.abs() / 1024;
+            reduction -= 65 * move_count;
+            reduction -= 3183 * correction_value.abs() / 1024;
 
             if is_quiet {
-                reduction += 2031;
-                reduction -= 152 * history / 1024;
+                reduction += 1922;
+                reduction -= 154 * history / 1024;
             } else {
-                reduction += 1563;
-                reduction -= 102 * history / 1024;
-                reduction -= 50 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
+                reduction += 1602;
+                reduction -= 109 * history / 1024;
+                reduction -= 57 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
 
             if NODE::PV {
-                reduction -= 425 + 453 * (beta - alpha) / td.root_delta;
+                reduction -= 411 + 421 * (beta - alpha) / td.root_delta;
             }
 
             if tt_pv {
-                reduction -= 349;
-                reduction -= 714 * (is_valid(tt_score) && tt_score > alpha) as i32;
-                reduction -= 897 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                reduction -= 371;
+                reduction -= 656 * (is_valid(tt_score) && tt_score > alpha) as i32;
+                reduction -= 824 * (is_valid(tt_score) && tt_depth >= depth) as i32;
             }
 
             if mv.is_noisy() && mv.to() == td.board.recapture_square() {
-                reduction -= 907;
+                reduction -= 910;
             }
 
             if !tt_pv && cut_node {
-                reduction += 1713;
-                reduction += 1086 * tt_move.is_null() as i32;
+                reduction += 1762;
+                reduction += 1092 * tt_move.is_null() as i32;
             }
 
             if !improving {
-                reduction += (443 - 268 * improvement / 128).min(1321);
+                reduction += (438 - 279 * improvement / 128).min(1288);
             }
 
             if td.board.in_check() || !td.board.has_non_pawns() {
-                reduction -= 884;
+                reduction -= 966;
             }
 
             if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1498;
+                reduction += 1604;
             }
 
             if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
-                reduction += 622;
+                reduction += 668;
             }
 
             if depth == 2 {
-                reduction -= 1264;
+                reduction -= 1195;
             }
 
             let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + 1) + 2 * NODE::PV as i32;
@@ -829,7 +829,7 @@ fn search<NODE: NodeType>(
 
             if score > alpha && new_depth > reduced_depth {
                 if !NODE::ROOT {
-                    new_depth += (score > best_score + 43 + 482 * depth / 128) as i32;
+                    new_depth += (score > best_score + 41 + 447 * depth / 128) as i32;
                     new_depth -= (score < best_score + new_depth) as i32;
                 }
 
@@ -843,50 +843,50 @@ fn search<NODE: NodeType>(
         }
         // Full Depth Search (FDS)
         else if !NODE::PV || move_count > 1 {
-            let mut reduction = 246 * (move_count.ilog2() * depth.ilog2()) as i32;
+            let mut reduction = 238 * (move_count.ilog2() * depth.ilog2()) as i32;
 
-            reduction += 25 * move_count.ilog2() as i32;
-            reduction += 25 * depth.ilog2() as i32;
+            reduction += 26 * move_count.ilog2() as i32;
+            reduction += 23 * depth.ilog2() as i32;
 
-            reduction -= 55 * move_count;
-            reduction -= 2484 * correction_value.abs() / 1024;
+            reduction -= 57 * move_count;
+            reduction -= 2513 * correction_value.abs() / 1024;
 
             if is_quiet {
-                reduction += 1634;
-                reduction -= 154 * history / 1024;
+                reduction += 1577;
+                reduction -= 158 * history / 1024;
             } else {
                 reduction += 1423;
                 reduction -= 65 * history / 1024;
-                reduction -= 47 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
+                reduction -= 48 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
 
             if tt_pv {
-                reduction -= 747;
-                reduction -= 1080 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                reduction -= 897;
+                reduction -= 1127 * (is_valid(tt_score) && tt_depth >= depth) as i32;
             }
 
             if !tt_pv && cut_node {
-                reduction += 1379;
-                reduction += 1211 * tt_move.is_null() as i32;
+                reduction += 1450;
+                reduction += 1176 * tt_move.is_null() as i32;
             }
 
             if !improving {
-                reduction += (443 - 268 * improvement / 128).min(1321);
+                reduction += (454 - 254 * improvement / 128).min(1368);
             }
 
             if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1445;
+                reduction += 1452;
             }
 
             if depth == 2 {
-                reduction -= 1166;
+                reduction -= 1144;
             }
 
             if mv == tt_move {
-                reduction -= 3187;
+                reduction -= 3316;
             }
 
-            let reduced_depth = new_depth - (reduction >= 3072) as i32 - (reduction >= 5653 && new_depth >= 3) as i32;
+            let reduced_depth = new_depth - (reduction >= 3072) as i32 - (reduction >= 5687 && new_depth >= 3) as i32;
 
             td.stack[ply].reduction = 1024 * ((initial_depth - 1) - new_depth);
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
@@ -988,14 +988,14 @@ fn search<NODE: NodeType>(
     }
 
     if best_move.is_some() {
-        let noisy_bonus = (111 * depth).min(861) - 54 - 77 * cut_node as i32;
-        let noisy_malus = (173 * initial_depth).min(1257) - 53 - 23 * noisy_moves.len() as i32;
+        let noisy_bonus = (106 * depth).min(808) - 54 - 80 * cut_node as i32;
+        let noisy_malus = (172 * initial_depth).min(1329) - 52 - 23 * noisy_moves.len() as i32;
 
-        let quiet_bonus = (179 * depth).min(1335) - 75 - 56 * cut_node as i32;
-        let quiet_malus = (156 * initial_depth).min(1056) - 44 - 41 * quiet_moves.len() as i32;
+        let quiet_bonus = (172 * depth).min(1459) - 78 - 54 * cut_node as i32;
+        let quiet_malus = (151 * initial_depth).min(1064) - 45 - 39 * quiet_moves.len() as i32;
 
-        let cont_bonus = (115 * depth).min(972) - 67 - 50 * cut_node as i32;
-        let cont_malus = (343 * initial_depth).min(856) - 47 - 21 * quiet_moves.len() as i32;
+        let cont_bonus = (108 * depth).min(977) - 67 - 52 * cut_node as i32;
+        let cont_malus = (369 * initial_depth).min(868) - 47 - 19 * quiet_moves.len() as i32;
 
         if best_move.is_noisy() {
             td.noisy_history.update(
@@ -1021,12 +1021,12 @@ fn search<NODE: NodeType>(
         }
 
         if !NODE::ROOT && td.stack[ply - 1].mv.is_quiet() && td.stack[ply - 1].move_count < 2 {
-            let malus = (86 * initial_depth - 58).min(778);
+            let malus = (90 * initial_depth - 60).min(771);
             update_continuation_histories(td, ply - 1, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to(), -malus);
         }
 
         if current_search_count > 1 && best_move.is_quiet() && best_score >= beta {
-            let bonus = (210 * depth - 87).min(1663);
+            let bonus = (211 * depth - 86).min(1634);
             update_continuation_histories(td, ply, td.stack[ply].piece, best_move.to(), bonus);
         }
     }
@@ -1034,25 +1034,25 @@ fn search<NODE: NodeType>(
     if !NODE::ROOT && bound == Bound::Upper {
         let pcm_move = td.stack[ply - 1].mv;
         if pcm_move.is_quiet() {
-            let mut factor = 97;
-            factor += 159 * (initial_depth > 5) as i32;
-            factor += 214 * (td.stack[ply - 1].move_count > 8) as i32;
-            factor += 112 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
-            factor += 151 * (!in_check && best_score <= eval.min(raw_eval) - 95) as i32;
-            factor += 319 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 113) as i32;
+            let mut factor = 95;
+            factor += 156 * (initial_depth > 5) as i32;
+            factor += 215 * (td.stack[ply - 1].move_count > 8) as i32;
+            factor += 113 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
+            factor += 156 * (!in_check && best_score <= eval.min(raw_eval) - 96) as i32;
+            factor += 317 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 120) as i32;
 
-            let scaled_bonus = factor * (157 * initial_depth - 33).min(2564) / 128;
+            let scaled_bonus = factor * (158 * initial_depth - 34).min(2474) / 128;
 
             td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
 
             let entry = &td.stack[ply - 2];
             if entry.mv.is_some() {
-                let bonus = (166 * initial_depth - 37).min(1268);
+                let bonus = (161 * initial_depth - 38).min(1169);
                 td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
             }
         } else if pcm_move.is_noisy() {
             let captured = td.board.captured_piece().unwrap_or_default().piece_type();
-            let bonus = 57;
+            let bonus = 60;
 
             td.noisy_history.update(
                 td.board.prior_threats(),
@@ -1219,14 +1219,14 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
                 break;
             }
 
-            let futility_score = best_score + 42 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128 + 109;
+            let futility_score = best_score + 42 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128 + 104;
 
             if !in_check && futility_score <= alpha && !td.board.see(mv, 1) {
                 continue;
             }
         }
 
-        if !is_loss(best_score) && !td.board.see(mv, -79) {
+        if !is_loss(best_score) && !td.board.see(mv, -81) {
             continue;
         }
 
@@ -1281,27 +1281,30 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
     let stm = td.board.side_to_move();
     let corrhist = td.corrhist();
 
-    (corrhist.pawn.get(stm, td.board.pawn_key())
-        + corrhist.minor.get(stm, td.board.minor_key())
-        + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
-        + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
-        + td.continuation_corrhist.get(
-            td.stack[ply - 2].contcorrhist,
-            td.stack[ply - 1].piece,
-            td.stack[ply - 1].mv.to(),
-        )
-        + td.continuation_corrhist.get(
-            td.stack[ply - 4].contcorrhist,
-            td.stack[ply - 1].piece,
-            td.stack[ply - 1].mv.to(),
-        ))
-        / 88
+    (1033 * corrhist.pawn.get(stm, td.board.pawn_key())
+        + 959 * corrhist.minor.get(stm, td.board.minor_key())
+        + 1044 * corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
+        + 1044 * corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
+        + 1001
+            * td.continuation_corrhist.get(
+                td.stack[ply - 2].contcorrhist,
+                td.stack[ply - 1].piece,
+                td.stack[ply - 1].mv.to(),
+            )
+        + 1014
+            * td.continuation_corrhist.get(
+                td.stack[ply - 4].contcorrhist,
+                td.stack[ply - 1].piece,
+                td.stack[ply - 1].mv.to(),
+            ))
+        / 1024
+        / 77
 }
 
 fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: isize) {
     let stm = td.board.side_to_move();
     let corrhist = td.corrhist();
-    let bonus = (140 * depth * diff / 128).clamp(-5042, 2895);
+    let bonus = (142 * depth * diff / 128).clamp(-4923, 3072);
 
     corrhist.pawn.update(stm, td.board.pawn_key(), bonus);
     corrhist.minor.update(stm, td.board.minor_key(), bonus);


### PR DESCRIPTION
LTC SMP
Elo   | 2.87 +- 2.18 (95%)
SPRT  | 40.0+0.40s Threads=8 Hash=512MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 20304 W: 5118 L: 4950 D: 10236
Penta | [0, 2027, 5931, 2193, 1]
https://recklesschess.space/test/10566/

LTC
Elo   | -3.30 +- 3.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11158 W: 2643 L: 2749 D: 5766
Penta | [2, 1347, 2989, 1237, 4]
https://recklesschess.space/test/10564/

STC
Elo   | -6.87 +- 4.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 5922 W: 1395 L: 1512 D: 3015
Penta | [11, 745, 1567, 626, 12]
https://recklesschess.space/test/10563/

Bench: 2758441