### PR TITLE
Simplify away piece value LMR/FDS rule

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -776,9 +776,8 @@ fn search<NODE: NodeType>(
                 reduction += 1922;
                 reduction -= 154 * history / 1024;
             } else {
-                reduction += 1602;
+                reduction += 1402;
                 reduction -= 109 * history / 1024;
-                reduction -= 57 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
 
             if NODE::PV {
@@ -855,9 +854,8 @@ fn search<NODE: NodeType>(
                 reduction += 1577;
                 reduction -= 158 * history / 1024;
             } else {
-                reduction += 1423;
+                reduction += 1248;
                 reduction -= 65 * history / 1024;
-                reduction -= 48 * PIECE_VALUES[td.board.piece_on(mv.to()).piece_type()] / 128;
             }
 
             if tt_pv {


### PR DESCRIPTION
STC
Elo   | 1.53 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 27508 W: 6973 L: 6852 D: 13683
Penta | [88, 3211, 7022, 3358, 75]
https://recklesschess.space/test/10594/

LTC
Elo   | 0.22 +- 1.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 60328 W: 14719 L: 14681 D: 30928
Penta | [19, 6826, 16448, 6840, 31]
https://recklesschess.space/test/10602/

Bench: 2952485