### PR TITLE
Update default network to v56-398f2547.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v55-75b40926.nnue";
+const NETWORK_NAME: &str = "v56-398f2547.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 4.55 +- 2.04 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40090 W: 11698 L: 11173 D: 17219
Penta | [565, 4644, 9172, 5029, 635]
https://recklesschess.space/test/12027/

STC
Elo   | 4.65 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16060 W: 4186 L: 3971 D: 7903
Penta | [46, 1845, 4034, 2058, 47]
https://recklesschess.space/test/12028/

LTC
Elo   | 3.55 +- 2.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20250 W: 5076 L: 4869 D: 10305
Penta | [7, 2263, 5384, 2458, 13]
https://recklesschess.space/test/12029/

Bench: 2984806