### PR TITLE
simplify zeroed_box

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -217,13 +217,6 @@ impl Default for ContinuationHistory {
     }
 }
 
-fn zeroed_box<T>() -> Box<T> {
-    unsafe {
-        let layout = std::alloc::Layout::new::<T>();
-        let ptr = std::alloc::alloc_zeroed(layout);
-        if ptr.is_null() {
-            std::alloc::handle_alloc_error(layout);
-        }
-        Box::<T>::from_raw(ptr.cast())
-    }
+pub fn zeroed_box<T>() -> Box<T> {
+    unsafe { Box::<T>::new_zeroed().assume_init() }
 }


### PR DESCRIPTION
Box::<T>::new_zeroed has been stabalized.
assembly is identical:
https://godbolt.org/z/TqE7K4v4K
