### PR TITLE
Simplify is_legal

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -330,7 +330,7 @@ impl Board {
             | (king_attacks(square) & self.pieces(PieceType::King))
     }
 
-    pub fn is_legal2(&self, mv: Move) -> bool {
+    pub fn is_legal(&self, mv: Move) -> bool {
         debug_assert!(mv.is_present());
         let stm = self.side_to_move();
         let king = self.king_square(stm);
@@ -413,106 +413,6 @@ impl Board {
         return !mv.is_special()
             && (mv.is_capture() == self.colors(!stm).contains(to))
             && attacks(piece, from, self.occupancies()).contains(to);
-    }
-
-    /// Checks if the given move is legal in the current position.
-    pub fn is_legal(&self, mv: Move) -> bool {
-        debug_assert!(mv.is_present());
-
-        let stm = self.side_to_move();
-        let king = self.king_square(stm);
-
-        let from = mv.from();
-        let to = mv.to();
-
-        if self.in_check() && king != from {
-            if self.checkers().is_multiple() {
-                return false;
-            }
-
-            if !mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to) {
-                return false;
-            }
-        }
-
-        if self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to) {
-            return false;
-        }
-
-        let piece = self.piece_on(from);
-        let captured = self.piece_on(to).piece_type();
-
-        if mv.is_castling() {
-            if king != from {
-                return false;
-            }
-
-            let kind = match to {
-                Square::G1 => CastlingKind::WhiteKingside,
-                Square::C1 => CastlingKind::WhiteQueenside,
-                Square::G8 => CastlingKind::BlackKingside,
-                Square::C8 => CastlingKind::BlackQueenside,
-                _ => return false,
-            };
-
-            return self.castling().is_allowed(kind)
-                && (self.castling_path[kind] & self.occupancies()).is_empty()
-                && (self.castling_threat[kind] & self.all_threats()).is_empty()
-                && !self.pinned(stm).contains(self.castling_rooks[kind]);
-        }
-
-        if king == from && self.all_threats().contains(to) {
-            return false;
-        }
-
-        if !self.colors(stm).contains(from) || self.colors(stm).contains(to) {
-            return false;
-        }
-
-        if captured != PieceType::None && (!mv.is_capture() || captured == PieceType::King) {
-            return false;
-        }
-
-        if mv.is_capture() && !mv.is_en_passant() && !self.colors(!stm).contains(to) {
-            return false;
-        }
-
-        if piece.piece_type() == PieceType::Pawn {
-            if mv.is_en_passant() {
-                let occupancies = self.occupancies() ^ from.to_bb() ^ to.to_bb() ^ (to ^ 8).to_bb();
-                let diagonal = self.colored_pieces2(!stm, PieceType::Bishop, PieceType::Queen);
-                let orthogonal = self.colored_pieces2(!stm, PieceType::Rook, PieceType::Queen);
-                let diagonal = bishop_attacks(king, occupancies) & diagonal;
-                let orthogonal = rook_attacks(king, occupancies) & orthogonal;
-                return to == self.en_passant()
-                    && pawn_attacks(from, stm).contains(to)
-                    && (orthogonal | diagonal).is_empty();
-            }
-
-            let offset = Square::UP[stm];
-            let promotion_rank = if stm == Color::White { Rank::R8 } else { Rank::R1 };
-
-            if mv.is_promotion() != (mv.to().rank() == promotion_rank) {
-                return false;
-            }
-
-            if mv.is_capture() {
-                return pawn_attacks(from, stm).contains(to) && self.colors(!stm).contains(to);
-            }
-
-            if mv.is_double_push() {
-                return from.rank() == (if stm == Color::White { Rank::R2 } else { Rank::R7 })
-                    && from.shift(2 * offset) == to
-                    && !self.occupancies().contains(from.shift(offset))
-                    && !self.occupancies().contains(to);
-            }
-
-            return from.shift(offset) == to && !self.occupancies().contains(to);
-        } else if mv.is_double_push() || mv.is_promotion() || mv.is_en_passant() {
-            return false;
-        }
-
-        attacks(piece, from, self.occupancies()).contains(to)
     }
 
     /// Quickly checks if the move *might* give check to the opponent's king.

--- a/src/board.rs
+++ b/src/board.rs
@@ -359,25 +359,25 @@ impl Board {
                     && !self.pinned(stm).contains(self.castling_rooks[kind]);
             }
 
-            return !mv.is_special() && !self.colors(stm).contains(to) &&
-                (mv.is_capture() == self.colors(!stm).contains(to)) &&
-                (attacks(piece, from, Bitboard(0)) & !self.all_threats()).contains(to);
+            return !mv.is_special()
+                && !self.colors(stm).contains(to)
+                && (mv.is_capture() == self.colors(!stm).contains(to))
+                && (attacks(piece, from, Bitboard(0)) & !self.all_threats()).contains(to);
         }
 
-        if self.colors(stm).contains(to)
-            || (self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to)) {
+        if self.colors(stm).contains(to) || (self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to)) {
             return false;
         }
 
         if self.in_check() {
             if self.checkers().is_multiple()
-                || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to)) {
+                || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to))
+            {
                 return false;
             }
         }
 
         if piece.piece_type() == PieceType::Pawn {
-
             if mv.is_en_passant() {
                 let occupancies = self.occupancies() ^ from.to_bb() ^ to.to_bb() ^ (to ^ 8).to_bb();
                 let diagonal = self.colored_pieces2(!stm, PieceType::Bishop, PieceType::Queen);

--- a/src/board.rs
+++ b/src/board.rs
@@ -369,12 +369,11 @@ impl Board {
             return false;
         }
 
-        if self.in_check() {
-            if self.checkers().is_multiple()
-                || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to))
-            {
-                return false;
-            }
+        if self.in_check()
+            && (self.checkers().is_multiple()
+                || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to)))
+        {
+            return false;
         }
 
         if piece.piece_type() == PieceType::Pawn {
@@ -410,9 +409,9 @@ impl Board {
             return !mv.is_castling() && from.shift(offset) == to && !self.occupancies().contains(to);
         }
 
-        return !mv.is_special()
+        !mv.is_special()
             && (mv.is_capture() == self.colors(!stm).contains(to))
-            && attacks(piece, from, self.occupancies()).contains(to);
+            && attacks(piece, from, self.occupancies()).contains(to)
     }
 
     /// Quickly checks if the move *might* give check to the opponent's king.

--- a/src/board.rs
+++ b/src/board.rs
@@ -362,7 +362,7 @@ impl Board {
             return !mv.is_special()
                 && !self.colors(stm).contains(to)
                 && (mv.is_capture() == self.colors(!stm).contains(to))
-                && (attacks(piece, from, Bitboard(0)) & !self.all_threats()).contains(to);
+                && (king_attacks(from) & !self.all_threats()).contains(to);
         }
 
         if self.colors(stm).contains(to) || (self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to)) {

--- a/src/board.rs
+++ b/src/board.rs
@@ -330,6 +330,91 @@ impl Board {
             | (king_attacks(square) & self.pieces(PieceType::King))
     }
 
+    pub fn is_legal2(&self, mv: Move) -> bool {
+        debug_assert!(mv.is_present());
+        let stm = self.side_to_move();
+        let king = self.king_square(stm);
+        let from = mv.from();
+        let to = mv.to();
+
+        if !self.colors(stm).contains(from) {
+            return false;
+        }
+
+        let piece = self.piece_on(from);
+
+        if piece.piece_type() == PieceType::King {
+            if mv.is_castling() {
+                let kind = match to {
+                    Square::G1 => CastlingKind::WhiteKingside,
+                    Square::C1 => CastlingKind::WhiteQueenside,
+                    Square::G8 => CastlingKind::BlackKingside,
+                    Square::C8 => CastlingKind::BlackQueenside,
+                    _ => return false,
+                };
+
+                return self.castling().is_allowed(kind)
+                    && (self.castling_path[kind] & self.occupancies()).is_empty()
+                    && (self.castling_threat[kind] & self.all_threats()).is_empty()
+                    && !self.pinned(stm).contains(self.castling_rooks[kind]);
+            }
+
+            return !mv.is_special() && !self.colors(stm).contains(to) &&
+                (mv.is_capture() == self.colors(!stm).contains(to)) &&
+                (attacks(piece, from, Bitboard(0)) & !self.all_threats()).contains(to);
+        }
+
+        if self.colors(stm).contains(to)
+            || (self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to)) {
+            return false;
+        }
+
+        if self.in_check() {
+            if self.checkers().is_multiple()
+                || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to)) {
+                return false;
+            }
+        }
+
+        if piece.piece_type() == PieceType::Pawn {
+
+            if mv.is_en_passant() {
+                let occupancies = self.occupancies() ^ from.to_bb() ^ to.to_bb() ^ (to ^ 8).to_bb();
+                let diagonal = self.colored_pieces2(!stm, PieceType::Bishop, PieceType::Queen);
+                let orthogonal = self.colored_pieces2(!stm, PieceType::Rook, PieceType::Queen);
+                let diagonal = bishop_attacks(king, occupancies) & diagonal;
+                let orthogonal = rook_attacks(king, occupancies) & orthogonal;
+                return to == self.en_passant()
+                    && pawn_attacks(from, stm).contains(to)
+                    && (orthogonal | diagonal).is_empty();
+            }
+
+            let offset = Square::UP[stm];
+            let promotion_rank = if stm == Color::White { Rank::R8 } else { Rank::R1 };
+
+            if mv.is_promotion() != (mv.to().rank() == promotion_rank) {
+                return false;
+            }
+
+            if mv.is_capture() {
+                return pawn_attacks(from, stm).contains(to) && self.colors(!stm).contains(to);
+            }
+
+            if mv.is_double_push() {
+                return from.rank() == (if stm == Color::White { Rank::R2 } else { Rank::R7 })
+                    && from.shift(2 * offset) == to
+                    && !self.occupancies().contains(from.shift(offset))
+                    && !self.occupancies().contains(to);
+            }
+
+            return !mv.is_castling() && from.shift(offset) == to && !self.occupancies().contains(to);
+        }
+
+        return !mv.is_special()
+            && (mv.is_capture() == self.colors(!stm).contains(to))
+            && attacks(piece, from, self.occupancies()).contains(to);
+    }
+
     /// Checks if the given move is legal in the current position.
     pub fn is_legal(&self, mv: Move) -> bool {
         debug_assert!(mv.is_present());

--- a/src/board.rs
+++ b/src/board.rs
@@ -365,13 +365,11 @@ impl Board {
                 && (king_attacks(from) & !self.all_threats()).contains(to);
         }
 
-        if self.colors(stm).contains(to) || (self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to)) {
-            return false;
-        }
-
-        if self.in_check()
-            && (self.checkers().is_multiple()
-                || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to)))
+        if self.colors(stm).contains(to)
+            || (self.pinned(stm).contains(from) && !ray_pass(king, from).contains(to))
+            || (self.in_check()
+                && (self.checkers().is_multiple()
+                    || (!mv.is_en_passant() && !(self.checkers() | between(king, self.checkers().lsb())).contains(to))))
         {
             return false;
         }

--- a/src/tools/perft.rs
+++ b/src/tools/perft.rs
@@ -113,8 +113,23 @@ fn is_legal_movegen(board: &Board) -> MoveList {
         if j == 0b0011 || j == 0b0110 || j == 0b0111 {
             continue;
         }
+
         let mv: Move = unsafe { std::mem::transmute(i as u16) };
-        if mv.is_present() && board.is_legal(mv) {
+
+        if !mv.is_present() {
+            continue;
+        }
+
+        let b1 = board.is_legal(mv);
+        let b2 = board.is_legal2(mv);
+
+        if b1 != b2 {
+            println!("{}", board);
+            println!("Move: {}-{}, {}", mv.from(), mv.to(), mv.kind() as u16);
+            println!("main: {}, patch {}", b1, b2);
+        }
+
+        if board.is_legal2(mv) {
             moves.push(mv.from(), mv.to(), mv.kind());
         }
     }

--- a/src/tools/perft.rs
+++ b/src/tools/perft.rs
@@ -116,20 +116,7 @@ fn is_legal_movegen(board: &Board) -> MoveList {
 
         let mv: Move = unsafe { std::mem::transmute(i as u16) };
 
-        if !mv.is_present() {
-            continue;
-        }
-
-        let b1 = board.is_legal(mv);
-        let b2 = board.is_legal2(mv);
-
-        if b1 != b2 {
-            println!("{}", board);
-            println!("Move: {}-{}, {}", mv.from(), mv.to(), mv.kind() as u16);
-            println!("main: {}, patch {}", b1, b2);
-        }
-
-        if board.is_legal2(mv) {
+        if mv.is_present() && board.is_legal(mv) {
             moves.push(mv.from(), mv.to(), mv.kind());
         }
     }

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -82,6 +82,10 @@ impl Move {
         )
     }
 
+    pub const fn is_special(self) -> bool {
+        (self.kind() as u8 & 11) != 0
+    }
+
     pub const fn is_capture(self) -> bool {
         (self.0 >> 14) & 1 != 0
     }


### PR DESCRIPTION
STC
Elo   | 1.25 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 32216 W: 8168 L: 8052 D: 15996
Penta | [83, 3517, 8803, 3611, 94]
https://recklesschess.space/test/13337/

Also, dramatically faster islegalperft suggests 50% speed increase (for is_legal).

bench 2718318