### PR TITLE
Remove the TT move only if no new best move is found

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -657,6 +657,7 @@ fn search<NODE: NodeType>(
         let singular_depth = (depth - 1) / 2;
 
         td.stack[ply].excluded = tt_move;
+        td.stack[ply].mv = Move::NULL;
         singular_score = search::<NonPV>(td, singular_beta - 1, singular_beta, singular_depth, cut_node, ply);
         td.stack[ply].excluded = Move::NULL;
 
@@ -677,11 +678,11 @@ fn search<NODE: NodeType>(
         // Multi-Cut
         else if singular_score >= beta && !is_decisive(singular_score) {
             return (2 * singular_score + beta) / 3;
+        } else if singular_score > tt_score && td.stack[ply].mv != Move::NULL {
+            tt_move = Move::NULL;
         }
         // Negative Extensions
-        else if singular_score > tt_score {
-            tt_move = Move::NULL;
-        } else if tt_score >= beta {
+        else if tt_score >= beta {
             extension = -2;
         } else if cut_node {
             extension = -2;


### PR DESCRIPTION
STC:
```
Elo   | 2.81 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27402 W: 7064 L: 6842 D: 13496
Penta | [50, 2788, 7805, 3006, 52]
```
https://recklesschess.space/test/13340/

LTC:
```
Elo   | 1.55 +- 1.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 62364 W: 15600 L: 15322 D: 31442
Penta | [29, 6113, 18625, 6381, 34]
```
https://recklesschess.space/test/13345/

Bench 2864276