### PR TITLE
Use actual subtree depth in do-deeper/do-shallower

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -822,8 +822,8 @@ fn search<NODE: NodeType>(
 
             if score > alpha {
                 if !NODE::ROOT {
-                    new_depth += (score > best_score + 41 + 447 * depth / 128) as i32;
-                    new_depth -= (score < best_score + new_depth) as i32;
+                    new_depth += (score > best_score + 50 + 4 * reduced_depth) as i32;
+                    new_depth -= (score < best_score + 5 + reduced_depth) as i32;
                 }
 
                 if new_depth > reduced_depth {


### PR DESCRIPTION
STC
Elo   | 1.32 +- 1.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 105948 W: 26478 L: 26074 D: 53396
Penta | [247, 12354, 27354, 12786, 233]
https://recklesschess.space/test/11458/

LTC
Elo   | 1.09 +- 0.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 151926 W: 37172 L: 36696 D: 78058
Penta | [55, 17052, 41277, 17520, 59]
https://recklesschess.space/test/11459/

Bench: 3915571
