### PR TITLE
Leave quiescence on quiet TT move.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1156,6 +1156,13 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         {
             return tt_score;
         }
+
+        if !NODE::PV && !td.reverse_qsearch && entry.mv.is_quiet() {
+            td.reverse_qsearch = true;
+            let score = search::<NonPV>(td, alpha, beta, 1, true, ply);
+            td.reverse_qsearch = false;
+            return score;
+        }
     }
 
     let mut best_score = -Score::INFINITE;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -150,6 +150,7 @@ pub struct ThreadData {
     pub pv_index: usize,
     pub pv_start: usize,
     pub pv_end: usize,
+    pub reverse_qsearch: bool,
 }
 
 impl ThreadData {
@@ -182,6 +183,7 @@ impl ThreadData {
             pv_index: 0,
             pv_start: 0,
             pv_end: 0,
+            reverse_qsearch: false,
         }
     }
 


### PR DESCRIPTION
Elo   | 1.13 +- 0.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 138604 W: 33983 L: 33533 D: 71088
Penta | [37, 15497, 37803, 15909, 56]
https://recklesschess.space/test/10739/

Bench: 3095086