### PR TITLE
Remove noclippy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
-#![deny(clippy::large_types_passed_by_value)]
-#![deny(clippy::trivially_copy_pass_by_ref)]
-#![deny(clippy::redundant_clone)]
+#![warn(clippy::large_types_passed_by_value)]
+#![warn(clippy::trivially_copy_pass_by_ref)]
+#![warn(clippy::redundant_clone)]
 
 mod board;
 mod evaluation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-#![allow(clippy::manual_is_multiple_of)]
-#![allow(clippy::if_same_then_else)]
 #![allow(unsafe_op_in_unsafe_fn)]
+#![deny(clippy::large_types_passed_by_value)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
+#![deny(clippy::redundant_clone)]
 
 mod board;
 mod evaluation;

--- a/src/nnue/accumulator/psq.rs
+++ b/src/nnue/accumulator/psq.rs
@@ -197,7 +197,7 @@ impl PstAccumulator {
 }
 
 const REGISTERS: usize = 8;
-const _: () = assert!(L1_SIZE % (REGISTERS * simd::I16_LANES) == 0);
+const _: () = assert!(L1_SIZE.is_multiple_of(REGISTERS * simd::I16_LANES));
 
 unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<PstFeature, 64>, subs: ArrayVec<PstFeature, 64>) {
     let mut registers: [_; REGISTERS] = std::mem::zeroed();

--- a/src/search.rs
+++ b/src/search.rs
@@ -682,9 +682,7 @@ fn search<NODE: NodeType>(
             tt_move = Move::NULL;
         }
         // Negative Extensions
-        else if tt_score >= beta {
-            extension = -2;
-        } else if cut_node {
+        else if tt_score >= beta || cut_node {
             extension = -2;
         }
     }


### PR DESCRIPTION
remove exclusion of clippy warnings (manual_is_multiple_of, if_same_then_else) fix them
add some warnings for (large_types_passed_by_value, trivially_copy_pass_by_ref, redundant_clone)