### PR TITLE
Double the weight of quiet history in move ordering

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -226,7 +226,7 @@ impl MovePicker {
             let mv = entry.mv;
             let pt = td.board.piece_on(mv.from()).piece_type();
 
-            entry.score = td.quiet_history.get(threats, side, mv)
+            entry.score = 2 * td.quiet_history.get(threats, side, mv)
                 + td.conthist(ply, 1, mv)
                 + td.conthist(ply, 2, mv)
                 + td.conthist(ply, 4, mv)


### PR DESCRIPTION
STC
Elo   | 3.38 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.22 (-2.25, 2.89) [0.00, 3.00]
Games | N: 25924 W: 6712 L: 6460 D: 12752
Penta | [92, 2997, 6538, 3237, 98]
https://recklesschess.space/test/13129/

LTC
Elo   | 1.94 +- 1.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 45950 W: 11511 L: 11254 D: 23185
Penta | [22, 5060, 12551, 5323, 19]
https://recklesschess.space/test/13130/

Bench: 2786596
