### PR TITLE
Simplify away reverse qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -533,7 +533,6 @@ fn search<NODE: NodeType>(
         && estimated_score >= eval
         && eval >= beta - 9 * depth + 126 * tt_pv as i32 - 128 * improvement / 1024 + 286
         && ply as i32 >= td.nmp_min_ply
-        && td.stack[ply - 1].mv.is_some()
         && td.board.has_non_pawns()
         && !is_loss(beta)
         && !(tt_bound == Bound::Lower
@@ -1128,12 +1127,14 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let hash = td.board.hash();
     let entry = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
 
+    let mut tt_move = Move::NULL;
     let mut tt_score = Score::NONE;
     let mut tt_bound = Bound::None;
     let mut tt_pv = NODE::PV;
 
     // QS early TT cutoff
     if let Some(entry) = &entry {
+        tt_move = entry.mv;
         tt_score = entry.score;
         tt_bound = entry.bound;
         tt_pv |= entry.tt_pv;
@@ -1147,13 +1148,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
         {
             return tt_score;
-        }
-
-        if !NODE::PV && !td.reverse_qsearch && entry.mv.is_quiet() && tt_bound != Bound::Upper {
-            td.reverse_qsearch = true;
-            let score = search::<NonPV>(td, alpha, beta, 1, true, ply);
-            td.reverse_qsearch = false;
-            return score;
         }
     }
 
@@ -1208,7 +1202,11 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_count = 0;
     let mut move_picker = MovePicker::new_qsearch();
 
-    while let Some(mv) = move_picker.next::<NODE>(td, !in_check || !is_loss(best_score), ply) {
+    let skip_quiets = |best_score| {
+        (!in_check || !is_loss(best_score)) && !(!NODE::PV && tt_move.is_quiet() && tt_bound != Bound::Upper)
+    };
+
+    while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
         if !td.board.is_legal(mv) {
             continue;
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1203,7 +1203,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_picker = MovePicker::new_qsearch();
 
     let skip_quiets = |best_score| {
-        (!in_check || !is_loss(best_score)) && !(!NODE::PV && tt_move.is_quiet() && tt_bound != Bound::Upper)
+        !((in_check && is_loss(best_score)) || (!NODE::PV && tt_move.is_quiet() && tt_bound != Bound::Upper))
     };
 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -154,7 +154,6 @@ pub struct ThreadData {
     pub pv_index: usize,
     pub pv_start: usize,
     pub pv_end: usize,
-    pub reverse_qsearch: bool,
 }
 
 impl ThreadData {
@@ -187,7 +186,6 @@ impl ThreadData {
             pv_index: 0,
             pv_start: 0,
             pv_end: 0,
-            reverse_qsearch: false,
         }
     }
 


### PR DESCRIPTION
The idea behind reverse qsearch is to be cautious when pruning quiet
moves in a node where the TT move itself is quiet - we might never even
search it. Returning from qsearch to normal search is basically a more
expensive and complicated way to consider quiet moves in qsearch, which
this patch does directly.

Additionally, it generalizes the idea to any node rather than a single activation
along the current DFS path.

STC
Elo   | 2.04 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 22672 W: 5782 L: 5649 D: 11241
Penta | [54, 2658, 5787, 2775, 62]
https://recklesschess.space/test/12131/

LTC
Elo   | 4.50 +- 3.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 11036 W: 2724 L: 2581 D: 5731
Penta | [3, 1197, 2977, 1336, 5]
https://recklesschess.space/test/12132/

Bench: 3621558