### PR TITLE
Simplify do-deeper LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -843,7 +843,7 @@ fn search<NODE: NodeType>(
 
             if score > alpha {
                 if !NODE::ROOT {
-                    new_depth += (score > best_score + 50 + 4 * reduced_depth) as i32;
+                    new_depth += (score > best_score + 60) as i32;
                     new_depth += (score > best_score + 768) as i32;
                     new_depth -= (score < best_score + 5 + reduced_depth) as i32;
                 }


### PR DESCRIPTION
STC
Elo   | 1.45 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 28790 W: 7292 L: 7172 D: 14326
Penta | [72, 3395, 7346, 3505, 77]
https://recklesschess.space/test/12768/

LTC
Elo   | 3.13 +- 2.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 14984 W: 3743 L: 3608 D: 7633
Penta | [4, 1636, 4076, 1773, 3]
https://recklesschess.space/test/12769/

Bench: 3260740