### PR TITLE
Use safe indexing instead of get_unchecked

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -72,13 +72,13 @@ impl Index<isize> for Stack {
 
     fn index(&self, index: isize) -> &Self::Output {
         debug_assert!(index + 8 >= 0 && index < MAX_PLY as isize + 16);
-        unsafe { self.data.get_unchecked((index + 8) as usize) }
+        &self.data[(index + 8) as usize]
     }
 }
 
 impl IndexMut<isize> for Stack {
     fn index_mut(&mut self, index: isize) -> &mut Self::Output {
         debug_assert!(index + 8 >= 0 && index < MAX_PLY as isize + 16);
-        unsafe { self.data.get_unchecked_mut((index + 8) as usize) }
+        &mut self.data[(index + 8) as usize]
     }
 }

--- a/src/types/castling.rs
+++ b/src/types/castling.rs
@@ -29,13 +29,13 @@ impl<T> Index<CastlingKind> for [T] {
     type Output = T;
 
     fn index(&self, index: CastlingKind) -> &Self::Output {
-        unsafe { self.get_unchecked(index as usize) }
+        &self[index as usize]
     }
 }
 
 impl<T> IndexMut<CastlingKind> for [T] {
     fn index_mut(&mut self, index: CastlingKind) -> &mut Self::Output {
-        unsafe { self.get_unchecked_mut(index as usize) }
+        &mut self[index as usize]
     }
 }
 
@@ -91,6 +91,6 @@ impl<T> Index<Castling> for [T] {
     type Output = T;
 
     fn index(&self, index: Castling) -> &Self::Output {
-        unsafe { self.get_unchecked(index.raw as usize) }
+        &self[index.raw as usize]
     }
 }

--- a/src/types/color.rs
+++ b/src/types/color.rs
@@ -35,13 +35,13 @@ impl<T> Index<Color> for [T] {
     type Output = T;
 
     fn index(&self, index: Color) -> &Self::Output {
-        unsafe { self.get_unchecked(index as usize) }
+        &self[index as usize]
     }
 }
 
 impl<T> IndexMut<Color> for [T] {
     fn index_mut(&mut self, index: Color) -> &mut Self::Output {
-        unsafe { self.get_unchecked_mut(index as usize) }
+        &mut self[index as usize]
     }
 }
 

--- a/src/types/piece.rs
+++ b/src/types/piece.rs
@@ -122,13 +122,13 @@ impl<T> Index<Piece> for [T] {
     type Output = T;
 
     fn index(&self, index: Piece) -> &Self::Output {
-        unsafe { self.get_unchecked(index as usize) }
+        &self[index as usize]
     }
 }
 
 impl<T> IndexMut<Piece> for [T] {
     fn index_mut(&mut self, index: Piece) -> &mut Self::Output {
-        unsafe { self.get_unchecked_mut(index as usize) }
+        &mut self[index as usize]
     }
 }
 
@@ -167,12 +167,12 @@ impl<T> Index<PieceType> for [T] {
     type Output = T;
 
     fn index(&self, index: PieceType) -> &Self::Output {
-        unsafe { self.get_unchecked(index as usize) }
+        &self[index as usize]
     }
 }
 
 impl<T> IndexMut<PieceType> for [T] {
     fn index_mut(&mut self, index: PieceType) -> &mut Self::Output {
-        unsafe { self.get_unchecked_mut(index as usize) }
+        &mut self[index as usize]
     }
 }

--- a/src/types/square.rs
+++ b/src/types/square.rs
@@ -123,7 +123,7 @@ impl<T> Index<Square> for [T] {
     type Output = T;
 
     fn index(&self, square: Square) -> &Self::Output {
-        unsafe { self.get_unchecked(square as usize) }
+        &self[square as usize]
     }
 }
 


### PR DESCRIPTION
Elo   | 1.00 +- 1.78 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 36228 W: 9376 L: 9272 D: 17580
Penta | [155, 3805, 10094, 3901, 159]
https://recklesschess.space/test/13292/

Bench: 2798043
