### PR TITLE
Simplify away initial depth variable

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -296,7 +296,6 @@ fn search<NODE: NodeType>(
     let mut best_score = -Score::INFINITE;
 
     let mut depth = depth.min(MAX_PLY as i32 - 1);
-    let initial_depth = depth;
 
     let hash = td.board.hash();
     let entry = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
@@ -337,18 +336,18 @@ fn search<NODE: NodeType>(
                 let pcm_move = td.stack[ply - 1].mv;
                 if pcm_move.is_quiet() {
                     let mut factor = 93;
-                    factor += 190 * (initial_depth > 5) as i32;
+                    factor += 190 * (depth > 5) as i32;
                     factor += 135 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
                     factor +=
                         202 * (is_valid(td.stack[ply - 1].eval) && tt_score <= -td.stack[ply - 1].eval - 94) as i32;
 
-                    let scaled_bonus = factor * (171 * initial_depth - 42).min(2310) / 128;
+                    let scaled_bonus = factor * (171 * depth - 42).min(2310) / 128;
 
                     td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
 
                     let entry = &td.stack[ply - 2];
                     if entry.mv.is_some() {
-                        let bonus = (115 * initial_depth - 34).min(1776);
+                        let bonus = (115 * depth - 34).min(1776);
                         td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
                     }
                 }
@@ -713,9 +712,9 @@ fn search<NODE: NodeType>(
             skip_quiets |= !in_check
                 && move_count
                     >= if improving || eval >= beta + 20 {
-                        (3127 + 1089 * initial_depth * initial_depth) / 1024
+                        (3127 + 1075 * depth * depth) / 1024
                     } else {
-                        (1320 + 315 * initial_depth * initial_depth) / 1024
+                        (1320 + 311 * depth * depth) / 1024
                     };
 
             // Futility Pruning (FP)
@@ -896,7 +895,7 @@ fn search<NODE: NodeType>(
 
             let reduced_depth = new_depth - (reduction >= 3072) as i32 - (reduction >= 5687 && new_depth >= 3) as i32;
 
-            td.stack[ply].reduction = 1024 * ((initial_depth - 1) - new_depth);
+            td.stack[ply].reduction = 1024 * ((depth - 1) - new_depth);
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
             td.stack[ply].reduction = 0;
             current_search_count += 1;
@@ -997,13 +996,13 @@ fn search<NODE: NodeType>(
 
     if best_move.is_some() {
         let noisy_bonus = (106 * depth).min(808) - 54 - 80 * cut_node as i32;
-        let noisy_malus = (172 * initial_depth).min(1329) - 52 - 23 * noisy_moves.len() as i32;
+        let noisy_malus = (164 * depth).min(1329) - 52 - 23 * noisy_moves.len() as i32;
 
         let quiet_bonus = (172 * depth).min(1459) - 78 - 54 * cut_node as i32;
-        let quiet_malus = (151 * initial_depth).min(1064) - 45 - 39 * quiet_moves.len() as i32;
+        let quiet_malus = (144 * depth).min(1064) - 45 - 39 * quiet_moves.len() as i32;
 
         let cont_bonus = (108 * depth).min(977) - 67 - 52 * cut_node as i32;
-        let cont_malus = (369 * initial_depth).min(868) - 47 - 19 * quiet_moves.len() as i32;
+        let cont_malus = (352 * depth).min(868) - 47 - 19 * quiet_moves.len() as i32;
 
         if best_move.is_noisy() {
             td.noisy_history.update(
@@ -1029,12 +1028,12 @@ fn search<NODE: NodeType>(
         }
 
         if !NODE::ROOT && td.stack[ply - 1].mv.is_quiet() && td.stack[ply - 1].move_count < 2 {
-            let malus = (90 * initial_depth - 60).min(771);
+            let malus = (86 * depth - 60).min(771);
             update_continuation_histories(td, ply - 1, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to(), -malus);
         }
 
         if current_search_count > 1 && best_move.is_quiet() && best_score >= beta {
-            let bonus = (211 * depth - 86).min(1634);
+            let bonus = (201 * depth - 86).min(1634);
             update_continuation_histories(td, ply, td.stack[ply].piece, best_move.to(), bonus);
         }
     }
@@ -1043,19 +1042,19 @@ fn search<NODE: NodeType>(
         let pcm_move = td.stack[ply - 1].mv;
         if pcm_move.is_quiet() {
             let mut factor = 95;
-            factor += 156 * (initial_depth > 5) as i32;
+            factor += 156 * (depth > 5) as i32;
             factor += 215 * (td.stack[ply - 1].move_count > 8) as i32;
             factor += 113 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
             factor += 156 * (!in_check && best_score <= eval.min(raw_eval) - 96) as i32;
             factor += 317 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 120) as i32;
 
-            let scaled_bonus = factor * (158 * initial_depth - 34).min(2474) / 128;
+            let scaled_bonus = factor * (153 * depth - 34).min(2474) / 128;
 
             td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
 
             let entry = &td.stack[ply - 2];
             if entry.mv.is_some() {
-                let bonus = (161 * initial_depth - 38).min(1169);
+                let bonus = (156 * depth - 38).min(1169);
                 td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
             }
         } else if pcm_move.is_noisy() {


### PR DESCRIPTION
Elo   | -0.19 +- 1.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 104852 W: 25435 L: 25491 D: 53926
Penta | [32, 11863, 28684, 11823, 24]
https://recklesschess.space/test/10758/

Bench: 3372187
