### PR TITLE
Remove log terms from LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -747,19 +747,16 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count >= 2 {
-            let mut reduction = 237 * (move_count.ilog2() * depth.ilog2()) as i32;
-
-            reduction += 29 * move_count.ilog2() as i32;
-            reduction += 29 * depth.ilog2() as i32;
+            let mut reduction = 250 * (move_count.ilog2() * depth.ilog2()) as i32;
 
             reduction -= 65 * move_count;
             reduction -= 3183 * correction_value.abs() / 1024;
 
             if is_quiet {
-                reduction += 1922;
+                reduction += 1972;
                 reduction -= 154 * history / 1024;
             } else {
-                reduction += 1402;
+                reduction += 1452;
                 reduction -= 109 * history / 1024;
             }
 


### PR DESCRIPTION
STC
Elo   | -0.00 +- 1.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 94092 W: 23537 L: 23537 D: 47018
Penta | [208, 11077, 24474, 11081, 206]
https://recklesschess.space/test/11189/

LTC
Elo   | 0.76 +- 1.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 37698 W: 9190 L: 9107 D: 19401
Penta | [4, 4205, 10361, 4262, 17]
https://recklesschess.space/test/11192/

Bench: 3789907