### PR TITLE
Update default network to v59-f6f160f4.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v58-ca025eef.nnue";
+const NETWORK_NAME: &str = "v59-f6f160f4.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 2.64 +- 2.01 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40196 W: 11651 L: 11345 D: 17200
Penta | [571, 4638, 9361, 4970, 558]
https://recklesschess.space/test/13263/

STC
Elo   | 2.26 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41084 W: 10534 L: 10267 D: 20283
Penta | [159, 4794, 10363, 5073, 153]
https://recklesschess.space/test/13264/

LTC
Elo   | 2.84 +- 2.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26640 W: 6582 L: 6364 D: 13694
Penta | [15, 2924, 7219, 3152, 10]
https://recklesschess.space/test/13267/

Bench: 3132435