### PR TITLE
Simplify promo piece types to remove redundant check for is_promotion

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -111,7 +111,7 @@ impl Board {
                 self.update_hash(rook, rook_to);
             }
             _ if mv.is_promotion() => {
-                let promotion = Piece::new(stm, mv.promotion_piece().unwrap());
+                let promotion = Piece::new(stm, mv.promotion_piece());
 
                 self.remove_piece(piece, to);
                 self.add_piece(promotion, to);

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -111,7 +111,7 @@ impl Board {
                 self.update_hash(rook, rook_to);
             }
             _ if mv.is_promotion() => {
-                let promotion = Piece::new(stm, mv.promotion_piece());
+                let promotion = Piece::new(stm, mv.promo_piece_type());
 
                 self.remove_piece(piece, to);
                 self.add_piece(promotion, to);

--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -23,8 +23,8 @@ impl super::Board {
         // In the worst case, we lose a piece, but still end up with a non-negative balance
         balance -= self.piece_on(mv.from()).value();
 
-        if let Some(promotion) = mv.promotion_piece() {
-            balance -= promotion.value();
+        if mv.is_promotion() {
+            balance -= mv.promotion_piece().value();
         }
 
         if balance >= 0 {
@@ -98,12 +98,21 @@ impl super::Board {
         }
 
         let capture = self.piece_on(mv.to()).piece_type();
+        let mut value = capture.value();
 
-        if let Some(promotion) = mv.promotion_piece() {
-            capture.value() + promotion.value() - PieceType::Pawn.value()
-        } else {
-            capture.value()
+        if mv.is_promotion() {
+            value += mv.promotion_piece().value() - PieceType::Pawn.value()
         }
+
+        value
+
+        //capture.value() + mv.is_promotion() as i32 * (mv.promotion_piece().value() - PieceType::Pawn.value())
+
+        //if let Some(promotion) = mv.promotion_piece() {
+            //capture.value() + promotion.value() - PieceType::Pawn.value()
+        //} else {
+            //capture.value()
+        //}
     }
 
     fn least_valuable_attacker(&self, attackers: Bitboard) -> PieceType {

--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -24,7 +24,7 @@ impl super::Board {
         balance -= self.piece_on(mv.from()).value();
 
         if mv.is_promotion() {
-            balance -= mv.promotion_piece().value();
+            balance -= mv.promo_piece_type().value();
         }
 
         if balance >= 0 {
@@ -101,18 +101,9 @@ impl super::Board {
         let mut value = capture.value();
 
         if mv.is_promotion() {
-            value += mv.promotion_piece().value() - PieceType::Pawn.value()
+            value += mv.promo_piece_type().value() - PieceType::Pawn.value()
         }
-
         value
-
-        //capture.value() + mv.is_promotion() as i32 * (mv.promotion_piece().value() - PieceType::Pawn.value())
-
-        //if let Some(promotion) = mv.promotion_piece() {
-            //capture.value() + promotion.value() - PieceType::Pawn.value()
-        //} else {
-            //capture.value()
-        //}
     }
 
     fn least_valuable_attacker(&self, attackers: Bitboard) -> PieceType {

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -171,7 +171,7 @@ impl MovePicker {
                 entry.score =
                     16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
 
-                if mv.is_promotion() && mv.promotion_piece() == PieceType::Queen {
+                if mv.is_promotion() && mv.promo_piece_type() == PieceType::Queen {
                     entry.score += 4000;
                 }
             }

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -171,7 +171,7 @@ impl MovePicker {
                 entry.score =
                     16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
 
-                if mv.is_promotion() && mv.promotion_piece() == Some(PieceType::Queen) {
+                if mv.is_promotion() && mv.promotion_piece() == PieceType::Queen {
                     entry.score += 4000;
                 }
             }

--- a/src/nnue/accumulator/psq.rs
+++ b/src/nnue/accumulator/psq.rs
@@ -105,8 +105,7 @@ impl PstAccumulator {
     pub fn update(&mut self, prev: &Self, board: &Board, king: Square, pov: Color) {
         let PstDelta { mv, piece, captured } = self.delta;
 
-        let resulting_piece = if mv.is_promotion() { mv.promo_piece_type() }
-            else { piece.piece_type() };
+        let resulting_piece = if mv.is_promotion() { mv.promo_piece_type() } else { piece.piece_type() };
 
         let add1 = pst_index(piece.piece_color(), resulting_piece, mv.to(), king, pov);
         let sub1 = pst_index(piece.piece_color(), piece.piece_type(), mv.from(), king, pov);

--- a/src/nnue/accumulator/psq.rs
+++ b/src/nnue/accumulator/psq.rs
@@ -105,7 +105,8 @@ impl PstAccumulator {
     pub fn update(&mut self, prev: &Self, board: &Board, king: Square, pov: Color) {
         let PstDelta { mv, piece, captured } = self.delta;
 
-        let resulting_piece = mv.promotion_piece().unwrap_or_else(|| piece.piece_type());
+        let resulting_piece = if mv.is_promotion() { mv.promotion_piece() }
+            else { piece.piece_type() };
 
         let add1 = pst_index(piece.piece_color(), resulting_piece, mv.to(), king, pov);
         let sub1 = pst_index(piece.piece_color(), piece.piece_type(), mv.from(), king, pov);

--- a/src/nnue/accumulator/psq.rs
+++ b/src/nnue/accumulator/psq.rs
@@ -105,7 +105,7 @@ impl PstAccumulator {
     pub fn update(&mut self, prev: &Self, board: &Board, king: Square, pov: Color) {
         let PstDelta { mv, piece, captured } = self.delta;
 
-        let resulting_piece = if mv.is_promotion() { mv.promotion_piece() }
+        let resulting_piece = if mv.is_promotion() { mv.promo_piece_type() }
             else { piece.piece_type() };
 
         let add1 = pst_index(piece.piece_color(), resulting_piece, mv.to(), king, pov);

--- a/src/tb.rs
+++ b/src/tb.rs
@@ -80,7 +80,7 @@ fn reckless_move_to_tb_move(mv: Move) -> TbMove {
     let mut tb_move: TbMove = (from << 6) | to;
 
     if mv.is_promotion() {
-        let promotion_bits = promo_bits_from_piece(mv.promotion_piece()) & 0x7;
+        let promotion_bits = promo_bits_from_piece(mv.promo_piece_type()) & 0x7;
         tb_move |= promotion_bits << 12;
     }
 

--- a/src/tb.rs
+++ b/src/tb.rs
@@ -79,8 +79,8 @@ fn reckless_move_to_tb_move(mv: Move) -> TbMove {
 
     let mut tb_move: TbMove = (from << 6) | to;
 
-    if let Some(pt) = mv.promotion_piece() {
-        let promotion_bits = promo_bits_from_piece(pt) & 0x7;
+    if mv.is_promotion() {
+        let promotion_bits = promo_bits_from_piece(mv.promotion_piece()) & 0x7;
         tb_move |= promotion_bits << 12;
     }
 

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -106,7 +106,7 @@ impl Move {
         matches!(self.kind(), MoveKind::DoublePush)
     }
 
-    pub const fn promotion_piece(self) -> PieceType {
+    pub const fn promo_piece_type(self) -> PieceType {
         debug_assert!(self.is_promotion());
         PieceType::new(((self.kind() as usize) & 3) + PieceType::Knight as usize)
     }
@@ -122,7 +122,7 @@ impl Move {
         let mut output = format!("{}{}", self.from(), self.to());
 
         if self.is_promotion() {
-            match self.promotion_piece() {
+            match self.promo_piece_type() {
                 PieceType::Knight => output.push('n'),
                 PieceType::Bishop => output.push('b'),
                 PieceType::Rook => output.push('r'),

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -106,11 +106,9 @@ impl Move {
         matches!(self.kind(), MoveKind::DoublePush)
     }
 
-    pub const fn promotion_piece(self) -> Option<PieceType> {
-        if self.is_promotion() {
-            return Some(PieceType::new(((self.kind() as usize) & 3) + PieceType::Knight as usize));
-        }
-        None
+    pub const fn promotion_piece(self) -> PieceType {
+        debug_assert!(self.is_promotion());
+        PieceType::new(((self.kind() as usize) & 3) + PieceType::Knight as usize)
     }
 
     pub fn to_uci(self, board: &Board) -> String {
@@ -125,10 +123,10 @@ impl Move {
 
         if self.is_promotion() {
             match self.promotion_piece() {
-                Some(PieceType::Knight) => output.push('n'),
-                Some(PieceType::Bishop) => output.push('b'),
-                Some(PieceType::Rook) => output.push('r'),
-                Some(PieceType::Queen) => output.push('q'),
+                PieceType::Knight => output.push('n'),
+                PieceType::Bishop => output.push('b'),
+                PieceType::Rook => output.push('r'),
+                PieceType::Queen => output.push('q'),
                 _ => (),
             }
         }


### PR DESCRIPTION
STC
Elo   | 1.67 +- 2.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 25954 W: 6717 L: 6592 D: 12645
Penta | [95, 2823, 7024, 2932, 103]
https://recklesschess.space/test/13365/