### PR TITLE
Simplify recapture rule in LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -789,10 +789,10 @@ fn search<NODE: NodeType>(
             reduction += 300 * (is_valid(tt_score) && tt_depth < depth) as i32;
 
             if is_quiet {
-                reduction += 1972;
+                reduction += 1875;
                 reduction -= 154 * history / 1024;
             } else {
-                reduction += 1452;
+                reduction += 1355;
                 reduction -= 109 * history / 1024;
             }
 
@@ -804,10 +804,6 @@ fn search<NODE: NodeType>(
                 reduction -= 371;
                 reduction -= 656 * (is_valid(tt_score) && tt_score > alpha) as i32;
                 reduction -= 824 * (is_valid(tt_score) && tt_depth >= depth) as i32;
-            }
-
-            if mv.is_noisy() && mv.to() == td.board.recapture_square() {
-                reduction -= 910;
             }
 
             if !tt_pv && cut_node {


### PR DESCRIPTION
STC
Elo   | 1.59 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 26390 W: 6664 L: 6543 D: 13183
Penta | [40, 3081, 6843, 3180, 51]
https://recklesschess.space/test/12755/

LTC
Elo   | 0.01 +- 1.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 92302 W: 22623 L: 22620 D: 47059
Penta | [39, 10465, 25122, 10504, 21]
https://recklesschess.space/test/12763/

Bench: 3363101