### PR TITLE
Fully extend single legal moves

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -977,7 +977,7 @@ fn search<NODE: NodeType>(
 
     if move_count == 0 {
         if excluded {
-            return alpha;
+            return -Score::TB_WIN_IN_MAX + 1;
         }
 
         return if in_check { mated_in(ply) } else { draw(td) };


### PR DESCRIPTION
Stopped STC:
Elo   | -1.02 +- 3.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.12 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12910 W: 3241 L: 3279 D: 6390
Penta | [45, 1546, 3299, 1532, 33]
https://recklesschess.space/test/10585/

Speculative LTC:
Elo   | 1.28 +- 1.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 100936 W: 24838 L: 24466 D: 51632
Penta | [45, 11351, 27308, 11715, 49]
https://recklesschess.space/test/10586/

Bench: 3080885