### PR TITLE
Prefer more extensions on average over implicit quadruples

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -623,17 +623,13 @@ fn search<NODE: NodeType>(
 
         if score < singular_beta {
             let double_margin =
-                -4 + 256 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
+                200 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
             let triple_margin =
-                48 + 288 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
+                288 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128 + 32;
 
             extension = 1;
             extension += (score < singular_beta - double_margin) as i32;
             extension += (score < singular_beta - triple_margin) as i32;
-
-            if extension > 1 && depth < 14 {
-                depth += 1;
-            }
         }
         // Multi-Cut
         else if score >= beta && !is_decisive(score) {
@@ -737,7 +733,8 @@ fn search<NODE: NodeType>(
 
         make_move(td, ply, mv);
 
-        let mut new_depth = if move_count == 1 { depth + extension - 1 } else { depth - 1 };
+        let mut new_depth = if move_count == 1 { depth + extension - 1 } else { depth + (extension > 0) as i32 - 1 };
+
         let mut score = Score::ZERO;
 
         // Internal Iterative Reductions (IIR)


### PR DESCRIPTION
STC
Elo   | 2.79 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28896 W: 7276 L: 7044 D: 14576
Penta | [68, 3295, 7486, 3535, 64]
https://recklesschess.space/test/11274/

LTC
Elo   | 1.60 +- 1.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63380 W: 15477 L: 15186 D: 32717
Penta | [11, 7028, 17328, 7305, 18]
https://recklesschess.space/test/11276/

VLTC
Elo   | 2.35 +- 1.75 (95%)
SPRT  | 120.0+1.20s Threads=1 Hash=256MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32872 W: 8052 L: 7830 D: 16990
Penta | [2, 3433, 9345, 3653, 3]
https://recklesschess.space/test/11277/

Bench: 3214551