### PR TITLE
Align standpat failfirm with RFP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1146,7 +1146,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
         if best_score >= beta {
             if !is_decisive(best_score) && !is_decisive(beta) {
-                best_score = (best_score + beta) / 2;
+                best_score = beta + (best_score - beta) / 3;
             }
 
             if entry.is_none() {


### PR DESCRIPTION
Elo   | 1.17 +- 0.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 147786 W: 36870 L: 36374 D: 74542
Penta | [326, 17387, 37963, 17899, 318]
https://recklesschess.space/test/11191/

Elo   | 1.71 +- 1.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 56254 W: 13659 L: 13382 D: 29213
Penta | [18, 6220, 15375, 6495, 19]
https://recklesschess.space/test/11193/

Bench: 4140649