### PR TITLE
Prefer &raw over cast

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -168,7 +168,7 @@ impl ContinuationCorrectionHistory {
     pub fn subtable_ptr(
         &mut self, in_check: bool, capture: bool, piece: Piece, to: Square,
     ) -> *mut PieceToHistory<i16> {
-        self.entries[in_check as usize][capture as usize][piece][to].as_mut_ptr().cast()
+        &raw mut self.entries[in_check as usize][capture as usize][piece][to]
     }
 
     pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square) -> i32 {
@@ -198,7 +198,7 @@ impl ContinuationHistory {
     pub fn subtable_ptr(
         &mut self, in_check: bool, capture: bool, piece: Piece, to: Square,
     ) -> *mut PieceToHistory<i16> {
-        self.entries[in_check as usize][capture as usize][piece][to].as_mut_ptr().cast()
+        &raw mut self.entries[in_check as usize][capture as usize][piece][to]
     }
 
     pub fn get(&self, subtable_ptr: *mut PieceToHistory<i16>, piece: Piece, to: Square) -> i32 {


### PR DESCRIPTION
Safer as this would catch type mismatch with return value.

No functional change.

Bench: 2798043