### PR TITLE
Cleanup logic in MovePicker::score_quiet

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -177,46 +177,53 @@ impl MovePicker {
     fn score_quiet(&mut self, td: &ThreadData, ply: isize) {
         let threats = td.board.all_threats();
         let side = td.board.side_to_move();
-        let pawn_threats = td.board.piece_threats(PieceType::Pawn);
-        let minor_threats =
-            pawn_threats | td.board.piece_threats(PieceType::Knight) | td.board.piece_threats(PieceType::Bishop);
-        let rook_threats = minor_threats | td.board.piece_threats(PieceType::Rook);
 
-        let threatened = [Bitboard(0), pawn_threats, pawn_threats, minor_threats, rook_threats, Bitboard(0)];
+        let threatened = {
+            let pawn_threats = td.board.piece_threats(PieceType::Pawn);
+            let minor_threats =
+                pawn_threats | td.board.piece_threats(PieceType::Knight) | td.board.piece_threats(PieceType::Bishop);
+            let rook_threats = minor_threats | td.board.piece_threats(PieceType::Rook);
+            [Bitboard(0), pawn_threats, pawn_threats, minor_threats, rook_threats, Bitboard(0)]
+        };
+
         let escape = [0, 7768, 8218, 13424, 20208, 0];
 
         // safe squares where we can attack an opponent piece
-        let mut n = Bitboard(0);
-        let mut b = Bitboard(0);
-        let mut q = Bitboard(0);
-        let pawn_offense = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
+        let offense = {
+            let mut n = Bitboard(0);
+            let mut b = Bitboard(0);
+            let mut q = Bitboard(0);
+            let pawn_offense = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
 
-        for square in td.board.colored_pieces(!side, PieceType::Bishop) & !threats {
-            n |= knight_attacks(square);
-            q |= rook_attacks(square, td.board.occupancies());
-        }
-
-        for square in td.board.colored_pieces(!side, PieceType::Rook) {
-            n |= knight_attacks(square);
-            b |= bishop_attacks(square, td.board.occupancies());
-
-            if !threats.contains(square) {
-                q |= bishop_attacks(square, td.board.occupancies());
+            for square in td.board.colored_pieces(!side, PieceType::Bishop) & !threats {
+                n |= knight_attacks(square);
+                q |= rook_attacks(square, td.board.occupancies());
             }
-        }
-        for square in td.board.colored_pieces(!side, PieceType::Queen) {
-            n |= knight_attacks(square);
-        }
 
-        let offense = [pawn_offense, n & !threats, b & !threats, Bitboard(0), q & !threats, Bitboard(0)];
+            for square in td.board.colored_pieces(!side, PieceType::Rook) {
+                n |= knight_attacks(square);
+                b |= bishop_attacks(square, td.board.occupancies());
+
+                if !threats.contains(square) {
+                    q |= bishop_attacks(square, td.board.occupancies());
+                }
+            }
+            for square in td.board.colored_pieces(!side, PieceType::Queen) {
+                n |= knight_attacks(square);
+            }
+
+            [pawn_offense, n & !threats, b & !threats, Bitboard(0), q & !threats, Bitboard(0)]
+        };
 
         // King ring diag attacks and ortho attacks
-        let mut king_ring_ortho = Bitboard(0);
-
-        for square in king_attacks(td.board.king_square(!side)) {
-            king_ring_ortho |= rook_attacks(square, td.board.occupancies());
-        }
-        king_ring_ortho &= !threats;
+        let king_ring_ortho = {
+            let mut king_ring_ortho = Bitboard(0);
+            for square in king_attacks(td.board.king_square(!side)) {
+                king_ring_ortho |= rook_attacks(square, td.board.occupancies());
+            }
+            king_ring_ortho &= !threats;
+            king_ring_ortho
+        };
 
         // don't move king wall pawns
         let wall_pawns = if Bitboard::HOME_ROWS[side].contains(td.board.king_square(side)) {


### PR DESCRIPTION
Add scopes for temporary variables to improve readability.

No functional change.

Bench: 3303737