### PR TITLE
Add more to the uci eval command output

### DIFF
--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -77,7 +77,7 @@ const INPUT_BUCKETS_LAYOUT: [u8; 64] = [
 ];
 
 #[rustfmt::skip]
-const OUTPUT_BUCKETS_LAYOUT: [usize; 33] = [
+pub const OUTPUT_BUCKETS_LAYOUT: [usize; 33] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0,
     1, 1, 1, 1,
     2, 2, 2, 2,
@@ -232,6 +232,42 @@ impl Network {
 
             (l3_out * NETWORK_SCALE as f32) as i32
         }
+    }
+
+    pub fn eval_with_bucket(&mut self, board: &Board, bucket: usize) -> i32 {
+        self.full_refresh(board);
+        self.evaluate(board); // just to update internal state
+
+        unsafe {
+            let ft_out =
+                forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
+            let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
+            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket);
+            let l2_out = forward::propagate_l2(l1_out, bucket);
+            let l3_out = forward::propagate_l3(l2_out, bucket);
+            (l3_out * NETWORK_SCALE as f32) as i32
+        }
+    }
+
+    pub fn piece_contribution(&mut self, board: &Board, sq: Square) -> Option<i32> {
+        let piece = board.piece_on(sq);
+
+        if piece == Piece::None || piece.piece_type() == PieceType::King {
+            return None;
+        }
+
+        let baseline = self.evaluate(board);
+
+        let mut board_without = board.clone();
+        board_without.remove_piece(piece, sq);
+
+        self.full_refresh(&board_without);
+        let without = self.evaluate(&board_without);
+
+        self.full_refresh(board);
+        self.evaluate(board);
+
+        Some(baseline - without)
     }
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -334,7 +334,7 @@ fn eval(td: &mut ThreadData) {
 
     let side = td.board.side_to_move();
 
-    println!(" NNUE derived piece values:");
+    println!("NNUE derived piece values");
     println!("+-------+-------+-------+-------+-------+-------+-------+-------+");
     for rank in (0..8).rev() {
         print!("|");
@@ -363,7 +363,7 @@ fn eval(td: &mut ThreadData) {
 
     let used_bucket = crate::nnue::OUTPUT_BUCKETS_LAYOUT[td.board.occupancies().popcount()];
 
-    println!("\n NNUE network contributions (White side)");
+    println!("\nNNUE output buckets (White side)");
     println!("+------------+------------+");
     println!("|   Bucket   |   Total    |");
     println!("+------------+------------+");

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -10,7 +10,7 @@ use crate::{
     time::{Limits, TimeManager},
     tools,
     transposition::DEFAULT_TT_SIZE,
-    types::{Color, MAX_MOVES, Move, Score, is_decisive, is_loss, is_win},
+    types::{Color, MAX_MOVES, Move, Piece, Score, Square, is_decisive, is_loss, is_win},
 };
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -330,11 +330,60 @@ fn set_option(threads: &mut ThreadPool, settings: &mut Settings, shared: &Arc<Sh
 
 fn eval(td: &mut ThreadData) {
     td.nnue.full_refresh(&td.board);
-    let eval = match td.board.side_to_move() {
-        Color::White => td.nnue.evaluate(&td.board),
-        Color::Black => -td.nnue.evaluate(&td.board),
-    };
-    println!("{eval}");
+    td.nnue.evaluate(&td.board);
+
+    let side = td.board.side_to_move();
+
+    println!(" NNUE derived piece values:");
+    println!("+-------+-------+-------+-------+-------+-------+-------+-------+");
+    for rank in (0..8).rev() {
+        print!("|");
+        for file in 0..8 {
+            let sq = Square::from_rank_file(rank, file);
+            let piece = td.board.piece_on(sq);
+            let piece_str = if piece == Piece::None { " ".to_string() } else { piece.to_string() };
+            print!("  {:^3}  |", piece_str);
+        }
+        println!();
+
+        print!("|");
+        for file in 0..8 {
+            let sq = Square::from_rank_file(rank, file);
+            match td.nnue.piece_contribution(&td.board, sq) {
+                None => print!("       |"),
+                Some(v) => {
+                    let val = v as f32 / 100.0;
+                    print!("{:+6.2} |", val);
+                }
+            }
+        }
+        println!();
+        println!("+-------+-------+-------+-------+-------+-------+-------+-------+");
+    }
+
+    let used_bucket = crate::nnue::OUTPUT_BUCKETS_LAYOUT[td.board.occupancies().popcount()];
+
+    println!("\n NNUE network contributions (White side)");
+    println!("+------------+------------+");
+    println!("|   Bucket   |   Total    |");
+    println!("+------------+------------+");
+
+    for bucket in 0..8 {
+        let raw_score = td.nnue.eval_with_bucket(&td.board, bucket);
+        let white_score = if side == Color::White { raw_score } else { -raw_score };
+        let total = white_score as f32 / 100.0;
+
+        if bucket == used_bucket {
+            println!("|  {:<2}        | {:+7.2}    | <-- this bucket is used", bucket, total);
+        } else {
+            println!("|  {:<2}        | {:+7.2}    |", bucket, total);
+        }
+    }
+    println!("+------------+------------+");
+
+    let final_eval = td.nnue.evaluate(&td.board);
+    let final_total = (if side == Color::White { final_eval } else { -final_eval }) as f32 / 100.0;
+    println!("\nNNUE evaluation        {:+.2} (White side)", final_total);
 }
 
 fn parse_limits(color: Color, tokens: &[&str]) -> Limits {


### PR DESCRIPTION
Previously only the nnue evaluation was printed

With this PR something like this should come
```bash
$ ./target/release/reckless
eval
 NNUE derived piece values:
+-------+-------+-------+-------+-------+-------+-------+-------+
|   r   |   n   |   b   |   q   |   k   |   b   |   n   |   r   |
|-12.68 |-12.77 |-12.71 |-16.47 |       |-13.02 |-12.44 |-12.09 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   p   |   p   |   p   |   p   |   p   |   p   |   p   |   p   |
| -2.62 | -3.95 | -4.28 | -5.88 | -5.50 | -5.56 | -5.14 | -2.96 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |       |       |       |       |       |       |
|       |       |       |       |       |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   P   |   P   |   P   |   P   |   P   |   P   |   P   |   P   |
| +2.74 | +4.03 | +4.28 | +5.71 | +5.60 | +5.37 | +5.06 | +3.15 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   R   |   N   |   B   |   Q   |   K   |   B   |   N   |   R   |
|+10.06 |+10.17 |+10.40 |+14.83 |       |+10.51 |+10.05 | +9.83 |
+-------+-------+-------+-------+-------+-------+-------+-------+

 NNUE network contributions (White side)
+------------+------------+
|   Bucket   |   Total    |
+------------+------------+
|  0         |   +2.20    |
|  1         |   +0.50    |
|  2         |   +2.21    |
|  3         |   +1.37    |
|  4         |   +1.18    |
|  5         |   +0.98    |
|  6         |   +0.92    |
|  7         |   +0.94    | <-- this bucket is used
+------------+------------+

NNUE evaluation        +0.94 (white side)
```

For the first table the values are calculated like so:
1. Full NNUE forward pass on the current position.
2. Remove the piece and create a copy of the board without that piece.
3. Run another full forward pass on the modified board.
4. Contribution = baseline - without.

For the second table:
1. For each bucket (0-7) run the forward pass using the buckets weights
2. Add an arrow to show which bucket is used