### PR TITLE
Guard SEE pruning from effectively guaranteed passes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1222,7 +1222,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
-            if !td.board.see(mv, (alpha - eval) / 8 - 100) {
+            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - 100) {
                 continue;
             }
         }


### PR DESCRIPTION
Elo   | 1.01 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 34650 W: 8640 L: 8539 D: 17471
Penta | [62, 3661, 9792, 3734, 76]
https://recklesschess.space/test/12224/

Bench: 3338261
