### PR TITLE
Remove recapture extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -683,8 +683,6 @@ fn search<NODE: NodeType>(
         } else if cut_node {
             extension = -2;
         }
-    } else if NODE::PV && tt_move.is_noisy() && tt_move.to() == td.board.recapture_square() {
-        extension = 1;
     }
 
     let mut best_move = Move::NULL;


### PR DESCRIPTION
STC
Elo   | -0.06 +- 1.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 102930 W: 25799 L: 25816 D: 51315
Penta | [232, 12227, 26587, 12164, 255]
https://recklesschess.space/test/12822/

LTC
Elo   | 0.33 +- 1.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 60646 W: 14836 L: 14779 D: 31031
Penta | [27, 6909, 16390, 6974, 23]
https://recklesschess.space/test/12842/

Bench: 2848395