### PR TITLE
Avoid wasteful probcut search when decisive

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -593,7 +593,7 @@ fn search<NODE: NodeType>(
     let mut probcut_beta = beta + 269 - 72 * improving as i32;
 
     if cut_node
-        && !is_decisive(beta)
+        && !is_win(beta)
         && if is_valid(tt_score) { tt_score >= probcut_beta && !is_decisive(tt_score) } else { eval >= beta }
         && !tt_move.is_quiet()
     {
@@ -639,6 +639,8 @@ fn search<NODE: NodeType>(
 
                 if !is_decisive(score) {
                     return (3 * score + beta) / 4;
+                } else {
+                    return score;
                 }
             }
         }


### PR DESCRIPTION
returns immediately if probcut returns a decisive score. This doesn’t cause a "short-pv" issue since probcut is only used at cut nodes.

Elo   | 0.78 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 42230 W: 10594 L: 10499 D: 21137
Penta | [95, 4901, 11043, 4966, 110]
https://recklesschess.space/test/12894/

Elo   | 0.45 +- 1.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 53188 W: 13157 L: 13088 D: 26943
Penta | [21, 5973, 14534, 6048, 18]
https://recklesschess.space/test/12895/

Bench: 2751460