### PR TITLE
Correct futility pruning margin logic

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -718,7 +718,7 @@ fn search<NODE: NodeType>(
                 };
 
             // Futility Pruning (FP)
-            let futility_value = eval + 88 * depth + 63 * history / 1024 + 88 * (eval >= alpha) as i32 - 114;
+            let futility_value = eval + 88 * depth + 63 * history / 1024 + 88 * (eval >= beta) as i32 - 114;
 
             if !in_check && is_quiet && depth < 14 && futility_value <= alpha && !td.board.is_direct_check(mv) {
                 if !is_decisive(best_score) && best_score <= futility_value {


### PR DESCRIPTION
STC
Elo   | 0.36 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 60268 W: 14972 L: 14909 D: 30387
Penta | [127, 7132, 15543, 7215, 117]
https://recklesschess.space/test/11832/

LTC
Elo   | 3.58 +- 2.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 12890 W: 3180 L: 3047 D: 6663
Penta | [1, 1388, 3537, 1515, 4]
https://recklesschess.space/test/11838/

Bench: 3161378