### PR TITLE
Prefetch TT entries into all levels of cache

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -229,11 +229,11 @@ impl TranspositionTable {
     pub fn prefetch(&self, hash: u64) {
         #[cfg(target_arch = "x86_64")]
         unsafe {
-            use std::arch::x86_64::{_MM_HINT_T1, _mm_prefetch};
+            use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
 
             let index = index(hash, self.len());
             let ptr = self.ptr().add(index).cast();
-            _mm_prefetch::<_MM_HINT_T1>(ptr);
+            _mm_prefetch::<_MM_HINT_T0>(ptr);
         }
 
         // No prefetching for non-x86_64 architectures


### PR DESCRIPTION
Elo   | 1.09 +- 0.82 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 173144 W: 44170 L: 43628 D: 85346
Penta | [579, 19059, 46805, 19499, 630]
https://recklesschess.space/test/12499/

Bench: 2795637