### PR TITLE
Simplify minor correction history away

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -24,7 +24,6 @@ mod see;
 struct InternalState {
     key: u64,
     pawn_key: u64,
-    minor_key: u64,
     non_pawn_keys: [u64; Color::NUM],
     en_passant: Square,
     castling: Castling,
@@ -84,10 +83,6 @@ impl Board {
 
     pub const fn pawn_key(&self) -> u64 {
         self.state.pawn_key
-    }
-
-    pub const fn minor_key(&self) -> u64 {
-        self.state.minor_key
     }
 
     pub const fn non_pawn_key(&self, color: Color) -> u64 {
@@ -228,10 +223,6 @@ impl Board {
             self.state.pawn_key ^= key;
         } else {
             self.state.non_pawn_keys[piece.piece_color()] ^= key;
-
-            if [PieceType::Knight, PieceType::Bishop, PieceType::King].contains(&piece.piece_type()) {
-                self.state.minor_key ^= key;
-            }
         }
     }
 
@@ -510,7 +501,6 @@ impl Board {
     pub fn update_hash_keys(&mut self) {
         self.state.key = 0;
         self.state.pawn_key = 0;
-        self.state.minor_key = 0;
         self.state.non_pawn_keys = [0; Color::NUM];
 
         for piece in 0..Piece::NUM {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1313,7 +1313,6 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
     let corrhist = td.corrhist();
 
     (corrhist.pawn.get(stm, td.board.pawn_key())
-        + corrhist.minor.get(stm, td.board.minor_key())
         + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
         + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
         + td.continuation_corrhist.get(
@@ -1335,7 +1334,6 @@ fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: 
     let bonus = (142 * depth * diff / 128).clamp(-4771, 3001);
 
     corrhist.pawn.update(stm, td.board.pawn_key(), bonus);
-    corrhist.minor.update(stm, td.board.minor_key(), bonus);
 
     corrhist.non_pawn[Color::White].update(stm, td.board.non_pawn_key(Color::White), bonus);
     corrhist.non_pawn[Color::Black].update(stm, td.board.non_pawn_key(Color::Black), bonus);

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -89,7 +89,6 @@ impl Default for Status {
 #[derive(Default)]
 pub struct SharedCorrectionHistory {
     pub pawn: CorrectionHistory,
-    pub minor: CorrectionHistory,
     pub non_pawn: [CorrectionHistory; 2],
 }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -176,7 +176,6 @@ fn reset(threads: &mut ThreadPool, shared: &Arc<SharedContext>) {
 
     for corrhist in unsafe { shared.replicator.get_all() } {
         corrhist.pawn.clear();
-        corrhist.minor.clear();
         corrhist.non_pawn[Color::White].clear();
         corrhist.non_pawn[Color::Black].clear();
     }


### PR DESCRIPTION
STC
Elo   | 2.24 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 20930 W: 5274 L: 5139 D: 10517
Penta | [54, 2432, 5368, 2547, 64]
https://recklesschess.space/test/13513/

LTC
Elo   | 0.05 +- 1.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 87334 W: 21706 L: 21693 D: 43935
Penta | [37, 9783, 24004, 9816, 27]
https://recklesschess.space/test/13514/

Bench: 2934206