### PR TITLE
Adjust hindsight reductions constants

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -456,7 +456,7 @@ fn search<NODE: NodeType>(
     }
 
     // Hindsight reductions
-    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].reduction >= 2247 && eval + td.stack[ply - 1].eval < 1
+    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].reduction >= 2247 && eval + td.stack[ply - 1].eval < 0
     {
         depth += 1;
     }
@@ -466,7 +466,7 @@ fn search<NODE: NodeType>(
         && !in_check
         && !excluded
         && depth >= 2
-        && td.stack[ply - 1].reduction >= 756
+        && td.stack[ply - 1].reduction > 0
         && is_valid(td.stack[ply - 1].eval)
         && eval + td.stack[ply - 1].eval > 59
     {


### PR DESCRIPTION
STC
Elo   | 1.82 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 55626 W: 14026 L: 13734 D: 27866
Penta | [137, 6471, 14307, 6759, 139]
https://recklesschess.space/test/11551/

LTC
Elo   | 3.22 +- 2.18 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22550 W: 5583 L: 5374 D: 11593
Penta | [10, 2468, 6111, 2675, 11]
https://recklesschess.space/test/11564/

Bench: 3634548