### PR TITLE
Remove a condition

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -816,8 +816,8 @@ fn search<NODE: NodeType>(
                 reduction += 1604;
             }
 
-            if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
-                reduction += 668;
+            if is_valid(tt_score) && tt_score < alpha {
+                reduction += 600;
             }
 
             if depth == 2 {


### PR DESCRIPTION
Remove a condition

Passed STC with non-reg bounds:
Elo   | 1.34 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 30636 W: 7644 L: 7526 D: 15466
Penta | [59, 3590, 7920, 3672, 77]
https://recklesschess.space/test/11039/

Passed LTC with non-reg bounds:
Elo   | 0.26 +- 1.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 57944 W: 14098 L: 14054 D: 29792
Penta | [12, 6482, 15940, 6526, 12]
https://recklesschess.space/test/11040/

bench: 4779163