### PR TITLE
Store intermediate search results into TT

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -966,6 +966,10 @@ fn search<NODE: NodeType>(
 
                 alpha = score;
 
+                if !(NODE::ROOT && td.pv_index > 0) && mv != tt_move {
+                    td.shared.tt.write(hash, depth, raw_eval, score, Bound::Lower, mv, ply, true, false);
+                }
+
                 if !is_decisive(score) {
                     alpha_raises += 1;
                 }


### PR DESCRIPTION
STC, 1-thread:
```
Elo   | -3.61 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10492 W: 2632 L: 2741 D: 5119
Penta | [51, 1215, 2802, 1148, 30]
```
https://recklesschess.space/test/13134/

VSTC, 8-thread:
```
Elo   | 3.99 +- 2.78 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=256MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 14188 W: 3619 L: 3456 D: 7113
Penta | [17, 1529, 3841, 1688, 19]
```
https://recklesschess.space/test/13116/

Bench 3085009