### PR TITLE
Use lsb and msb to simplify rook from squares.

### DIFF
--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -69,38 +69,22 @@ impl Board {
         for right in rights.chars() {
             match right {
                 'K' => {
-                    let mut rook_from = Square::H1;
-                    while self.piece_on(rook_from).piece_type() != PieceType::Rook {
-                        rook_from = rook_from.shift(-1);
-                    }
-
+                    let rook_from = self.colored_pieces(Color::White, PieceType::Rook).msb();
                     let king_from = self.king_square(Color::White);
                     self.set_castling_for(CastlingKind::WhiteKingside, king_from, Square::G1, rook_from, Square::F1);
                 }
                 'Q' => {
-                    let mut rook_from = Square::A1;
-                    while self.piece_on(rook_from).piece_type() != PieceType::Rook {
-                        rook_from = rook_from.shift(1);
-                    }
-
+                    let rook_from = self.colored_pieces(Color::White, PieceType::Rook).lsb();
                     let king_from = self.king_square(Color::White);
                     self.set_castling_for(CastlingKind::WhiteQueenside, king_from, Square::C1, rook_from, Square::D1);
                 }
                 'k' => {
-                    let mut rook_from = Square::H8;
-                    while self.piece_on(rook_from).piece_type() != PieceType::Rook {
-                        rook_from = rook_from.shift(-1);
-                    }
-
+                    let rook_from = self.colored_pieces(Color::Black, PieceType::Rook).msb();
                     let king_from = self.king_square(Color::Black);
                     self.set_castling_for(CastlingKind::BlackKingside, king_from, Square::G8, rook_from, Square::F8);
                 }
                 'q' => {
-                    let mut rook_from = Square::A8;
-                    while self.piece_on(rook_from).piece_type() != PieceType::Rook {
-                        rook_from = rook_from.shift(1);
-                    }
-
+                    let rook_from = self.colored_pieces(Color::Black, PieceType::Rook).lsb();
                     let king_from = self.king_square(Color::Black);
                     self.set_castling_for(CastlingKind::BlackQueenside, king_from, Square::C8, rook_from, Square::D8);
                 }

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -45,6 +45,10 @@ impl Bitboard {
         Square::new(self.0.trailing_zeros() as u8)
     }
 
+    pub const fn msb(self) -> Square {
+        Square::new(63 - self.0.leading_zeros() as u8)
+    }
+
     pub const fn shift(self, offset: i8) -> Self {
         if offset > 0 { Self(self.0 << offset) } else { Self(self.0 >> -offset) }
     }


### PR DESCRIPTION
bench 2864276

Not tested.

What do we want the behavior to be if castling rights are specified, but there is no rook?