### PR TITLE
simplify is_legal

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -3,7 +3,9 @@ use crate::{
         attacks, between, bishop_attacks, cuckoo, cuckoo_a, cuckoo_b, h1, h2, king_attacks, knight_attacks,
         pawn_attacks, pawn_attacks_setwise, queen_attacks, ray_pass, rook_attacks,
     },
-    types::{Bitboard, Castling, CastlingKind, Color, Move, Piece, PieceType, PAWN_HOME_RANK, PROMO_RANK, Square, ZOBRIST},
+    types::{
+        Bitboard, Castling, CastlingKind, Color, Move, PAWN_HOME_RANK, PROMO_RANK, Piece, PieceType, Square, ZOBRIST,
+    },
 };
 
 #[cfg(test)]

--- a/src/board.rs
+++ b/src/board.rs
@@ -3,7 +3,7 @@ use crate::{
         attacks, between, bishop_attacks, cuckoo, cuckoo_a, cuckoo_b, h1, h2, king_attacks, knight_attacks,
         pawn_attacks, pawn_attacks_setwise, queen_attacks, ray_pass, rook_attacks,
     },
-    types::{Bitboard, Castling, CastlingKind, Color, Move, Piece, PieceType, Rank, Square, ZOBRIST},
+    types::{Bitboard, Castling, CastlingKind, Color, Move, Piece, PieceType, PAWN_HOME_RANK, PROMO_RANK, Square, ZOBRIST},
 };
 
 #[cfg(test)]
@@ -386,10 +386,7 @@ impl Board {
                     && (orthogonal | diagonal).is_empty();
             }
 
-            let offset = Square::UP[stm];
-            let promotion_rank = if stm == Color::White { Rank::R8 } else { Rank::R1 };
-
-            if mv.is_promotion() != (mv.to().rank() == promotion_rank) {
+            if mv.is_promotion() != (mv.to().rank() == PROMO_RANK[stm]) {
                 return false;
             }
 
@@ -398,13 +395,13 @@ impl Board {
             }
 
             if mv.is_double_push() {
-                return from.rank() == (if stm == Color::White { Rank::R2 } else { Rank::R7 })
-                    && from.shift(2 * offset) == to
-                    && !self.occupancies().contains(from.shift(offset))
+                return from.rank() == PAWN_HOME_RANK[stm]
+                    && from.shift(2 * Square::UP[stm]) == to
+                    && !self.occupancies().contains(from.shift(Square::UP[stm]))
                     && !self.occupancies().contains(to);
             }
 
-            return !mv.is_castling() && from.shift(offset) == to && !self.occupancies().contains(to);
+            return !mv.is_castling() && from.shift(Square::UP[stm]) == to && !self.occupancies().contains(to);
         }
 
         !mv.is_special()

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -33,6 +33,9 @@ pub const MAX_MOVES: usize = 256;
 #[derive(PartialEq, PartialOrd)]
 pub enum Rank { R1, R2, R3, R4, R5, R6, R7, R8 }
 
+pub const PROMO_RANK: [Rank; 2] = [Rank::R8, Rank::R1];
+pub const PAWN_HOME_RANK: [Rank; 2] = [Rank::R2, Rank::R7];
+
 #[rustfmt::skip]
 #[repr(u8)]
 #[derive(PartialEq, PartialOrd)]


### PR DESCRIPTION
I'm pretty sure these const arrays are much better than the branching in is_legal.

STC
Elo   | 1.20 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.07 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 33324 W: 8394 L: 8279 D: 16651
Penta | [82, 3595, 9185, 3726, 74]
https://recklesschess.space/test/13362/

bench 2701511