### PR TITLE
Simplify RFP margin formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -514,8 +514,8 @@ fn search<NODE: NodeType>(
         && estimated_score
             >= beta + 1125 * depth * depth / 128 + 26 * depth - (77 * improving as i32)
                 + 519 * correction_value.abs() / 1024
-                + 32 * (depth == 1) as i32
                 - 64 * ((td.board.all_threats() & td.board.us()).is_empty() && !td.board.in_check()) as i32
+                + 32
         && !is_loss(beta)
         && !is_win(estimated_score)
     {


### PR DESCRIPTION
STC
Elo   | 0.68 +- 1.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 46482 W: 11619 L: 11528 D: 23335
Penta | [102, 5471, 12035, 5500, 133]
https://recklesschess.space/test/12528/

LTC
Elo   | 0.46 +- 1.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 53658 W: 13041 L: 12970 D: 27647
Penta | [15, 6050, 14634, 6109, 21]
https://recklesschess.space/test/12529/

Bench: 3554133