### PR TITLE
Simplify LMR extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -831,10 +831,8 @@ fn search<NODE: NodeType>(
                 reduction += 128;
             }
 
-            let lmr_extension = reduction < -3072 && move_count <= 3;
-
             let reduced_depth =
-                (new_depth - reduction / 1024).clamp(1, new_depth + 1 + lmr_extension as i32) + 2 * NODE::PV as i32;
+                (new_depth - reduction / 1024).clamp(1, new_depth + (move_count <= 3) as i32 + 1) + 2 * NODE::PV as i32;
 
             td.stack[ply].reduction = reduction;
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true, ply + 1);


### PR DESCRIPTION
STC
Elo   | 2.60 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 18842 W: 4771 L: 4630 D: 9441
Penta | [38, 2189, 4841, 2300, 53]
https://recklesschess.space/test/12766/

LTC
Elo   | 4.68 +- 3.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 10908 W: 2712 L: 2565 D: 5631
Penta | [5, 1161, 2977, 1304, 7]
https://recklesschess.space/test/12767/

Bench: 3350837