### PR TITLE
MovePicker: Add 4k for queen promotions.

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -170,6 +170,10 @@ impl MovePicker {
 
                 entry.score =
                     16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
+
+                if mv.is_promotion() && mv.promotion_piece() == Some(PieceType::Queen) {
+                    entry.score += 4000;
+                }
             }
         }
     }


### PR DESCRIPTION
STC
Elo   | 2.42 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36026 W: 9233 L: 8982 D: 17811
Penta | [99, 4109, 9355, 4342, 108]
https://recklesschess.space/test/13282/

LTC
Elo   | 1.20 +- 0.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 117802 W: 29359 L: 28952 D: 59491
Penta | [58, 13194, 31984, 13613, 52]
https://recklesschess.space/test/13286/

bench 2798043