### PR TITLE
Increase scoring weight for counter-move continuation history

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -226,11 +226,11 @@ impl MovePicker {
             let mv = entry.mv;
             let pt = td.board.piece_on(mv.from()).piece_type();
 
-            entry.score = 2 * td.quiet_history.get(threats, side, mv)
-                + td.conthist(ply, 1, mv)
-                + td.conthist(ply, 2, mv)
-                + td.conthist(ply, 4, mv)
-                + td.conthist(ply, 6, mv)
+            entry.score = 2048 * td.quiet_history.get(threats, side, mv) / 1024
+                + 1536 * td.conthist(ply, 1, mv) / 1024
+                + 1024 * td.conthist(ply, 2, mv) / 1024
+                + 1024 * td.conthist(ply, 4, mv) / 1024
+                + 1024 * td.conthist(ply, 6, mv) / 1024
                 + escape[pt] * threatened[pt].contains(mv.from()) as i32
                 + 9325 * td.board.checking_squares(pt).contains(mv.to()) as i32
                 - 7584 * threatened[pt].contains(mv.to()) as i32

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -228,9 +228,9 @@ impl MovePicker {
 
             entry.score = 2048 * td.quiet_history.get(threats, side, mv) / 1024
                 + 1536 * td.conthist(ply, 1, mv) / 1024
-                + 1024 * td.conthist(ply, 2, mv) / 1024
-                + 1024 * td.conthist(ply, 4, mv) / 1024
-                + 1024 * td.conthist(ply, 6, mv) / 1024
+                + td.conthist(ply, 2, mv)
+                + td.conthist(ply, 4, mv)
+                + td.conthist(ply, 6, mv)
                 + escape[pt] * threatened[pt].contains(mv.from()) as i32
                 + 9325 * td.board.checking_squares(pt).contains(mv.to()) as i32
                 - 7584 * threatened[pt].contains(mv.to()) as i32


### PR DESCRIPTION
STC
Elo   | 4.40 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16328 W: 4173 L: 3966 D: 8189
Penta | [51, 1791, 4260, 2024, 38]
https://recklesschess.space/test/13219/

LTC
Elo   | 3.36 +- 2.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21192 W: 5388 L: 5183 D: 10621
Penta | [7, 2288, 5801, 2493, 7]
https://recklesschess.space/test/13223/

Bench: 3303737
