### PR TITLE
Simplify away correction and ordering history weights

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -190,12 +190,11 @@ impl MovePicker {
                 continue;
             }
 
-            entry.score = (994 * td.quiet_history.get(threats, side, mv)
-                + 1049 * td.conthist(ply, 1, mv)
-                + 990 * td.conthist(ply, 2, mv)
-                + 969 * td.conthist(ply, 4, mv)
-                + 1088 * td.conthist(ply, 6, mv))
-                / 1024;
+            entry.score = td.quiet_history.get(threats, side, mv)
+                + td.conthist(ply, 1, mv)
+                + td.conthist(ply, 2, mv)
+                + td.conthist(ply, 4, mv)
+                + td.conthist(ply, 6, mv);
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1267,23 +1267,20 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
     let stm = td.board.side_to_move();
     let corrhist = td.corrhist();
 
-    (1033 * corrhist.pawn.get(stm, td.board.pawn_key())
-        + 959 * corrhist.minor.get(stm, td.board.minor_key())
-        + 1044 * corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
-        + 1044 * corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
-        + 1001
-            * td.continuation_corrhist.get(
-                td.stack[ply - 2].contcorrhist,
-                td.stack[ply - 1].piece,
-                td.stack[ply - 1].mv.to(),
-            )
-        + 1014
-            * td.continuation_corrhist.get(
-                td.stack[ply - 4].contcorrhist,
-                td.stack[ply - 1].piece,
-                td.stack[ply - 1].mv.to(),
-            ))
-        / 1024
+    (corrhist.pawn.get(stm, td.board.pawn_key())
+        + corrhist.minor.get(stm, td.board.minor_key())
+        + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
+        + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
+        + td.continuation_corrhist.get(
+            td.stack[ply - 2].contcorrhist,
+            td.stack[ply - 1].piece,
+            td.stack[ply - 1].mv.to(),
+        )
+        + td.continuation_corrhist.get(
+            td.stack[ply - 4].contcorrhist,
+            td.stack[ply - 1].piece,
+            td.stack[ply - 1].mv.to(),
+        ))
         / 77
 }
 


### PR DESCRIPTION
STC
Elo   | 1.25 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 31350 W: 7800 L: 7687 D: 15863
Penta | [68, 3663, 8112, 3752, 80]
https://recklesschess.space/test/11395/

LTC
Elo   | 1.53 +- 2.08 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 24922 W: 6148 L: 6038 D: 12736
Penta | [11, 2798, 6730, 2914, 8]
https://recklesschess.space/test/11396/

Bench: 2916087