### PR TITLE
Simplify bad noisy qsearch pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1220,10 +1220,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         move_count += 1;
 
         if !is_loss(best_score) && mv.to() != td.board.recapture_square() {
-            if move_picker.stage() == Stage::BadNoisy {
-                break;
-            }
-
             if !NODE::PV && move_count >= 3 && !td.board.is_direct_check(mv) {
                 break;
             }


### PR DESCRIPTION
STC
Elo   | 0.52 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 51834 W: 12988 L: 12911 D: 25935
Penta | [100, 6166, 13316, 6227, 108]
https://recklesschess.space/test/11074/

LTC
Elo   | -0.00 +- 1.16 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 77828 W: 18971 L: 18971 D: 39886
Penta | [24, 8722, 21421, 8724, 23]
https://recklesschess.space/test/11077/

Bench: 3990113