### PR TITLE
Simplify depth adjustment conditions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -831,7 +831,7 @@ fn search<NODE: NodeType>(
             td.stack[ply].reduction = 0;
             current_search_count += 1;
 
-            if score > alpha && new_depth > reduced_depth {
+            if score > alpha {
                 if !NODE::ROOT {
                     new_depth += (score > best_score + 41 + 447 * depth / 128) as i32;
                     new_depth -= (score < best_score + new_depth) as i32;
@@ -841,8 +841,6 @@ fn search<NODE: NodeType>(
                     score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node, ply + 1);
                     current_search_count += 1;
                 }
-            } else if score > alpha && score < best_score + 14 {
-                new_depth -= 1;
             }
         }
         // Full Depth Search (FDS)


### PR DESCRIPTION
STC
Elo   | -0.01 +- 1.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 94776 W: 23478 L: 23481 D: 47817
Penta | [193, 11267, 24456, 11294, 178]
https://recklesschess.space/test/10832/

LTC
Elo   | 1.29 +- 1.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 27652 W: 6790 L: 6687 D: 14175
Penta | [5, 3043, 7629, 3142, 7]
https://recklesschess.space/test/10836/

Bench: 3745477
