### PR TITLE
Correct value for capture of promoted piece in SEE

### DIFF
--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -21,11 +21,7 @@ impl super::Board {
         }
 
         // In the worst case, we lose a piece, but still end up with a non-negative balance
-        balance -= self.piece_on(mv.from()).value();
-
-        if mv.is_promotion() {
-            balance -= mv.promo_piece_type().value();
-        }
+        balance -= if mv.is_promotion() { mv.promo_piece_type().value() } else { self.piece_on(mv.from()).value() };
 
         if balance >= 0 {
             return true;


### PR DESCRIPTION
STC
Elo   | 0.16 +- 1.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 75746 W: 19117 L: 19083 D: 37546
Penta | [175, 8595, 20309, 8609, 185]
https://recklesschess.space/test/13471/

LTC
Elo   | 0.26 +- 1.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 66422 W: 16391 L: 16342 D: 33689
Penta | [20, 7364, 18402, 7397, 28]
https://recklesschess.space/test/13484/

Bench: 3135368