### PR TITLE
Remove Recapture Multiplier in Time Management

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -211,11 +211,9 @@ pub fn start(td: &mut ThreadData, report: Report) {
 
             let score_trend = (0.8 + 0.05 * (td.previous_best_score - td.root_moves[0].score) as f32).clamp(0.80, 1.45);
 
-            let recapture_factor = if td.root_moves[0].mv.to() == td.board.recapture_square() { 0.9 } else { 1.0 };
-
             let best_move_stability = 1.0 + best_move_changes as f32 / 4.0;
 
-            nodes_factor * pv_stability * eval_stability * score_trend * recapture_factor * best_move_stability
+            nodes_factor * pv_stability * eval_stability * score_trend * best_move_stability
         };
 
         if td.time_manager.soft_limit(td, multiplier) {


### PR DESCRIPTION
First try, first hit :P
Remove Recapture Multiplier in Time Management

Passed STC:
LLR: 3.01 (-2.25, 2.89) [-2.75, 0.25]
Games: 55390 W: 13858 L: 13785 D: 27747
Ptnml(0-2): 126, 6076, 15213, 6159, 121
https://recklesschess.space/test/10652/

Passed LTC:
LLR: 2.96 (-2.25, 2.89) [-3.00, 0.00]
Games: 43670 W: 10697 L: 10626 D: 22347
Ptnml(0-2): 11, 4562, 12621, 4627, 14
https://recklesschess.space/test/10654/

bench: 3196877
No Functional Change