### PR TITLE
cleanup clippy::missing_const_for_fn warnings

### DIFF
--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -18,7 +18,7 @@ pub enum Color {
     Black,
 }
 
-pub fn pawn_attacks(square: u8, color: Color) -> u64 {
+pub const fn pawn_attacks(square: u8, color: Color) -> u64 {
     let bitboard = 1 << square;
     if matches!(color, Color::White) {
         (bitboard & !A_FILE) << 7 | (bitboard & !H_FILE) << 9
@@ -27,7 +27,7 @@ pub fn pawn_attacks(square: u8, color: Color) -> u64 {
     }
 }
 
-pub fn king_attacks(square: u8) -> u64 {
+pub const fn king_attacks(square: u8) -> u64 {
     let bitboard = 1 << square;
 
     (bitboard >> 8 | bitboard << 8)
@@ -39,7 +39,7 @@ pub fn king_attacks(square: u8) -> u64 {
         | (bitboard & !H_FILE) << 9
 }
 
-pub fn knight_attacks(square: u8) -> u64 {
+pub const fn knight_attacks(square: u8) -> u64 {
     let bitboard = 1 << square;
 
     (bitboard & !A_FILE) >> 17

--- a/build/maps.rs
+++ b/build/maps.rs
@@ -67,11 +67,11 @@ fn generate_sliding_map(size: usize, magics: &[MagicEntry], directions: &[(i8, i
     map
 }
 
-fn get_permutation_count(mask: u64) -> u64 {
+const fn get_permutation_count(mask: u64) -> u64 {
     1 << mask.count_ones()
 }
 
-fn magic_index(occupancies: u64, entry: &MagicEntry) -> usize {
+const fn magic_index(occupancies: u64, entry: &MagicEntry) -> usize {
     let mut hash = occupancies & entry.mask;
     hash = hash.wrapping_mul(entry.magic) >> entry.shift;
     hash as usize + entry.offset

--- a/src/board.rs
+++ b/src/board.rs
@@ -197,11 +197,11 @@ impl Board {
         (self.pieces(PieceType::Pawn) | self.pieces(PieceType::King)) != self.occupancies()
     }
 
-    pub fn advance_fullmove_counter(&mut self) {
+    pub const fn advance_fullmove_counter(&mut self) {
         self.fullmove_number += self.side_to_move() as usize;
     }
 
-    pub fn set_frc(&mut self, frc: bool) {
+    pub const fn set_frc(&mut self, frc: bool) {
         self.frc = frc;
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -23,7 +23,7 @@ impl QuietHistoryEntry {
     const MAX_FACTORIZER: i32 = 1852;
     const MAX_BUCKET: i32 = 6324;
 
-    pub fn bucket(&self, threats: Bitboard, mv: Move) -> i16 {
+    pub const fn bucket(&self, threats: Bitboard, mv: Move) -> i16 {
         let from_threatened = threats.contains(mv.from()) as usize;
         let to_threatened = threats.contains(mv.to()) as usize;
 

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -119,7 +119,7 @@ impl Network {
         self.threat_stack[self.index].delta.clear();
     }
 
-    pub fn pop(&mut self) {
+    pub const fn pop(&mut self) {
         self.index -= 1;
     }
 

--- a/src/nnue/accumulator/threats/vectorized/avx2.rs
+++ b/src/nnue/accumulator/threats/vectorized/avx2.rs
@@ -37,7 +37,7 @@ pub fn closest_on_rays(rays: [__m256i; 2]) -> u64 {
     x & occupied
 }
 
-pub fn ray_fill(x: u64) -> u64 {
+pub const fn ray_fill(x: u64) -> u64 {
     let x = (x + 0x7E7E7E7E7E7E7E7E) & 0x8080808080808080;
     x - (x >> 7)
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -308,7 +308,7 @@ impl PrincipalVariationTable {
         &self.table[0][..self.len[0]]
     }
 
-    pub fn clear(&mut self, ply: usize) {
+    pub const fn clear(&mut self, ply: usize) {
         self.len[ply] = 0;
     }
 

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -50,7 +50,7 @@ impl ThreadPool {
         &mut self.vector[0]
     }
 
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.vector.len()
     }
 

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -78,7 +78,7 @@ pub struct InternalEntry {
 }
 
 impl InternalEntry {
-    fn depth(&self) -> i32 {
+    const fn depth(&self) -> i32 {
         TtDepth::from_tt(self.offset_depth)
     }
 }
@@ -89,7 +89,7 @@ impl TtDepth {
     pub const NONE: i32 = 0;
     pub const SOME: i32 = -1;
 
-    fn from_tt(offset_depth: u8) -> i32 {
+    const fn from_tt(offset_depth: u8) -> i32 {
         offset_depth as i32 - 1
     }
 

--- a/src/types/arrayvec.rs
+++ b/src/types/arrayvec.rs
@@ -42,11 +42,11 @@ impl<T: Copy, const N: usize> ArrayVec<T, N> {
         self.len += mask as usize;
     }
 
-    pub fn clear(&mut self) {
+    pub const fn clear(&mut self) {
         self.len = 0;
     }
 
-    pub fn swap_remove(&mut self, index: usize) -> T {
+    pub const fn swap_remove(&mut self, index: usize) -> T {
         unsafe {
             let value = std::ptr::read(self.data[index].as_ptr());
 

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -49,11 +49,11 @@ impl Bitboard {
         if offset > 0 { Self(self.0 << offset) } else { Self(self.0 >> -offset) }
     }
 
-    pub fn set(&mut self, square: Square) {
+    pub const fn set(&mut self, square: Square) {
         self.0 |= 1 << square as u64;
     }
 
-    pub fn clear(&mut self, square: Square) {
+    pub const fn clear(&mut self, square: Square) {
         self.0 &= !(1 << square as u64);
     }
 }

--- a/src/types/movelist.rs
+++ b/src/types/movelist.rs
@@ -122,7 +122,7 @@ impl MoveList {
         self.inner.iter_mut()
     }
 
-    pub fn remove(&mut self, index: usize) -> MoveEntry {
+    pub const fn remove(&mut self, index: usize) -> MoveEntry {
         self.inner.swap_remove(index)
     }
 }

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -102,7 +102,7 @@ impl Move {
         matches!(self.kind(), MoveKind::DoublePush)
     }
 
-    pub fn promotion_piece(self) -> Option<PieceType> {
+    pub const fn promotion_piece(self) -> Option<PieceType> {
         if self.is_promotion() {
             return Some(PieceType::new(((self.kind() as usize) & 3) + PieceType::Knight as usize));
         }


### PR DESCRIPTION
const_mut_refs was added in 1.83
this addresses the warnings from:  cargo clippy -- -W clippy::missing_const_for_fn
