### PR TITLE
Only apply IIR in cut nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -742,7 +742,7 @@ fn search<NODE: NodeType>(
         let mut score = Score::ZERO;
 
         // Internal Iterative Reductions (IIR)
-        if (NODE::PV || cut_node) && new_depth >= 5 && tt_move.is_null() {
+        if cut_node && new_depth >= 5 && tt_move.is_null() {
             new_depth -= 1;
         }
 


### PR DESCRIPTION
STC
Elo   | 0.04 +- 1.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 87552 W: 21860 L: 21849 D: 43843
Penta | [191, 10364, 22654, 10377, 190]
https://recklesschess.space/test/11110/

LTC
Elo   | 0.01 +- 1.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 76562 W: 18506 L: 18503 D: 39553
Penta | [19, 8638, 20970, 8629, 25]
https://recklesschess.space/test/11118/

Bench: 3926067
