### PR TITLE
Fix UCI parsing bug + incorrect starting position when using `position moves <move>`

### DIFF
--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -32,7 +32,7 @@ impl ThreadPool {
 
     pub fn new(shared: Arc<SharedContext>) -> Self {
         let workers = make_worker_threads(1);
-        let data = make_thread_data(shared, &workers, Board::default().into());
+        let data = make_thread_data(shared, &workers, Board::starting_position().into());
 
         Self { workers, vector: data }
     }
@@ -69,7 +69,7 @@ impl ThreadPool {
         let shared = self.vector[0].shared.clone();
 
         std::mem::drop(self.vector.drain(..));
-        self.vector = make_thread_data(shared, &self.workers, Board::default().into());
+        self.vector = make_thread_data(shared, &self.workers, Board::starting_position().into());
     }
 
     pub fn execute_searches(&mut self, time_manager: TimeManager, report: Report, shared: &Arc<SharedContext>) {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -242,7 +242,7 @@ fn go(threads: &mut ThreadPool, settings: &Settings, shared: &Arc<SharedContext>
 }
 
 fn position(threads: &mut ThreadPool, settings: &Settings, mut tokens: &[&str]) {
-    let mut board = Board::default();
+    let mut board = threads.main_thread().board.clone();
 
     while !tokens.is_empty() {
         match tokens {
@@ -264,10 +264,7 @@ fn position(threads: &mut ThreadPool, settings: &Settings, mut tokens: &[&str]) 
                 }
                 break;
             }
-            _ => {
-                tokens = &tokens[1..];
-                continue;
-            }
+            _ => tokens = &tokens[1..],
         }
     }
 
@@ -379,5 +376,122 @@ fn parse_limits(color: Color, tokens: &[&str]) -> Limits {
     match moves {
         Some(moves) => Limits::Cyclic(main, inc, moves),
         None => Limits::Fischer(main, inc),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_position_helper(tokens: &[&str]) -> Board {
+        let shared = Arc::new(SharedContext::default());
+        let settings = Settings::default();
+        let mut threads = ThreadPool::new(shared);
+
+        position(&mut threads, &settings, tokens);
+        threads.main_thread().board.clone()
+    }
+
+    #[test]
+    fn test_position_startpos() {
+        let board = test_position_helper(&["startpos"]);
+        assert_eq!(board.to_fen(), "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        let board = test_position_helper(&[]);
+        assert_eq!(board.to_fen(), "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    }
+
+    #[test]
+    fn test_position_startpos_multiple_moves() {
+        let board = test_position_helper(&["moves", "e2e4", "e7e5", "g1f3"]);
+        assert_eq!(board.side_to_move(), Color::Black);
+        let fen = board.to_fen();
+        let fen_position = fen.split_whitespace().next().unwrap();
+        assert!(fen_position.contains("5N2"));
+    }
+
+    #[test]
+    fn test_position_fen_with_moves() {
+        let board = test_position_helper(&[
+            "fen",
+            "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR",
+            "b",
+            "KQkq",
+            "e3",
+            "0",
+            "1",
+            "moves",
+            "e7e5",
+        ]);
+        assert_eq!(board.side_to_move(), Color::White);
+    }
+
+    #[test]
+    fn test_position_empty_moves_list() {
+        let board = test_position_helper(&["moves"]);
+        assert_eq!(board.to_fen(), "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    }
+
+    #[test]
+    fn test_position_invalid_move_ignored() {
+        let board = test_position_helper(&["moves", "e2e4", "invalid", "e7e5"]);
+        assert_eq!(board.side_to_move(), Color::White);
+    }
+
+    #[test]
+    fn test_position_long_move_sequence() {
+        let board = test_position_helper(&["moves", "e2e4", "e7e5", "g1f3", "b8c6", "f1b5", "a7a6"]);
+        assert_eq!(board.side_to_move(), Color::White);
+    }
+
+    #[test]
+    fn test_position_castling() {
+        let board = test_position_helper(&[
+            "fen",
+            "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R",
+            "w",
+            "KQkq",
+            "-",
+            "0",
+            "1",
+            "moves",
+            "e1g1",
+        ]);
+        assert_eq!(board.side_to_move(), Color::Black);
+    }
+
+    #[test]
+    fn test_position_en_passant() {
+        let board = test_position_helper(&[
+            "fen",
+            "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR",
+            "w",
+            "KQkq",
+            "f6",
+            "0",
+            "1",
+            "moves",
+            "e5f6",
+        ]);
+        assert_eq!(board.side_to_move(), Color::Black);
+    }
+
+    #[test]
+    fn test_position_promotion() {
+        let board = test_position_helper(&["fen", "8/P7/8/8/8/8/8/4K2k", "w", "-", "-", "0", "1", "moves", "a7a8q"]);
+        assert_eq!(board.side_to_move(), Color::Black);
+    }
+
+    #[test]
+    fn test_make_uci_move_invalid() {
+        let mut board = Board::starting_position();
+        let fen_before = board.to_fen();
+        make_uci_move(&mut board, "invalid_move");
+        assert_eq!(board.to_fen(), fen_before);
+    }
+
+    #[test]
+    fn test_position_moves_without_startpos_ignored() {
+        let board = test_position_helper(&["moves", "e2e4", "e7e5"]);
+        assert_eq!(board.to_fen(), "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2");
     }
 }


### PR DESCRIPTION
- My previous PR added a bug ;-; where its was calling Board::default(), due to which new boards were empty. Replaced with `starting_position()`.
- `position moves <move>` without a preceding startpos/fen now uses the current board instead of the default board
- Added tests for UCI (The rest of the codebase doesn't have many tests so I am not sure if  this belongs here)