### PR TITLE
Update default network to v58-ca025eef.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v57-1c1652e7.nnue";
+const NETWORK_NAME: &str = "v58-ca025eef.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | -0.67 +- 2.03 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40514 W: 11467 L: 11545 D: 17502
Penta | [631, 4862, 9280, 4922, 562]
https://recklesschess.space/test/12537/

STC
Elo   | 2.02 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [0.00, 3.00]
Games | N: 51132 W: 13070 L: 12773 D: 25289
Penta | [156, 6034, 12894, 6321, 161]
https://recklesschess.space/test/12538/

LTC
Elo   | 4.95 +- 2.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13270 W: 3381 L: 3192 D: 6697
Penta | [11, 1381, 3658, 1578, 7]
https://recklesschess.space/test/12546/

Bench: 2873544