### PR TITLE
Update default network to v52-dd20aadb.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v51-3f72a764.nnue";
+const NETWORK_NAME: &str = "v52-dd20aadb.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Huge thanks to @cosmobobak for the implementation of L1-regularisation trainer-side.

Fixed-nodes:
```
Elo   | 4.00 +- 2.15 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40634 W: 12476 L: 12008 D: 16150
Penta | [821, 4662, 8952, 4992, 890]
```
https://recklesschess.space/test/11196/

STC:
```
Elo   | 7.23 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9760 W: 2559 L: 2356 D: 4845
Penta | [25, 1112, 2417, 1287, 39]
```
https://recklesschess.space/test/11197/

LTC:
```
Elo   | 3.92 +- 2.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17660 W: 4410 L: 4211 D: 9039
Penta | [7, 1938, 4738, 2143, 4]
```
https://recklesschess.space/test/11198/

Bench: 3791106