### PR TITLE
Simplify away RFP in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -519,13 +519,13 @@ fn search<NODE: NodeType>(
 
     // Reverse Futility Pruning (RFP)
     if !tt_pv
+        && !in_check
         && !excluded
-        && is_valid(estimated_score)
         && estimated_score >= beta
         && estimated_score
             >= beta + 1125 * depth * depth / 128 + 26 * depth - (77 * improving as i32)
                 + 519 * correction_value.abs() / 1024
-                - 64 * ((td.board.all_threats() & td.board.colors(stm)).is_empty() && !td.board.in_check()) as i32
+                - 64 * (td.board.all_threats() & td.board.colors(stm)).is_empty() as i32
                 + 32
         && !is_loss(beta)
         && !is_win(estimated_score)


### PR DESCRIPTION
STC
Elo   | -0.20 +- 0.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 135750 W: 33942 L: 34019 D: 67789
Penta | [342, 16126, 35041, 15999, 367]
https://recklesschess.space/test/12972/

LTC
Elo   | 0.62 +- 1.53 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 45898 W: 11389 L: 11307 D: 23202
Penta | [26, 5162, 12479, 5268, 14]
https://recklesschess.space/test/12977/

Bench: 2801761