### PR TITLE
Implement collective thread voting for soft stop

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -233,11 +233,14 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
                     td.shared.status.set(Status::STOPPED);
                 }
             }
+        } else if soft_stop_voted {
+            soft_stop_voted = false;
+            td.shared.soft_stop_votes.fetch_sub(1, Ordering::AcqRel);
+        }
 
-            if td.shared.status.get() == Status::STOPPED {
-                td.stopped = true;
-                break;
-            }
+        if td.shared.status.get() == Status::STOPPED {
+            td.stopped = true;
+            break;
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -229,7 +229,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
                 soft_stop_voted = true;
 
                 let votes = td.shared.soft_stop_votes.fetch_add(1, Ordering::AcqRel) + 1;
-                let majority = (thread_count * 65 + 99) / 100;
+                let majority = (thread_count * 65).div_ceil(100);
                 if votes >= majority {
                     td.shared.status.set(Status::STOPPED);
                 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -53,7 +53,6 @@ impl NodeType for NonPV {
 pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
     td.completed_depth = 0;
     td.stopped = false;
-    let mut soft_stop_voted = false;
 
     td.pv_table.clear(0);
     td.nnue.full_refresh(&td.board);
@@ -82,6 +81,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
     let mut eval_stability = 0;
     let mut pv_stability = 0;
     let mut best_move_changes = 0;
+    let mut soft_stop_voted = false;
 
     // Iterative Deepening
     for depth in 1..MAX_PLY as i32 {
@@ -229,7 +229,8 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
                 soft_stop_voted = true;
 
                 let votes = td.shared.soft_stop_votes.fetch_add(1, Ordering::AcqRel) + 1;
-                if votes >= thread_count / 2 {
+                let majority = (thread_count * 65 + 99) / 100;
+                if votes >= majority {
                     td.shared.status.set(Status::STOPPED);
                 }
             }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -100,6 +100,7 @@ pub struct SharedContext {
     pub status: Status,
     pub nodes: Counter,
     pub tb_hits: Counter,
+    pub soft_stop_votes: AtomicUsize,
     pub history: *const SharedCorrectionHistory,
     pub replicator: NumaReplicator<SharedCorrectionHistory>,
 }
@@ -113,6 +114,7 @@ impl Default for SharedContext {
             status: Status::default(),
             nodes: Counter::default(),
             tb_hits: Counter::default(),
+            soft_stop_votes: AtomicUsize::new(0),
             history: unsafe { replicator.get() },
             replicator,
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -14,6 +14,7 @@ pub enum Limits {
 
 const TIME_OVERHEAD_MS: u64 = 15;
 
+#[derive(Clone)]
 pub struct TimeManager {
     limits: Limits,
     start_time: Instant,


### PR DESCRIPTION
Allow threads to collectively decide when to stop searching
based on a majority vote.

MTC SMP 8th
Elo   | 4.48 +- 2.94 (95%)
SPRT  | 25.0+0.25s Threads=8 Hash=512MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11092 W: 2797 L: 2654 D: 5641
Penta | [0, 1072, 3259, 1215, 0]
https://recklesschess.space/test/11331/

VSTC SMP 8th
Elo   | 1.21 +- 1.64 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=256MB
LLR   | 0.67 (-2.25, 2.89) [0.00, 4.00]
Games | N: 39778 W: 9866 L: 9728 D: 20184
Penta | [46, 4369, 10898, 4553, 23]
https://recklesschess.space/test/11325/

VSTC SMP 16th
Elo   | 2.59 +- 2.02 (95%)
SPRT  | 5.0+0.05s Threads=16 Hash=512MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 25394 W: 6384 L: 6195 D: 12815
Penta | [11, 2710, 7062, 2907, 7]
https://recklesschess.space/test/11354/

Bench: 3214551
