### PR TITLE
Prevent razoring if TTbound is lower

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -512,6 +512,7 @@ fn search<NODE: NodeType>(
         && estimated_score < alpha - 295 - 261 * depth * depth
         && alpha < 2048
         && !tt_move.is_quiet()
+        && tt_bound != Bound::Lower
     {
         return qsearch::<NonPV>(td, alpha, beta, ply);
     }


### PR DESCRIPTION
Elo   | 1.10 +- 0.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 3.00]
Games | N: 186484 W: 47073 L: 46484 D: 92927
Penta | [496, 21664, 48379, 22161, 542]
https://recklesschess.space/test/13462/

Elo   | 1.85 +- 1.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 49370 W: 12321 L: 12058 D: 24991
Penta | [8, 5428, 13556, 5679, 14]
https://recklesschess.space/test/13468/

Bench: 3496372