### PR TITLE
Simplify quiescence search pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1152,18 +1152,21 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     }
 
     let raw_eval;
+    let eval;
     let mut best_score;
 
     // Evaluation
     if in_check {
         raw_eval = Score::NONE;
+        eval = Score::NONE;
         best_score = -Score::INFINITE;
     } else {
         raw_eval = match &entry {
             Some(entry) if is_valid(entry.raw_eval) => entry.raw_eval,
             _ => td.nnue.evaluate(&td.board),
         };
-        best_score = correct_eval(td, raw_eval, eval_correction(td, ply));
+        eval = correct_eval(td, raw_eval, eval_correction(td, ply));
+        best_score = eval;
 
         if is_valid(tt_score)
             && (!NODE::PV || !is_decisive(tt_score))
@@ -1212,17 +1215,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
                 break;
             }
 
-            // QS Futility Pruning (QSFP)
-            if !in_check
-                && mv.to() != td.board.recapture_square()
-                && best_score + 42 * td.board.piece_on(mv.to()).piece_type().value() / 128 + 104 <= alpha
-                && !td.board.see(mv, 1)
-            {
-                continue;
-            }
-
-            // QS SEE Pruning (QSSEE)
-            if !td.board.see(mv, -81) {
+            if !td.board.see(mv, (alpha - eval) / 8 - 100) {
                 continue;
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1210,11 +1210,12 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         move_count += 1;
 
         if !is_loss(best_score) {
-            // QS Late Move Pruning (QSLMP)
+            // Late Move Pruning (LMP)
             if !NODE::PV && mv.to() != td.board.recapture_square() && move_count >= 3 && !td.board.is_direct_check(mv) {
                 break;
             }
 
+            // Static Exchange Evaluation Pruning (SEE Pruning)
             if !td.board.see(mv, (alpha - eval) / 8 - 100) {
                 continue;
             }


### PR DESCRIPTION
STC
Elo   | -0.10 +- 1.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 110460 W: 27618 L: 27649 D: 55193
Penta | [279, 13284, 28143, 13237, 287]
https://recklesschess.space/test/11837/

LTC
Elo   | 2.13 +- 2.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 19902 W: 4951 L: 4829 D: 10122
Penta | [11, 2217, 5369, 2347, 7]
https://recklesschess.space/test/11839/

Bench: 3344139