### PR TITLE
Fix upcoming repetition before or at root

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -290,42 +290,41 @@ impl Board {
     ///
     /// <http://web.archive.org/web/20201107002606/https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf>
     pub fn upcoming_repetition(&self, ply: usize) -> bool {
-        let hm = self.state.plies_from_null.min(self.state.halfmove_clock as usize);
-        if hm < 3 {
+        let half_moves = self.state.plies_from_null.min(self.state.halfmove_clock as usize);
+        if half_moves < 3 {
             return false;
         }
 
-        let s = |v: usize| self.state_stack[self.state_stack.len() - v].key;
-        let s0 = self.state.key;
+        let current_key = self.state.key;
+        let stack = &self.state_stack;
+        let len = stack.len();
 
-        let mut other = s0 ^ s(1) ^ ZOBRIST.side;
+        let mut index = len - 1;
+        let mut other = current_key ^ stack[index].key ^ ZOBRIST.side;
 
-        for d in (3..=hm).step_by(2) {
-            other ^= s(d - 1) ^ s(d) ^ ZOBRIST.side;
+        for compared_ply in (3..=half_moves).step_by(2) {
+            index -= 1;
+            other ^= stack[index].key ^ stack[index - 1].key ^ ZOBRIST.side;
+            index -= 1;
 
             if other != 0 {
                 continue;
             }
 
-            let diff = s0 ^ s(d);
-            let mut i = h1(diff);
+            let diff = current_key ^ stack[index].key;
+            let mut cuckoo_index = h1(diff);
 
-            if cuckoo(i) != diff {
-                i = h2(diff);
-
-                if cuckoo(i) != diff {
+            if cuckoo(cuckoo_index) != diff {
+                cuckoo_index = h2(diff);
+                if cuckoo(cuckoo_index) != diff {
                     continue;
                 }
             }
 
-            if (between(cuckoo_a(i), cuckoo_b(i)) & self.occupancies()).is_empty() {
-                if ply > d {
-                    return true;
-                }
-
-                if self.state.repetition != 0 {
-                    return true;
-                }
+            if (between(cuckoo_a(cuckoo_index), cuckoo_b(cuckoo_index)) & self.occupancies()).is_empty()
+                && (ply > compared_ply || stack[index].repetition != 0)
+            {
+                return true;
             }
         }
 


### PR DESCRIPTION
Elo   | 0.96 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 36192 W: 9233 L: 9133 D: 17826
Penta | [83, 3850, 10124, 3962, 77]
https://recklesschess.space/test/12873/

Bench: 3278762
Co-Authored-By: cj5716 <125858804+cj5716@users.noreply.github.com>