### PR TITLE
Use correction-value to adjust qsearch futility margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1162,6 +1162,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let raw_eval;
     let eval;
     let mut best_score;
+    let correction_value = eval_correction(td, ply);
 
     // Evaluation
     if in_check {
@@ -1173,7 +1174,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             Some(entry) if is_valid(entry.raw_eval) => entry.raw_eval,
             _ => td.nnue.evaluate(&td.board),
         };
-        eval = correct_eval(td, raw_eval, eval_correction(td, ply));
+        eval = correct_eval(td, raw_eval, correction_value);
         best_score = eval;
 
         if is_valid(tt_score)
@@ -1223,7 +1224,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
-            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - 108) {
+            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - correction_value.abs().min(64) - 79) {
                 continue;
             }
         }


### PR DESCRIPTION
When the magnitude of the correction-value is low, we know the position is not very sharp, so we reduce the margin we leave when cutting, and the opposite when it is high.

STC:
```
Elo   | 1.70 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 65648 W: 16683 L: 16362 D: 32603
Penta | [216, 7689, 16691, 8014, 214]
```
https://recklesschess.space/test/13231/

LTC:
```
Elo   | 0.95 +- 0.65 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 256268 W: 63443 L: 62744 D: 130081
Penta | [147, 28990, 69166, 29679, 152]
```
https://recklesschess.space/test/13234/

Bench 2981881