### PR TITLE
Another round of minor code cleanups

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -69,7 +69,7 @@ impl Board {
 
             self.update_hash(captured, to);
 
-            self.state.material -= captured.piece_type().value();
+            self.state.material -= captured.value();
             self.state.captured = Some(captured);
             self.state.recapture_square = to;
         } else if !mv.is_castling() {
@@ -94,7 +94,7 @@ impl Board {
 
                 self.update_hash(captured, to ^ 8);
 
-                self.state.material -= captured.piece_type().value();
+                self.state.material -= captured.value();
             }
             MoveKind::Castling => {
                 let (rook_from, rook_to) = self.get_castling_rook(to);
@@ -127,7 +127,7 @@ impl Board {
                 self.update_hash(piece, to);
                 self.update_hash(promotion, to);
 
-                self.state.material += promotion.piece_type().value() - PieceType::Pawn.value();
+                self.state.material += promotion.value() - PieceType::Pawn.value();
             }
             _ => (),
         }

--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -40,7 +40,7 @@ impl Board {
                 let square = Square::from_rank_file(rank as u8, file);
 
                 board.add_piece(piece, square);
-                board.state.material += piece.piece_type().value();
+                board.state.material += piece.value();
                 file += 1;
             }
         }

--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -21,7 +21,7 @@ impl super::Board {
         }
 
         // In the worst case, we lose a piece, but still end up with a non-negative balance
-        balance -= self.piece_on(mv.from()).piece_type().value();
+        balance -= self.piece_on(mv.from()).value();
 
         if let Some(promotion) = mv.promotion_piece() {
             balance -= promotion.value();

--- a/src/search.rs
+++ b/src/search.rs
@@ -530,7 +530,7 @@ fn search<NODE: NodeType>(
         && !(tt_bound == Bound::Lower
             && tt_move.is_some()
             && tt_move.is_capture()
-            && td.board.piece_on(tt_move.to()).piece_type().value() >= PieceType::Knight.value())
+            && td.board.piece_on(tt_move.to()).value() >= PieceType::Knight.value())
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
@@ -728,11 +728,8 @@ fn search<NODE: NodeType>(
             }
 
             // Bad Noisy Futility Pruning (BNFP)
-            let noisy_futility_value = eval
-                + 71 * depth
-                + 69 * history / 1024
-                + 81 * td.board.piece_on(mv.to()).piece_type().value() / 1024
-                + 25;
+            let noisy_futility_value =
+                eval + 71 * depth + 69 * history / 1024 + 81 * td.board.piece_on(mv.to()).value() / 1024 + 25;
 
             if !in_check
                 && depth < 12
@@ -771,7 +768,7 @@ fn search<NODE: NodeType>(
         }
 
         // Late Move Reductions (LMR)
-        if depth >= 2 && move_count > 1 {
+        if depth >= 2 && move_count >= 2 {
             let mut reduction = 237 * (move_count.ilog2() * depth.ilog2()) as i32;
 
             reduction += 29 * move_count.ilog2() as i32;


### PR DESCRIPTION
Elo   | -0.11 +- 1.23 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 92016 W: 24377 L: 24405 D: 43234
Penta | [802, 10644, 23168, 10568, 826]
https://recklesschess.space/test/10788/

No functional change.

Bench: 3372187