### PR TITLE
Simplify away PCM updates in TT cuts

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -331,27 +331,6 @@ fn search<NODE: NodeType>(
                 update_continuation_histories(td, ply, td.board.moved_piece(tt_move), tt_move.to(), cont_bonus);
             }
 
-            if tt_score <= alpha && td.stack[ply - 1].move_count > 8 {
-                let pcm_move = td.stack[ply - 1].mv;
-                if pcm_move.is_quiet() {
-                    let mut factor = 93;
-                    factor += 190 * (depth > 5) as i32;
-                    factor += 135 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
-                    factor +=
-                        202 * (is_valid(td.stack[ply - 1].eval) && tt_score <= -td.stack[ply - 1].eval - 94) as i32;
-
-                    let scaled_bonus = factor * (171 * depth - 42).min(2310) / 128;
-
-                    td.quiet_history.update(td.board.prior_threats(), !td.board.side_to_move(), pcm_move, scaled_bonus);
-
-                    let entry = &td.stack[ply - 2];
-                    if entry.mv.is_some() {
-                        let bonus = (115 * depth - 34).min(1776);
-                        td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, pcm_move.to(), bonus);
-                    }
-                }
-            }
-
             if td.board.halfmove_clock() < 90 {
                 return tt_score;
             }


### PR DESCRIPTION
LTC
Elo   | 0.80 +- 1.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 37198 W: 9062 L: 8976 D: 19160
Penta | [10, 4130, 10232, 4218, 9]
https://recklesschess.space/test/11106/

Bench: 4139355