### PR TITLE
Update default network to v53-0ba42a8c.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v52-dd20aadb.nnue";
+const NETWORK_NAME: &str = "v53-0ba42a8c.nnue";
 
 fn main() {
     generate_model_env();

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -596,7 +596,7 @@ impl BoardObserver for Network {
 
 #[repr(C)]
 struct Parameters {
-    ft_threat_weights: Aligned<[[i8; L1_SIZE]; 79856]>,
+    ft_threat_weights: Aligned<[[i8; L1_SIZE]; 66864]>,
     ft_piece_weights: Aligned<[[i16; L1_SIZE]; INPUT_BUCKETS * 768]>,
     ft_biases: Aligned<[i16; L1_SIZE]>,
     l1_weights: Aligned<[[i8; L2_SIZE * L1_SIZE]; OUTPUT_BUCKETS]>,

--- a/src/nnue/threats.rs
+++ b/src/nnue/threats.rs
@@ -34,14 +34,14 @@ pub fn initialize() {
     #[rustfmt::skip]
     const PIECE_INTERACTION_MAP: [[i32; 6]; 6] = [
         [0,  1, -1,  2, -1, -1],
-        [0,  1,  2,  3,  4,  5],
-        [0,  1,  2,  3, -1,  4],
-        [0,  1,  2,  3, -1,  4],
-        [0,  1,  2,  3,  4,  5],
+        [0,  1,  2,  3,  4, -1],
+        [0,  1,  2,  3, -1, -1],
+        [0,  1,  2,  3, -1, -1],
+        [0,  1,  2,  3,  4, -1],
         [0,  1,  2,  3, -1, -1],
     ];
 
-    const PIECE_TARGET_COUNT: [i32; 6] = [6, 12, 10, 10, 12, 8];
+    const PIECE_TARGET_COUNT: [i32; 6] = [6, 10, 8, 8, 10, 8];
 
     let mut offset = 0;
     let mut piece_offset = [0; Piece::NUM];


### PR DESCRIPTION
Simplify away piece -> king threat input features, saving 6.4 MB
of weights and additional threat accumulator updates.

Thanks to @sscg13 for the idea.

VSTC
Elo   | 2.63 +- 1.98 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34426 W: 9121 L: 8860 D: 16445
Penta | [180, 4137, 8344, 4346, 206]
https://recklesschess.space/test/11208/

STC
Elo   | 0.14 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 78592 W: 19817 L: 19786 D: 38989
Penta | [219, 9502, 19820, 9539, 216]
https://recklesschess.space/test/11206/

LTC
Elo   | 0.08 +- 1.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 70800 W: 17319 L: 17303 D: 36178
Penta | [31, 8146, 19035, 8152, 36]
https://recklesschess.space/test/11209/

Bench: 4262482
