### PR TITLE
Fix minor inconsistencies across LMR rules

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -785,7 +785,7 @@ fn search<NODE: NodeType>(
             reduction -= 3183 * correction_value.abs() / 1024;
             reduction += 1300 * alpha_raises;
 
-            reduction += 600 * (is_valid(tt_score) && tt_score < alpha) as i32;
+            reduction += 600 * (is_valid(tt_score) && tt_score <= alpha) as i32;
             reduction += 300 * (is_valid(tt_score) && tt_depth < depth) as i32;
 
             if is_quiet {


### PR DESCRIPTION
STC
Elo   | 1.93 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 23582 W: 5932 L: 5801 D: 11849
Penta | [50, 2725, 6102, 2872, 42]
https://recklesschess.space/test/12664/

LTC
Elo   | 0.93 +- 1.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 36724 W: 9048 L: 8950 D: 18726
Penta | [10, 4082, 10076, 4188, 6]
https://recklesschess.space/test/12762/

Bench: 3563871
