### PR TITLE
Simplify multi-cut fail-firm formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -659,7 +659,7 @@ fn search<NODE: NodeType>(
         }
         // Multi-Cut
         else if score >= beta && !is_decisive(score) {
-            return (score * singular_depth + beta) / (singular_depth + 1);
+            return (2 * score + beta) / 3;
         }
         // Negative Extensions
         else if tt_score >= beta {


### PR DESCRIPTION
STC
Elo   | 1.39 +- 1.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 95842 W: 23911 L: 23528 D: 48403
Penta | [224, 11163, 24782, 11510, 242]
https://recklesschess.space/test/11983/

LTC
Elo   | 0.84 +- 1.53 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.25, 2.89) [-2.50, 0.25]
Games | N: 46044 W: 11227 L: 11116 D: 23701
Penta | [14, 5262, 12355, 5381, 10]
https://recklesschess.space/test/11989/

Bench: 3098225