### PR TITLE
Remove captured piece margin from bad noisy futility pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -734,8 +734,7 @@ fn search<NODE: NodeType>(
             }
 
             // Bad Noisy Futility Pruning (BNFP)
-            let noisy_futility_value =
-                eval + 71 * depth + 69 * history / 1024 + 81 * td.board.piece_on(mv.to()).value() / 1024 + 25;
+            let noisy_futility_value = eval + 71 * depth + 69 * history / 1024 + 25;
 
             if !in_check
                 && depth < 12


### PR DESCRIPTION
STC
Elo   | 2.20 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 20832 W: 5236 L: 5104 D: 10492
Penta | [36, 2427, 5372, 2531, 50]
https://recklesschess.space/test/12507/

LTC
Elo   | 0.04 +- 1.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 89024 W: 21540 L: 21531 D: 45953
Penta | [38, 10037, 24349, 10054, 34]
https://recklesschess.space/test/12512/

Bench: 3410801