### PR TITLE
nmp-tt-capture-condition

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -521,7 +521,10 @@ fn search<NODE: NodeType>(
         && ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
         && !is_loss(beta)
-        && !(tt_bound == Bound::Lower && tt_move != Move::NULL && tt_move.is_capture() && td.board.piece_on(tt_move.to()).is_valuable())
+        && !(tt_bound == Bound::Lower
+            && tt_move.is_some()
+            && tt_move.is_capture()
+            && td.board.piece_on(tt_move.to()).is_valuable())
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 

--- a/src/types/piece.rs
+++ b/src/types/piece.rs
@@ -55,7 +55,7 @@ impl Piece {
     ];
 
     pub fn is_valuable(self) -> bool {
-        return Piece::VALUABLE.contains(&self);
+        Piece::VALUABLE.contains(&self)
     }
 
     pub const fn new(color: Color, piece_type: PieceType) -> Self {


### PR DESCRIPTION
Elo   | 3.43 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22374 W: 5700 L: 5479 D: 11195
Penta | [44, 2593, 5704, 2790, 56]
https://recklesschess.space/test/10664/
Elo   | 3.67 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.17 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20816 W: 5169 L: 4949 D: 10698
Penta | [8, 2277, 5616, 2501, 6]
https://recklesschess.space/test/10665/
bench: 3241114