### PR TITLE
Simplify away LMR/FDS rules

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -808,7 +808,7 @@ fn search<NODE: NodeType>(
                 reduction += (438 - 279 * improvement / 128).min(1288);
             }
 
-            if td.board.in_check() || !td.board.has_non_pawns() {
+            if td.board.in_check() {
                 reduction -= 966;
             }
 
@@ -818,10 +818,6 @@ fn search<NODE: NodeType>(
 
             if is_valid(tt_score) && tt_score < alpha && tt_bound == Bound::Upper {
                 reduction += 668;
-            }
-
-            if depth == 2 {
-                reduction -= 1195;
             }
 
             let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + 1) + 2 * NODE::PV as i32;
@@ -847,17 +843,14 @@ fn search<NODE: NodeType>(
         else if !NODE::PV || move_count > 1 {
             let mut reduction = 238 * (move_count.ilog2() * depth.ilog2()) as i32;
 
-            reduction += 26 * move_count.ilog2() as i32;
-            reduction += 23 * depth.ilog2() as i32;
-
             reduction -= 57 * move_count;
             reduction -= 2513 * correction_value.abs() / 1024;
 
             if is_quiet {
-                reduction += 1577;
+                reduction += 1427;
                 reduction -= 158 * history / 1024;
             } else {
-                reduction += 1248;
+                reduction += 1098;
                 reduction -= 65 * history / 1024;
             }
 
@@ -877,10 +870,6 @@ fn search<NODE: NodeType>(
 
             if td.stack[ply + 1].cutoff_count > 2 {
                 reduction += 1452;
-            }
-
-            if depth == 2 {
-                reduction -= 1144;
             }
 
             if mv == tt_move {


### PR DESCRIPTION
STC
Elo   | 0.12 +- 1.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 79542 W: 19717 L: 19690 D: 40135
Penta | [203, 9347, 20598, 9466, 157]
https://recklesschess.space/test/11067/

LTC
Elo   | -0.20 +- 1.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 107350 W: 25926 L: 25987 D: 55437
Penta | [32, 12256, 29163, 12189, 35]
https://recklesschess.space/test/11068/

Bench: 4106237