### PR TITLE
Reckless v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "reckless"
-version = "0.9.0-dev"
+version = "0.9.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reckless"
-version = "0.9.0-dev"
+version = "0.9.0"
 edition = "2024"
 build = "build/build.rs"
 publish = false

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -141,7 +141,7 @@ fn spawn_listener(shared: Arc<SharedContext>) -> std::sync::mpsc::Receiver<Strin
 }
 
 fn uci() {
-    println!("id name Reckless {}", env!("ENGINE_VERSION"));
+    println!("id name Reckless {}", env!("CARGO_PKG_VERSION"));
     println!("id author Arseniy Surkov, Shahin M. Shahin, and Styx");
     println!("option name Hash type spin default {DEFAULT_TT_SIZE} min 1 max 262144");
     println!("option name Threads type spin default 1 min 1 max {}", ThreadPool::available_threads());


### PR DESCRIPTION
Reckless 0.9.0 is ready! You can download pre-built binaries for Windows, Linux, and macOS from the [GitHub Releases](https://github.com/codedeliveryservice/Reckless/releases/tag/v0.9.0) page.

Thanks to everyone who contributed through code, testing, hardware support, or any other effort. This release came together because of your help.

## Update highlights

### NNUE

The neuron network has been updated to a modern threat-based architecture. It models the interactions between pieces, where one piece attacks or defends another, and extends the existing king-bucketed piece-square-based inputs with additional features.

### Multithreading and NUMA support

NUMA (Non-Uniform Memory Access) support has been added to Reckless. Worker threads allocate memory and bind to the same NUMA node as the memory they access, reducing the cross-node memory access latency for high thread counts on multi-socket systems. Additionally, more improvements have been made specifically to improve the strength of the multithreading search.

### MultiPV Support

Reckless now supports MultiPV (Multiple Principal Variations). It can analyze and display multiple candidate moves, each with its corresponding principal variation. This feature is particularly useful for these who use Reckless for chess analysis as it provides a broader view of possibilities.

### License

The project is now licensed under the GNU Affero General Public License v3.0. The AGPL-3.0 grants the right to use, modify, and distribute it, while requiring that any changes to the source code must be made available under the same license and that distribution of Reckless, including distribution over a network (such as providing access via a web application or service), must also include the full source code (or a pointer to where the source code can be found) to generate the exact binary being used.

**Full Changelog**: https://github.com/codedeliveryservice/Reckless/compare/v0.8.0...v0.9.0

## Playing Strength

Reckless v0.9.0 brings a significant Elo gain over the previous version, including in multithreaded settings and (D)FRC variants. The results of the progression are as follows:

[UHO 40.0+0.40s](https://recklesschess.space/test/11785/)

```
Elo   | 62.40 +- 3.31 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 10000 W: 3435 L: 1658 D: 4907
Penta | [1, 491, 2275, 2196, 37]
```

[DFRC 40.0+0.40s](https://recklesschess.space/test/11787/)

```
Elo   | 68.13 +- 3.39 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 10020 W: 3351 L: 1411 D: 5258
Penta | [9, 447, 2229, 2245, 80]
```

[SMP 20.20+0.20s](https://recklesschess.space/test/11789/)

```
Elo   | 70.91 +- 3.15 (95%)
Conf  | 20.0+0.20s Threads=8 Hash=512MB
Games | N: 10000 W: 3514 L: 1501 D: 4985
Penta | [0, 362, 2279, 2343, 16]
```

## New contributors

We are excited to welcome new contributors, who have joined the project and made this release possible. Each of them invested time, knowledge, and effort into new features, optimizations, code quality improvements, and Elo gains that have been invaluable. We are grateful for your contributions and look forward to seeing more of your amazing work in the future. Thank you!

_(in alphabetical order)_

- @87flowers
- @cj5716
- @connormcmonigle
- @cosmobobak
- @FauziAkram
- @MrBrain295
- @protonspring
- @SunnyWar

Special thanks to all hardware contributors for supporting Reckless' development by providing access to their machines, which is crucial for making progress:
<https://recklesschess.space/users>

## Binaries

Pre-built binaries are provided for Windows, Linux, and macOS, with versions optimized for AVX2, AVX512, and a generic build that runs on virtually all CPUs.

Select the binary that matches your operating system (`-windows`, `-linux`, or `-macos`) and your CPU capabilities (`-generic`, `-avx2`, or `-avx512`). On macOS, a single universal build is provided.

- Generic builds are the most portable but are significantly slower than AVX2 or AVX512 builds.
- AVX2 builds are faster and supported on most modern CPUs.
- AVX512 builds are generally the fastest but require a newer CPU.

If you're unsure which to use, you can start with the AVX512 build and fall back to AVX2 if you encounter issues.

Bench: 3652336