### PR TITLE
Use adaptive improvement formula for LMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -706,8 +706,8 @@ fn search<NODE: NodeType>(
             skip_quiets |= !in_check
                 && move_count >= {
                     let adjust = improvement.clamp(-100, 218);
-                    let factor0 = 2398 + 149 * adjust / 16;
-                    let factor1 = 678 + 71 * adjust / 16;
+                    let factor0 = 2515 + 130 * adjust / 16;
+                    let factor1 = 946 + 79 * adjust / 16;
 
                     (factor0 + factor1 * depth * depth) / 1024
                 };

--- a/src/search.rs
+++ b/src/search.rs
@@ -704,12 +704,13 @@ fn search<NODE: NodeType>(
         if !NODE::ROOT && !is_loss(best_score) {
             // Late Move Pruning (LMP)
             skip_quiets |= !in_check
-                && move_count
-                    >= if improving || eval >= beta + 20 {
-                        (3127 + 1075 * depth * depth) / 1024
-                    } else {
-                        (1320 + 311 * depth * depth) / 1024
-                    };
+                && move_count >= {
+                    let adjust = improvement.clamp(-116, 219);
+                    let factor0 = 2216 + 138 * adjust / 16;
+                    let factor1 = 794 + 70 * adjust / 16;
+
+                    (factor0 + factor1 * depth * depth) / 1024
+                };
 
             // Futility Pruning (FP)
             let futility_value = eval + 88 * depth + 63 * history / 1024 + 88 * (eval >= alpha) as i32 - 114;

--- a/src/search.rs
+++ b/src/search.rs
@@ -705,9 +705,9 @@ fn search<NODE: NodeType>(
             // Late Move Pruning (LMP)
             skip_quiets |= !in_check
                 && move_count >= {
-                    let adjust = improvement.clamp(-116, 219);
-                    let factor0 = 2216 + 138 * adjust / 16;
-                    let factor1 = 794 + 70 * adjust / 16;
+                    let adjust = improvement.clamp(-100, 218);
+                    let factor0 = 2398 + 149 * adjust / 16;
+                    let factor1 = 678 + 71 * adjust / 16;
 
                     (factor0 + factor1 * depth * depth) / 1024
                 };


### PR DESCRIPTION
The parameters were obtained via Bayesian optimization using Optuna
and a Gaussian-process regression fitted on the gathered data points.

STC
Elo   | 3.92 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18970 W: 4874 L: 4660 D: 9436
Penta | [52, 2159, 4866, 2339, 69]
https://recklesschess.space/test/11557/

LTC
Elo   | 5.19 +- 2.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12598 W: 3138 L: 2950 D: 6510
Penta | [3, 1359, 3389, 1543, 5]
https://recklesschess.space/test/11558/

Bench: 3677253