### PR TITLE
Guard against sequential null moves caused by reverse searches

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -523,6 +523,7 @@ fn search<NODE: NodeType>(
         && estimated_score >= eval
         && eval >= beta - 9 * depth + 126 * tt_pv as i32 - 128 * improvement / 1024 + 286
         && ply as i32 >= td.nmp_min_ply
+        && td.stack[ply - 1].mv.is_some()
         && td.board.has_non_pawns()
         && !is_loss(beta)
         && !(tt_bound == Bound::Lower


### PR DESCRIPTION
In rare cases where null move pruning falls into quiescence search,
it may later return to the main search, causing NMP to trigger
twice in succession.

Elo   | 0.63 +- 1.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 39464 W: 9587 L: 9515 D: 20362
Penta | [8, 3636, 12374, 3704, 10]
https://recklesschess.space/test/11384/

Bench: 3375856
