### PR TITLE
Use TT depth to adjust LMR reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -779,6 +779,9 @@ fn search<NODE: NodeType>(
             reduction -= 3183 * correction_value.abs() / 1024;
             reduction += 1300 * alpha_raises;
 
+            reduction += 600 * (is_valid(tt_score) && tt_score < alpha) as i32;
+            reduction += 300 * (is_valid(tt_score) && tt_depth < depth) as i32;
+
             if is_quiet {
                 reduction += 1972;
                 reduction -= 154 * history / 1024;
@@ -816,10 +819,6 @@ fn search<NODE: NodeType>(
 
             if td.stack[ply + 1].cutoff_count > 2 {
                 reduction += 1604;
-            }
-
-            if is_valid(tt_score) && tt_score < alpha {
-                reduction += 600;
             }
 
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 512 {


### PR DESCRIPTION
STC
Elo   | 2.20 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41654 W: 10389 L: 10125 D: 21140
Penta | [105, 4823, 10713, 5075, 111]
https://recklesschess.space/test/12217/

LTC
Elo   | 1.80 +- 1.43 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 51850 W: 12671 L: 12402 D: 26777
Penta | [16, 5754, 14118, 6019, 18]
https://recklesschess.space/test/12220/

Bench: 3070578