### PR TITLE
Guard cutnode reduction with ttpv

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -780,10 +780,6 @@ fn search<NODE: NodeType>(
                 reduction -= 109 * history / 1024;
             }
 
-            if cut_node && tt_move.is_null() {
-                reduction += 1024;
-            }
-
             if NODE::PV {
                 reduction -= 411 + 421 * (beta - alpha) / td.root_delta;
             }
@@ -800,7 +796,7 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1762;
-                reduction += 1092 * tt_move.is_null() as i32;
+                reduction += 2116 * tt_move.is_null() as i32;
             }
 
             if !improving {
@@ -860,10 +856,6 @@ fn search<NODE: NodeType>(
                 reduction -= 65 * history / 1024;
             }
 
-            if cut_node && tt_move.is_null() {
-                reduction += 1024;
-            }
-
             if tt_pv {
                 reduction -= 897;
                 reduction -= 1127 * (is_valid(tt_score) && tt_depth >= depth) as i32;
@@ -871,7 +863,7 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1450;
-                reduction += 1176 * tt_move.is_null() as i32;
+                reduction += 2200 * tt_move.is_null() as i32;
             }
 
             if !improving {


### PR DESCRIPTION
Forgot to merge this earlier

Elo   | 0.84 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 40594 W: 10260 L: 10162 D: 20172
Penta | [101, 4856, 10301, 4922, 117]
https://recklesschess.space/test/11490/

Elo   | 0.38 +- 1.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 50578 W: 12183 L: 12127 D: 26268
Penta | [17, 5724, 13759, 5764, 25]
https://recklesschess.space/test/11465/

Bench: 3330786