### PR TITLE
SMP SPSA session 108k games

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,9 +1,9 @@
 use crate::{thread::ThreadData, types::Score};
 
 pub fn correct_eval(td: &ThreadData, raw_eval: i32, correction_value: i32) -> i32 {
-    let mut eval = (raw_eval * (21061 + td.board.material())
-        + td.optimism[td.board.side_to_move()] * (1519 + td.board.material()))
-        / 26556;
+    let mut eval = (raw_eval * (20664 + td.board.material())
+        + td.optimism[td.board.side_to_move()] * (1487 + td.board.material()))
+        / 26685;
 
     eval = eval * (200 - td.board.halfmove_clock() as i32) / 200;
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -84,7 +84,7 @@ impl MovePicker {
                     continue;
                 }
 
-                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 46 + 109);
+                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 45 + 111);
                 if !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;
@@ -183,7 +183,7 @@ impl MovePicker {
         let rook_threats = minor_threats | td.board.piece_threats(PieceType::Rook);
 
         let threatened = [Bitboard(0), pawn_threats, pawn_threats, minor_threats, rook_threats, Bitboard(0)];
-        let escape = [0, 8000, 8000, 14000, 20000, 0];
+        let escape = [0, 7768, 8218, 13424, 20208, 0];
 
         // safe squares where we can attack an opponent piece
         let mut n = Bitboard(0);
@@ -232,9 +232,9 @@ impl MovePicker {
                 + td.conthist(ply, 4, mv)
                 + td.conthist(ply, 6, mv)
                 + escape[pt] * threatened[pt].contains(mv.from()) as i32
-                + 10000 * td.board.checking_squares(pt).contains(mv.to()) as i32
-                - 8000 * threatened[pt].contains(mv.to()) as i32
-                + 6000 * offense[pt].contains(mv.to()) as i32
+                + 9325 * td.board.checking_squares(pt).contains(mv.to()) as i32
+                - 7584 * threatened[pt].contains(mv.to()) as i32
+                + 6158 * offense[pt].contains(mv.to()) as i32
                 + 5000 * (pt == PieceType::Rook && king_ring_ortho.contains(mv.to())) as i32;
 
             if Bitboard::HOME_ROWS[side].contains(td.board.king_square(side)) && wall_pawns.contains(mv.from()) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1036,11 +1036,11 @@ fn search<NODE: NodeType>(
     if !NODE::ROOT && bound == Bound::Upper {
         let prior_move = td.stack[ply - 1].mv;
         if prior_move.is_quiet() {
-            let mut factor = 116;
-            factor += 202 * (td.stack[ply - 1].move_count > 7) as i32;
-            factor += 116 * (prior_move == td.stack[ply - 1].tt_move) as i32;
-            factor += 138 * (!in_check && best_score <= eval - 93) as i32;
-            factor += 321 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 128) as i32;
+            let factor = 116
+                + 202 * (td.stack[ply - 1].move_count > 7) as i32
+                + 116 * (prior_move == td.stack[ply - 1].tt_move) as i32
+                + 138 * (!in_check && best_score <= eval - 93) as i32
+                + 321 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 128) as i32;
 
             let scaled_bonus = factor * (165 * depth - 35).min(2467) / 128;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -100,7 +100,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             rm.previous_score = rm.score;
         }
 
-        let mut delta = 13;
+        let mut delta = 15;
         let mut reduction = 0;
 
         for index in 0..td.multi_pv {
@@ -117,7 +117,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             }
 
             // Aspiration Windows
-            delta += average[td.pv_index] * average[td.pv_index] / 23660;
+            delta += average[td.pv_index] * average[td.pv_index] / 25833;
 
             let mut alpha = (average[td.pv_index] - delta).max(-Score::INFINITE);
             let mut beta = (average[td.pv_index] + delta).min(Score::INFINITE);
@@ -125,7 +125,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             let best_avg = ((td.shared.best_stats[td.pv_index].load(Ordering::Acquire) & 0xffff) as i32 - 32768
                 + average[td.pv_index])
                 / 2;
-            td.optimism[td.board.side_to_move()] = 169 * best_avg / (best_avg.abs() + 187);
+            td.optimism[td.board.side_to_move()] = 159 * best_avg / (best_avg.abs() + 186);
             td.optimism[!td.board.side_to_move()] = -td.optimism[td.board.side_to_move()];
 
             loop {
@@ -146,13 +146,13 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
                         beta = (3 * alpha + beta) / 4;
                         alpha = (score - delta).max(-Score::INFINITE);
                         reduction = 0;
-                        delta += 27 * delta / 128;
+                        delta += 28 * delta / 128;
                     }
                     s if s >= beta => {
                         alpha = (beta - delta).max(alpha);
                         beta = (score + delta).min(Score::INFINITE);
                         reduction += 1;
-                        delta += 63 * delta / 128;
+                        delta += 62 * delta / 128;
                     }
                     _ => {
                         average[td.pv_index] = if average[td.pv_index] == Score::NONE {
@@ -356,8 +356,8 @@ fn search<NODE: NodeType>(
             }
         {
             if tt_move.is_quiet() && tt_score >= beta && td.stack[ply - 1].move_count < 4 {
-                let quiet_bonus = (185 * depth - 81).min(1806);
-                let cont_bonus = (108 * depth - 56).min(1365);
+                let quiet_bonus = (175 * depth - 79).min(1637);
+                let cont_bonus = (114 * depth - 57).min(1284);
 
                 td.quiet_history.update(td.board.all_threats(), stm, tt_move, quiet_bonus);
                 update_continuation_histories(td, ply, td.board.moved_piece(tt_move), tt_move.to(), cont_bonus);
@@ -467,14 +467,14 @@ fn search<NODE: NodeType>(
 
     // Quiet move ordering using eval difference
     if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].mv.is_quiet() && is_valid(td.stack[ply - 1].eval) {
-        let value = 819 * (-(eval + td.stack[ply - 1].eval)) / 128;
-        let bonus = value.clamp(-124, 312);
+        let value = 824 * (-(eval + td.stack[ply - 1].eval)) / 128;
+        let bonus = value.clamp(-133, 348);
 
         td.quiet_history.update(td.board.prior_threats(), !stm, td.stack[ply - 1].mv, bonus);
     }
 
     // Hindsight reductions
-    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].reduction >= 2247 && eval + td.stack[ply - 1].eval < 0
+    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].reduction >= 2367 && eval + td.stack[ply - 1].eval < 0
     {
         depth += 1;
     }
@@ -510,7 +510,7 @@ fn search<NODE: NodeType>(
     // Razoring
     if !NODE::PV
         && !in_check
-        && estimated_score < alpha - 299 - 252 * depth * depth
+        && estimated_score < alpha - 295 - 261 * depth * depth
         && alpha < 2048
         && !tt_move.is_quiet()
     {
@@ -523,10 +523,10 @@ fn search<NODE: NodeType>(
         && !excluded
         && estimated_score >= beta
         && estimated_score
-            >= beta + 1125 * depth * depth / 128 + 26 * depth - (77 * improving as i32)
-                + 519 * correction_value.abs() / 1024
-                - 64 * (td.board.all_threats() & td.board.colors(stm)).is_empty() as i32
-                + 32
+            >= beta + 1165 * depth * depth / 128 + 25 * depth - (80 * improving as i32)
+                + 560 * correction_value.abs() / 1024
+                - 59 * (td.board.all_threats() & td.board.colors(stm)).is_empty() as i32
+                + 30
         && !is_loss(beta)
         && !is_win(estimated_score)
     {
@@ -540,7 +540,7 @@ fn search<NODE: NodeType>(
         && !potential_singularity
         && estimated_score >= beta
         && estimated_score
-            >= beta - 9 * depth + 126 * tt_pv as i32 - 128 * improvement / 1024 + 286
+            >= beta - 8 * depth + 116 * tt_pv as i32 - 106 * improvement / 1024 + 304
                 - 20 * (td.stack[ply + 1].cutoff_count < 2) as i32
         && ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
@@ -552,7 +552,7 @@ fn search<NODE: NodeType>(
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
-        let r = (5154 + 271 * depth + 535 * (estimated_score - beta).clamp(0, 1073) / 128) / 1024;
+        let r = (5335 + 260 * depth + 493 * (estimated_score - beta).clamp(0, 1003) / 128) / 1024;
 
         td.stack[ply].conthist = td.stack.sentinel().conthist;
         td.stack[ply].contcorrhist = td.stack.sentinel().contcorrhist;
@@ -590,7 +590,7 @@ fn search<NODE: NodeType>(
     }
 
     // ProbCut
-    let mut probcut_beta = beta + 269 - 72 * improving as i32;
+    let mut probcut_beta = beta + 270 - 75 * improving as i32;
 
     if cut_node
         && !is_win(beta)
@@ -613,10 +613,10 @@ fn search<NODE: NodeType>(
             let mut score = -qsearch::<NonPV>(td, -probcut_beta, -probcut_beta + 1, ply + 1);
 
             let base_depth = (depth - 4).max(0);
-            let mut probcut_depth = (base_depth - (score - probcut_beta) / 295).clamp(0, base_depth);
+            let mut probcut_depth = (base_depth - (score - probcut_beta) / 319).clamp(0, base_depth);
 
             if score >= probcut_beta && probcut_depth > 0 {
-                let adjusted_beta = (probcut_beta + 282 * (base_depth - probcut_depth)).min(Score::INFINITE);
+                let adjusted_beta = (probcut_beta + 260 * (base_depth - probcut_depth)).min(Score::INFINITE);
 
                 score = -search::<NonPV>(td, -adjusted_beta, -adjusted_beta + 1, probcut_depth, false, ply + 1);
 
@@ -667,9 +667,9 @@ fn search<NODE: NodeType>(
 
         if score < singular_beta {
             let double_margin =
-                200 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
+                204 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
             let triple_margin =
-                288 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128 + 32;
+                257 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 15 * correction_value.abs() / 128 + 32;
 
             extension = 1;
             extension += (score < singular_beta - double_margin) as i32;
@@ -726,16 +726,16 @@ fn search<NODE: NodeType>(
             if !in_check
                 && !td.board.is_direct_check(mv)
                 && is_quiet
-                && move_count >= (3072 + 4 * improvement + 1536 * depth * depth + 64 * history / 1024) / 1024
+                && move_count >= (3006 + 70 * improvement / 16 + 1455 * depth * depth + 68 * history / 1024) / 1024
             {
                 skip_quiets = true;
                 continue;
             }
 
             // Futility Pruning (FP)
-            let futility_value = eval + 88 * depth + 63 * history / 1024 + 88 * (eval >= beta) as i32 - 114;
+            let futility_value = eval + 79 * depth + 64 * history / 1024 + 84 * (eval >= beta) as i32 - 115;
 
-            if !in_check && is_quiet && depth < 14 && futility_value <= alpha && !td.board.is_direct_check(mv) {
+            if !in_check && is_quiet && depth < 15 && futility_value <= alpha && !td.board.is_direct_check(mv) {
                 if !is_decisive(best_score) && best_score < futility_value {
                     best_score = futility_value;
                 }
@@ -744,10 +744,10 @@ fn search<NODE: NodeType>(
             }
 
             // Bad Noisy Futility Pruning (BNFP)
-            let noisy_futility_value = eval + 71 * depth + 69 * history / 1024 + 25;
+            let noisy_futility_value = eval + 71 * depth + 68 * history / 1024 + 23;
 
             if !in_check
-                && depth < 12
+                && depth < 11
                 && move_picker.stage() == Stage::BadNoisy
                 && noisy_futility_value <= alpha
                 && !td.board.is_direct_check(mv)
@@ -760,7 +760,7 @@ fn search<NODE: NodeType>(
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
-                (-16 * depth * depth + 52 * depth - 21 * history / 1024 + 22).min(0)
+                (-17 * depth * depth + 52 * depth - 21 * history / 1024 + 20).min(0)
             } else {
                 (-8 * depth * depth - 36 * depth - 32 * history / 1024 + 11).min(0)
             };
@@ -780,52 +780,52 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count >= 2 {
-            let mut reduction = 250 * (move_count.ilog2() * depth.ilog2()) as i32;
+            let mut reduction = 225 * (move_count.ilog2() * depth.ilog2()) as i32;
 
-            reduction -= 65 * move_count;
-            reduction -= 3183 * correction_value.abs() / 1024;
-            reduction += 1300 * alpha_raises;
+            reduction -= 68 * move_count;
+            reduction -= 3297 * correction_value.abs() / 1024;
+            reduction += 1306 * alpha_raises;
 
-            reduction += 600 * (is_valid(tt_score) && tt_score <= alpha) as i32;
-            reduction += 300 * (is_valid(tt_score) && tt_depth < depth) as i32;
+            reduction += 546 * (is_valid(tt_score) && tt_score <= alpha) as i32;
+            reduction += 322 * (is_valid(tt_score) && tt_depth < depth) as i32;
 
             if is_quiet {
-                reduction += 1875;
-                reduction -= 154 * history / 1024;
+                reduction += 1806;
+                reduction -= 166 * history / 1024;
             } else {
-                reduction += 1355;
+                reduction += 1449;
                 reduction -= 109 * history / 1024;
             }
 
             if NODE::PV {
-                reduction -= 411 + 421 * (beta - alpha) / td.root_delta;
+                reduction -= 424 + 433 * (beta - alpha) / td.root_delta;
             }
 
             if tt_pv {
-                reduction -= 371;
-                reduction -= 656 * (is_valid(tt_score) && tt_score > alpha) as i32;
-                reduction -= 824 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                reduction -= 361;
+                reduction -= 636 * (is_valid(tt_score) && tt_score > alpha) as i32;
+                reduction -= 830 * (is_valid(tt_score) && tt_depth >= depth) as i32;
             }
 
             if !tt_pv && cut_node {
-                reduction += 1762;
-                reduction += 2116 * tt_move.is_null() as i32;
+                reduction += 1818;
+                reduction += 2118 * tt_move.is_null() as i32;
             }
 
             if !improving {
-                reduction += (438 - 279 * improvement / 128).min(1288);
+                reduction += (430 - 263 * improvement / 128).min(1096);
             }
 
             if td.board.in_check() {
-                reduction -= 966;
+                reduction -= 1021;
             }
 
             if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1604;
+                reduction += 1515;
             }
 
-            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 512 {
-                reduction += 128;
+            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 485 {
+                reduction += 129;
             }
 
             let reduced_depth =
@@ -838,8 +838,8 @@ fn search<NODE: NodeType>(
 
             if score > alpha {
                 if !NODE::ROOT {
-                    new_depth += (score > best_score + 60) as i32;
-                    new_depth += (score > best_score + 768) as i32;
+                    new_depth += (score > best_score + 61) as i32;
+                    new_depth += (score > best_score + 801) as i32;
                     new_depth -= (score < best_score + 5 + reduced_depth) as i32;
                 }
 
@@ -851,46 +851,46 @@ fn search<NODE: NodeType>(
         }
         // Full Depth Search (FDS)
         else if !NODE::PV || move_count > 1 {
-            let mut reduction = 238 * (move_count.ilog2() * depth.ilog2()) as i32;
+            let mut reduction = 232 * (move_count.ilog2() * depth.ilog2()) as i32;
 
-            reduction -= 57 * move_count;
-            reduction -= 2513 * correction_value.abs() / 1024;
+            reduction -= 48 * move_count;
+            reduction -= 2408 * correction_value.abs() / 1024;
 
             if is_quiet {
-                reduction += 1427;
-                reduction -= 158 * history / 1024;
+                reduction += 1429;
+                reduction -= 152 * history / 1024;
             } else {
-                reduction += 1098;
-                reduction -= 65 * history / 1024;
+                reduction += 1053;
+                reduction -= 67 * history / 1024;
             }
 
             if tt_pv {
-                reduction -= 897;
-                reduction -= 1127 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                reduction -= 936;
+                reduction -= 1080 * (is_valid(tt_score) && tt_depth >= depth) as i32;
             }
 
             if !tt_pv && cut_node {
-                reduction += 1450;
-                reduction += 2200 * tt_move.is_null() as i32;
+                reduction += 1543;
+                reduction += 2058 * tt_move.is_null() as i32;
             }
 
             if !improving {
-                reduction += (454 - 254 * improvement / 128).min(1368);
+                reduction += (409 - 254 * improvement / 128).min(1488);
             }
 
             if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1452;
+                reduction += 1360;
             }
 
             if mv == tt_move {
-                reduction -= 3316;
+                reduction -= 3281;
             }
 
-            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 512 {
-                reduction += 128;
+            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {
+                reduction += 130;
             }
 
-            let reduced_depth = new_depth - (reduction >= 3072) as i32 - (reduction >= 5687 && new_depth >= 3) as i32;
+            let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585 && new_depth >= 3) as i32;
 
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
             current_search_count += 1;
@@ -990,14 +990,14 @@ fn search<NODE: NodeType>(
     }
 
     if best_move.is_present() {
-        let noisy_bonus = (106 * depth).min(808) - 54 - 80 * cut_node as i32;
-        let noisy_malus = (164 * depth).min(1329) - 52 - 23 * noisy_moves.len() as i32;
+        let noisy_bonus = (115 * depth).min(778) - 50 - 77 * cut_node as i32;
+        let noisy_malus = (176 * depth).min(1343) - 51 - 21 * noisy_moves.len() as i32;
 
-        let quiet_bonus = (172 * depth).min(1459) - 78 - 54 * cut_node as i32;
-        let quiet_malus = (144 * depth).min(1064) - 45 - 39 * quiet_moves.len() as i32;
+        let quiet_bonus = (172 * depth).min(1508) - 76 - 55 * cut_node as i32;
+        let quiet_malus = (156 * depth).min(1065) - 45 - 36 * quiet_moves.len() as i32;
 
-        let cont_bonus = (108 * depth).min(977) - 67 - 52 * cut_node as i32;
-        let cont_malus = (352 * depth).min(868) - 47 - 19 * quiet_moves.len() as i32;
+        let cont_bonus = (99 * depth).min(995) - 65 - 49 * cut_node as i32;
+        let cont_malus = (371 * depth).min(914) - 44 - 18 * quiet_moves.len() as i32;
 
         if best_move.is_noisy() {
             td.noisy_history.update(
@@ -1023,12 +1023,12 @@ fn search<NODE: NodeType>(
         }
 
         if !NODE::ROOT && td.stack[ply - 1].mv.is_quiet() && td.stack[ply - 1].move_count < 2 {
-            let malus = (86 * depth - 60).min(771);
+            let malus = (90 * depth - 58).min(789);
             update_continuation_histories(td, ply - 1, td.stack[ply - 1].piece, td.stack[ply - 1].mv.to(), -malus);
         }
 
         if current_search_count > 1 && best_move.is_quiet() && best_score >= beta {
-            let bonus = (201 * depth - 86).min(1634);
+            let bonus = (194 * depth - 89).min(1595);
             update_continuation_histories(td, ply, td.stack[ply].piece, best_move.to(), bonus);
         }
     }
@@ -1036,20 +1036,19 @@ fn search<NODE: NodeType>(
     if !NODE::ROOT && bound == Bound::Upper {
         let prior_move = td.stack[ply - 1].mv;
         if prior_move.is_quiet() {
-            let factor = 95
-                + 156 * (depth > 5) as i32
-                + 215 * (td.stack[ply - 1].move_count > 8) as i32
-                + 113 * (prior_move == td.stack[ply - 1].tt_move) as i32
-                + 130 * (!in_check && best_score <= eval - 96) as i32
-                + 317 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 120) as i32;
+            let mut factor = 116;
+            factor += 202 * (td.stack[ply - 1].move_count > 7) as i32;
+            factor += 116 * (prior_move == td.stack[ply - 1].tt_move) as i32;
+            factor += 138 * (!in_check && best_score <= eval - 93) as i32;
+            factor += 321 * (is_valid(td.stack[ply - 1].eval) && best_score <= -td.stack[ply - 1].eval - 128) as i32;
 
-            let scaled_bonus = factor * (153 * depth - 34).min(2474) / 128;
+            let scaled_bonus = factor * (165 * depth - 35).min(2467) / 128;
 
             td.quiet_history.update(td.board.prior_threats(), !stm, prior_move, scaled_bonus);
 
             let entry = &td.stack[ply - 2];
             if entry.mv.is_present() {
-                let bonus = (156 * depth - 38).min(1169);
+                let bonus = (159 * depth - 39).min(1160);
                 td.continuation_history.update(entry.conthist, td.stack[ply - 1].piece, prior_move.to(), bonus);
             }
         } else if prior_move.is_noisy() {
@@ -1222,7 +1221,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
-            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - 100) {
+            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - 108) {
                 continue;
             }
         }
@@ -1306,13 +1305,13 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
             td.stack[ply - 1].piece,
             td.stack[ply - 1].mv.to(),
         ))
-        / 77
+        / 73
 }
 
 fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: isize) {
     let stm = td.board.side_to_move();
     let corrhist = td.corrhist();
-    let bonus = (142 * depth * diff / 128).clamp(-4923, 3072);
+    let bonus = (142 * depth * diff / 128).clamp(-4771, 3001);
 
     corrhist.pawn.update(stm, td.board.pawn_key(), bonus);
     corrhist.minor.update(stm, td.board.minor_key(), bonus);


### PR DESCRIPTION
STC
Elo   | -6.52 +- 4.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6448 W: 1536 L: 1657 D: 3255
Penta | [24, 818, 1653, 713, 16]
https://recklesschess.space/test/13108/

MTC SMP
Elo   | 10.02 +- 4.69 (95%)
SPRT  | 25.0+0.25s Threads=8 Hash=512MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 4406 W: 1130 L: 1003 D: 2273
Penta | [0, 397, 1283, 522, 1]
https://recklesschess.space/test/13109/

Bench: 3085009