### PR TITLE
Simplify quiescence search LMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1211,7 +1211,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
         if !is_loss(best_score) {
             // Late Move Pruning (LMP)
-            if !NODE::PV && mv.to() != td.board.recapture_square() && move_count >= 3 && !td.board.is_direct_check(mv) {
+            if move_count >= 3 && !td.board.is_direct_check(mv) {
                 break;
             }
 


### PR DESCRIPTION
STC
Elo   | 0.71 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 44778 W: 11284 L: 11193 D: 22301
Penta | [126, 5258, 11527, 5355, 123]
https://recklesschess.space/test/11861/

LTC
Elo   | 1.69 +- 2.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 24654 W: 6058 L: 5938 D: 12658
Penta | [11, 2757, 6670, 2879, 10]
https://recklesschess.space/test/11862/

Bench: 3304591