### PR TITLE
Consider search quiet moves in PV nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1205,7 +1205,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_picker = MovePicker::new_qsearch();
 
     let skip_quiets = |best_score| {
-        !((in_check && is_loss(best_score)) || (!NODE::PV && tt_move.is_quiet() && tt_bound != Bound::Upper))
+        !((in_check && is_loss(best_score)) || (tt_move.is_quiet() && tt_bound != Bound::Upper))
     };
 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1204,9 +1204,8 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_count = 0;
     let mut move_picker = MovePicker::new_qsearch();
 
-    let skip_quiets = |best_score| {
-        !((in_check && is_loss(best_score)) || (tt_move.is_quiet() && tt_bound != Bound::Upper))
-    };
+    let skip_quiets =
+        |best_score| !((in_check && is_loss(best_score)) || (tt_move.is_quiet() && tt_bound != Bound::Upper));
 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
         if !td.board.is_legal(mv) {


### PR DESCRIPTION
STC
Elo   | 0.39 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 57876 W: 14532 L: 14467 D: 28877
Penta | [171, 6858, 14801, 6951, 157]
https://recklesschess.space/test/12140/

LTC
Elo   | 1.23 +- 1.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 30672 W: 7485 L: 7376 D: 15811
Penta | [15, 3445, 8302, 3564, 10]
https://recklesschess.space/test/12142/

Bench: 3072364