### PR TITLE
Remove dependency on raw evaluation in PCM

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1039,7 +1039,7 @@ fn search<NODE: NodeType>(
             factor += 156 * (depth > 5) as i32;
             factor += 215 * (td.stack[ply - 1].move_count > 8) as i32;
             factor += 113 * (pcm_move == td.stack[ply - 1].tt_move) as i32;
-            factor += 156 * (!in_check && best_score <= eval.min(raw_eval) - 96) as i32;
+            factor += 130 * (!in_check && best_score <= eval - 96) as i32;
             factor += 317 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 120) as i32;
 
             let scaled_bonus = factor * (153 * depth - 34).min(2474) / 128;


### PR DESCRIPTION
STC
Elo   | 0.59 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 49280 W: 12442 L: 12358 D: 24480
Penta | [139, 5909, 12474, 5965, 153]
https://recklesschess.space/test/12211/

LTC
Elo   | 0.71 +- 1.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 43262 W: 10513 L: 10425 D: 22324
Penta | [18, 4889, 11720, 4995, 9]
https://recklesschess.space/test/12237/

Bench: 3219880