### PR TITLE
Simplify away hindsight reductions for FDS

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -883,9 +883,7 @@ fn search<NODE: NodeType>(
 
             let reduced_depth = new_depth - (reduction >= 3072) as i32 - (reduction >= 5687 && new_depth >= 3) as i32;
 
-            td.stack[ply].reduction = 1024 * ((depth - 1) - new_depth);
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
-            td.stack[ply].reduction = 0;
             current_search_count += 1;
         }
 


### PR DESCRIPTION
STC
Elo   | 0.38 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 58266 W: 14704 L: 14640 D: 28922
Penta | [145, 6916, 14948, 6978, 146]
https://recklesschess.space/test/11543/

LTC
Elo   | 2.85 +- 2.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 15630 W: 3868 L: 3740 D: 8022
Penta | [4, 1714, 4249, 1846, 2]
https://recklesschess.space/test/11555/

Bench: 3644857