### PR TITLE
Prevent razoring when ttmove is quiet

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -499,7 +499,12 @@ fn search<NODE: NodeType>(
     let improving = improvement > 0;
 
     // Razoring
-    if !NODE::PV && !in_check && estimated_score < alpha - 299 - 252 * depth * depth && alpha < 2048 {
+    if !NODE::PV
+        && !in_check
+        && estimated_score < alpha - 299 - 252 * depth * depth
+        && alpha < 2048
+        && !tt_move.is_quiet()
+    {
         return qsearch::<NonPV>(td, alpha, beta, ply);
     }
 


### PR DESCRIPTION
Elo   | 3.64 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.17 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21668 W: 5455 L: 5228 D: 10985
Penta | [53, 2293, 5922, 2506, 60]
https://recklesschess.space/test/12111/

Elo   | 2.49 +- 1.83 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 30820 W: 7597 L: 7376 D: 15847
Penta | [6, 3286, 8612, 3493, 13]
https://recklesschess.space/test/12112/

Bench: 3390305