### PR TITLE
Guard LMP for moves that give checks

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -719,6 +719,7 @@ fn search<NODE: NodeType>(
         if !NODE::ROOT && !is_loss(best_score) {
             // Late Move Pruning (LMP)
             if !in_check
+                && !td.board.is_direct_check(mv)
                 && is_quiet
                 && move_count >= (3072 + 4 * improvement + 1536 * depth * depth + 64 * history / 1024) / 1024
             {


### PR DESCRIPTION
STC
Elo   | 2.84 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28536 W: 7260 L: 7027 D: 14249
Penta | [71, 3231, 7438, 3450, 78]
https://recklesschess.space/test/12650/

LTC
Elo   | 9.46 +- 4.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6500 W: 1681 L: 1504 D: 3315
Penta | [2, 654, 1764, 825, 5]
https://recklesschess.space/test/12663/

Bench: 3336699