### PR TITLE
Allow singular extensions in nodes far from root

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -642,7 +642,7 @@ fn search<NODE: NodeType>(
     // Singular Extensions (SE)
     let mut extension = 0;
 
-    if !NODE::ROOT && !excluded && potential_singularity && ply < 2 * td.root_depth as isize {
+    if !NODE::ROOT && !excluded && potential_singularity {
         debug_assert!(is_valid(tt_score));
 
         let singular_beta = tt_score - depth - depth * (tt_pv && !NODE::PV) as i32;


### PR DESCRIPTION
STC
Elo   | -1.66 +- 1.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.31 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 45498 W: 11276 L: 11493 D: 22729
Penta | [122, 5414, 11874, 5237, 102]
https://recklesschess.space/test/12639/

LTC
Elo   | 0.62 +- 1.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 45802 W: 11138 L: 11056 D: 23608
Penta | [14, 5089, 12611, 5175, 12]
https://recklesschess.space/test/12640/

Bench: 3274011