### PR TITLE
Update default network to v57-1c1652e7.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v56-398f2547.nnue";
+const NETWORK_NAME: &str = "v57-1c1652e7.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 2.47 +- 2.01 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40928 W: 11693 L: 11402 D: 17833
Penta | [564, 4879, 9324, 5096, 601]
https://recklesschess.space/test/12303/

STC
Elo   | 2.15 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44980 W: 11497 L: 11219 D: 22264
Penta | [144, 5286, 11360, 5548, 152]
https://recklesschess.space/test/12304/

LTC
Elo   | 2.99 +- 2.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 25192 W: 6165 L: 5948 D: 13079
Penta | [23, 2787, 6754, 3014, 18]
https://recklesschess.space/test/12310/

Bench: 3541319