### PR TITLE
Limit blending factor in fail-high adjustment

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1068,7 +1068,8 @@ fn search<NODE: NodeType>(
     tt_pv |= !NODE::ROOT && bound == Bound::Upper && move_count > 2 && td.stack[ply - 1].tt_pv;
 
     if !NODE::ROOT && best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {
-        best_score = (best_score * depth + beta) / (depth + 1);
+        let weight = depth.min(8);
+        best_score = (best_score * weight + beta) / (weight + 1);
     }
 
     #[cfg(feature = "syzygy")]


### PR DESCRIPTION
STC
Elo   | 1.27 +- 1.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 116574 W: 29222 L: 28795 D: 58557
Penta | [253, 13659, 30051, 14056, 268]
https://recklesschess.space/test/12210/

LTC
Elo   | 3.00 +- 2.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 25104 W: 6199 L: 5982 D: 12923
Penta | [11, 2719, 6875, 2936, 11]
https://recklesschess.space/test/12214/

Bench: 3338261
