### PR TITLE
Make Syzygy tablebase support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ build = "build/build.rs"
 publish = false
 
 [features]
+default = ["syzygy"]
+syzygy = []
 numa = []
 spsa = []
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ cargo rustc --release -- -C target-cpu=native
 # ./target/release/reckless
 ```
 
+To build without Syzygy tablebase support and Clang dependency, add the `--no-default-features` flag:
+
+```bash
+cargo rustc --release --no-default-features -- -C target-cpu=native
+```
+
 #### PGO builds
 
 For profile-guided optimization (PGO) builds, you need to install additional tools:

--- a/build/build.rs
+++ b/build/build.rs
@@ -18,6 +18,8 @@ fn main() {
     generate_attack_maps();
     generate_compiler_info();
     generate_engine_version();
+
+    #[cfg(feature = "syzygy")]
     generate_syzygy_binding();
 
     if !Path::new("networks").join(NETWORK_NAME).exists() && env::var("EVALFILE").is_err() {
@@ -30,6 +32,7 @@ fn main() {
     println!("cargo:rerun-if-changed=networks/{NETWORK_NAME}");
 }
 
+#[cfg(feature = "syzygy")]
 fn generate_syzygy_binding() {
     cc::Build::new()
         .compiler("clang")

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ mod numa;
 mod parameters;
 mod search;
 mod stack;
-mod tb;
 mod thread;
 mod threadpool;
 mod time;
@@ -22,6 +21,10 @@ mod transposition;
 mod types;
 mod uci;
 
+#[cfg(feature = "syzygy")]
+mod tb;
+
+#[cfg(feature = "syzygy")]
 #[allow(warnings)]
 mod bindings;
 

--- a/src/tb.rs
+++ b/src/tb.rs
@@ -17,27 +17,27 @@ pub enum GameOutcome {
     Draw,
 }
 
-static mut TB_SIZE: usize = 0;
+static mut SIZE: usize = 0;
 
-pub fn tb_initialize(path: &str) -> Option<usize> {
+pub fn initialize(path: &str) -> Option<usize> {
     let cpath = ffi::CString::new(path).ok()?;
 
     unsafe {
         tb_init(cpath.as_ptr());
-        TB_SIZE = TB_LARGEST as usize;
+        SIZE = TB_LARGEST as usize;
     };
 
-    match tb_size() {
+    match size() {
         0 => None,
-        _ => Some(tb_size()),
+        _ => Some(size()),
     }
 }
 
-pub fn tb_size() -> usize {
-    unsafe { TB_SIZE }
+pub fn size() -> usize {
+    unsafe { SIZE }
 }
 
-pub fn tb_probe(board: &Board) -> Option<GameOutcome> {
+pub fn probe(board: &Board) -> Option<GameOutcome> {
     let code = unsafe {
         tb_probe_wdl(
             board.colors(Color::White).0,
@@ -87,7 +87,7 @@ fn reckless_move_to_tb_move(mv: Move) -> TbMove {
     tb_move
 }
 
-pub fn tb_rank_rootmoves(td: &mut ThreadData) {
+pub fn rank_rootmoves(td: &mut ThreadData) {
     let mut rootmoves_in_c: mem::MaybeUninit<TbRootMoves> = mem::MaybeUninit::uninit();
 
     unsafe {

--- a/src/types/score.rs
+++ b/src/types/score.rs
@@ -29,10 +29,12 @@ pub const fn mate_in(ply: isize) -> i32 {
     Score::MATE - ply as i32
 }
 
+#[cfg(feature = "syzygy")]
 pub const fn tb_loss_in(ply: isize) -> i32 {
     -Score::TB_WIN + ply as i32
 }
 
+#[cfg(feature = "syzygy")]
 pub const fn tb_win_in(ply: isize) -> i32 {
     Score::TB_WIN - ply as i32
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use crate::{
     board::{Board, NullBoardObserver},
     search::Report,
-    tb::tb_initialize,
     thread::{SharedContext, Status, ThreadData},
     threadpool::ThreadPool,
     time::{Limits, TimeManager},
@@ -134,9 +133,11 @@ fn uci() {
     println!("option name MoveOverhead type spin default 100 min 0 max 2000");
     println!("option name Minimal type check default false");
     println!("option name Clear Hash type button");
-    println!("option name SyzygyPath type string default");
     println!("option name UCI_Chess960 type check default false");
     println!("option name MultiPV type spin default 1 min 1 max {MAX_MOVES}");
+
+    #[cfg(feature = "syzygy")]
+    println!("option name SyzygyPath type string default");
 
     #[cfg(feature = "spsa")]
     crate::parameters::print_options();
@@ -289,7 +290,8 @@ fn set_option(threads: &mut ThreadPool, settings: &mut Settings, shared: &Arc<Sh
             settings.move_overhead = v.parse().unwrap();
             println!("info string set MoveOverhead to {v} ms");
         }
-        ["name", "SyzygyPath", "value", v] => match tb_initialize(v) {
+        #[cfg(feature = "syzygy")]
+        ["name", "SyzygyPath", "value", v] => match crate::tb::initialize(v) {
             Some(size) => println!("info string Loaded Syzygy tablebases with {size} pieces"),
             None => eprintln!("Failed to load Syzygy tablebases"),
         },


### PR DESCRIPTION
Add a Cargo feature to control Syzygy tablebase support. The default
behavior remains unchanged with Syzygy enabled and Clang required.

Bench: 3451440