### PR TITLE
Update default network to v55-75b40926.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v54-5478683c.nnue";
+const NETWORK_NAME: &str = "v55-75b40926.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 3.96 +- 2.05 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40200 W: 11665 L: 11207 D: 17328
Penta | [580, 4712, 9145, 4996, 667]
https://recklesschess.space/test/11833/

STC
Elo   | 2.82 +- 1.76 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=16MB
Games | N: 40098 W: 10285 L: 9959 D: 19854
Penta | [127, 4694, 10105, 4972, 151]
https://recklesschess.space/test/11836/

LTC
Elo   | 4.01 +- 2.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17510 W: 4330 L: 4128 D: 9052
Penta | [6, 1943, 4654, 2147, 5]
https://recklesschess.space/test/11835/

Bench: 3563890