### PR TITLE
Overhaul of LMP implementation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -718,14 +718,13 @@ fn search<NODE: NodeType>(
 
         if !NODE::ROOT && !is_loss(best_score) {
             // Late Move Pruning (LMP)
-            skip_quiets |= !in_check
-                && move_count >= {
-                    let adjust = improvement.clamp(-100, 218);
-                    let factor0 = 2515 + 130 * adjust / 16;
-                    let factor1 = 946 + 79 * adjust / 16;
-
-                    (factor0 + factor1 * depth * depth) / 1024
-                };
+            if !in_check
+                && is_quiet
+                && move_count >= (3072 + 4 * improvement + 1536 * depth * depth + 64 * history / 1024) / 1024
+            {
+                skip_quiets = true;
+                continue;
+            }
 
             // Futility Pruning (FP)
             let futility_value = eval + 88 * depth + 63 * history / 1024 + 88 * (eval >= beta) as i32 - 114;


### PR DESCRIPTION
STC
Elo   | 3.23 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26016 W: 6663 L: 6421 D: 12932
Penta | [69, 3009, 6617, 3237, 76]
https://recklesschess.space/test/12641/

LTC
Elo   | 5.33 +- 2.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12190 W: 3033 L: 2846 D: 6311
Penta | [3, 1303, 3300, 1482, 7]
https://recklesschess.space/test/12646/

Bench: 3190788