### PR TITLE
Change extern declaration to unsafe extern in numa.rs

### DIFF
--- a/src/numa.rs
+++ b/src/numa.rs
@@ -151,7 +151,7 @@ mod api {
     }
 
     #[link(name = "numa")]
-    extern "C" {
+    unsafe extern "C" {
         pub fn numa_available() -> c_int;
         pub fn numa_max_node() -> c_int;
         pub fn numa_node_of_cpu(cpu: c_int) -> c_int;


### PR DESCRIPTION
Added unsafe to adhere to Rust 2024 standards.

Tested on 2x7742 machine.