### PR TITLE
Standardize fail-firm in ProbCut

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -624,7 +624,7 @@ fn search<NODE: NodeType>(
                 td.shared.tt.write(hash, probcut_depth + 1, raw_eval, score, Bound::Lower, mv, ply, tt_pv, false);
 
                 if !is_decisive(score) {
-                    return score - (probcut_beta - beta);
+                    return (3 * score + beta) / 4;
                 }
             }
         }


### PR DESCRIPTION
STC
Elo   | 2.37 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39016 W: 9890 L: 9624 D: 19502
Penta | [93, 4583, 9903, 4823, 106]
https://recklesschess.space/test/12023/

LTC
Elo   | 3.35 +- 2.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20920 W: 5185 L: 4983 D: 10752
Penta | [13, 2209, 5808, 2423, 7]
https://recklesschess.space/test/12026/

Bench: 3710330