### PR TITLE
Simplify conditions in NMP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -525,8 +525,7 @@ fn search<NODE: NodeType>(
         && !excluded
         && !potential_singularity
         && estimated_score >= beta
-        && estimated_score >= eval
-        && eval
+        && estimated_score
             >= beta - 9 * depth + 126 * tt_pv as i32 - 128 * improvement / 1024 + 286
                 - 20 * (td.stack[ply + 1].cutoff_count < 2) as i32
         && ply as i32 >= td.nmp_min_ply


### PR DESCRIPTION
STC
Elo   | 1.15 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 33462 W: 8348 L: 8237 D: 16877
Penta | [87, 3885, 8666, 4016, 77]
https://recklesschess.space/test/12444/

LTC
Elo   | 0.99 +- 1.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 35304 W: 8553 L: 8452 D: 18299
Penta | [10, 4004, 9533, 4085, 20]
https://recklesschess.space/test/12448/

Bench: 3236003