### PR TITLE
Add local x86_64 SIMD compile checks

### DIFF
--- a/.github/workflows/architectures.yml
+++ b/.github/workflows/architectures.yml
@@ -19,41 +19,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64 scalar
           - name: linux-generic
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            config: target.x86_64-unknown-linux-gnu.rustflags=["-C","target-cpu=x86-64"]
-          # Linux x86_64 with AVX2
+            config: target.x86_64-unknown-linux-gnu.rustflags=["-C", "target-cpu=x86-64"]
+
           - name: linux-avx2
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            config: target.x86_64-unknown-linux-gnu.rustflags=["-C","target-cpu=x86-64-v3"]
-          # Linux x86_64 with AVX512
+            config: target.x86_64-unknown-linux-gnu.rustflags=["-C", "target-cpu=x86-64-v3"]
+
           - name: linux-avx512
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            config: target.x86_64-unknown-linux-gnu.rustflags=["-C","target-cpu=x86-64-v4","-C","target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg"]
-          # Windows x86_64 scalar
+            config: target.x86_64-unknown-linux-gnu.rustflags=["-C", "target-cpu=x86-64-v4", "-C", "target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg"]
+
           - name: windows-generic
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            config: target.x86_64-pc-windows-msvc.rustflags=["-C","target-cpu=x86-64"]
-          # Windows x86_64 with AVX2
+            config: target.x86_64-pc-windows-msvc.rustflags=["-C", "target-cpu=x86-64"]
+
           - name: windows-avx2
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            config: target.x86_64-pc-windows-msvc.rustflags=["-C","target-cpu=x86-64-v3"]
-          # Windows x86_64 with AVX512
+            config: target.x86_64-pc-windows-msvc.rustflags=["-C", "target-cpu=x86-64-v3"]
+
           - name: windows-avx512
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            config: target.x86_64-pc-windows-msvc.rustflags=["-C","target-cpu=x86-64-v4","-C","target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg"]
-          # macOS arm64 with NEON
+            config: target.x86_64-pc-windows-msvc.rustflags=["-C", "target-cpu=x86-64-v4", "-C", "target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg"]
+
           - name: macos
             os: macos-latest
             target: ""
-            config: build.rustflags=["-C","target-cpu=native"]
+            config: build.rustflags=["-C", "target-cpu=native"]
 
     name: ${{ matrix.name }}
 
@@ -63,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build supported architecture
+      - name: Check supported architecture
         shell: bash
         run: |
           if [ -n "${TARGET}" ]; then

--- a/.github/workflows/architectures.yml
+++ b/.github/workflows/architectures.yml
@@ -1,0 +1,76 @@
+name: Supported Architectures
+
+on:
+  push:
+    branches:
+      - main
+      - tournaments
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  supported-architectures:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64 scalar
+          - name: linux-generic
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            config: target.x86_64-unknown-linux-gnu.rustflags=["-C","target-cpu=x86-64"]
+          # Linux x86_64 with AVX2
+          - name: linux-avx2
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            config: target.x86_64-unknown-linux-gnu.rustflags=["-C","target-cpu=x86-64-v3"]
+          # Linux x86_64 with AVX512
+          - name: linux-avx512
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            config: target.x86_64-unknown-linux-gnu.rustflags=["-C","target-cpu=x86-64-v4","-C","target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg"]
+          # Windows x86_64 scalar
+          - name: windows-generic
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            config: target.x86_64-pc-windows-msvc.rustflags=["-C","target-cpu=x86-64"]
+          # Windows x86_64 with AVX2
+          - name: windows-avx2
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            config: target.x86_64-pc-windows-msvc.rustflags=["-C","target-cpu=x86-64-v3"]
+          # Windows x86_64 with AVX512
+          - name: windows-avx512
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            config: target.x86_64-pc-windows-msvc.rustflags=["-C","target-cpu=x86-64-v4","-C","target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg"]
+          # macOS arm64 with NEON
+          - name: macos
+            os: macos-latest
+            target: ""
+            config: build.rustflags=["-C","target-cpu=native"]
+
+    name: ${{ matrix.name }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build supported architecture
+        shell: bash
+        run: |
+          if [ -n "${TARGET}" ]; then
+            cargo check --verbose --target "${TARGET}" --config "${CONFIG}" --no-default-features
+          else
+            cargo check --verbose --config "${CONFIG}" --no-default-features
+          fi
+        env:
+          TARGET: ${{ matrix.target }}
+          CONFIG: ${{ matrix.config }}

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ endif
 rule:
 	cargo rustc --release -- -C target-cpu=native --emit link=$(NAME)
 
+x64-check:
+	RUSTFLAGS="-C target-cpu=x86-64" cargo check --target x86_64-unknown-linux-gnu --no-default-features
+	RUSTFLAGS="-C target-cpu=x86-64-v3" cargo check --target x86_64-unknown-linux-gnu --no-default-features
+	RUSTFLAGS="-C target-cpu=x86-64-v4 -C target-feature=+gfni,+avx512bw,+avx512vl,+avx512vbmi,+avx512vbmi2,+avx512vnni,+avx512bitalg" cargo check --target x86_64-unknown-linux-gnu --no-default-features
+
 pgo:
 	cargo pgo instrument
 	cargo pgo run -- bench

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ To build without Syzygy tablebase support and Clang dependency, add the `--no-de
 cargo rustc --release --no-default-features -- -C target-cpu=native
 ```
 
+#### Local x86_64 compile check
+
+If you develop on Apple Silicon, install the Linux x86_64 Rust target:
+
+```bash
+rustup target add x86_64-unknown-linux-gnu
+```
+
+Then run the local x86_64 compile check before submitting changes that touch target-specific code:
+
+```bash
+make x64-check
+```
+
+This checks the Linux x86_64 scalar, AVX2, and AVX512 Rust codepaths.
+
+See the wiki for more background and rationale:
+<https://github.com/codedeliveryservice/Reckless/wiki/Cross-Architecture-Compile-Checks>
+
 #### PGO builds
 
 For profile-guided optimization (PGO) builds, you need to install additional tools:

--- a/README.md
+++ b/README.md
@@ -74,25 +74,6 @@ To build without Syzygy tablebase support and Clang dependency, add the `--no-de
 cargo rustc --release --no-default-features -- -C target-cpu=native
 ```
 
-#### Local x86_64 compile check
-
-If you develop on Apple Silicon, install the Linux x86_64 Rust target:
-
-```bash
-rustup target add x86_64-unknown-linux-gnu
-```
-
-Then run the local x86_64 compile check before submitting changes that touch target-specific code:
-
-```bash
-make x64-check
-```
-
-This checks the Linux x86_64 scalar, AVX2, and AVX512 Rust codepaths.
-
-See the wiki for more background and rationale:
-<https://github.com/codedeliveryservice/Reckless/wiki/Cross-Architecture-Compile-Checks>
-
 #### PGO builds
 
 For profile-guided optimization (PGO) builds, you need to install additional tools:


### PR DESCRIPTION
## Summary

Add a lightweight local and CI guard for target-specific SIMD codepaths that are not exercised by a normal native Apple Silicon build.

This adds:
- `make x64-check` for local Linux x86_64 scalar/AVX2/AVX512 pre-flight checks
- a separate `Supported Architectures` workflow that mirrors the supported release build families
- README documentation for why the local check exists and how to set it up

## Motivation

Native Apple Silicon builds only compile the AArch64/NEON path. That means x86_64-specific SIMD code can break locally without being noticed, then fail immediately on OpenBench or other Linux x86_64 builders.

The local check is meant to catch that class of problem before uploading a branch.

## What the local check does

`make x64-check` runs Rust-only cross-target compile checks against Linux x86_64:

- `x86-64`
  - covers the generic scalar path
- `x86-64-v3`
  - covers the AVX2 path
- `x86-64-v4`
  - covers the AVX512 path

All three use:

- `--target x86_64-unknown-linux-gnu`
- `--no-default-features`

The local check focuses on the Linux x86_64 paths that are easiest to miss on Apple Silicon. CI covers the broader supported architecture matrix in a separate workflow.

`--no-default-features` is intentional. On Apple Silicon, a full Linux x86_64 build with Syzygy enabled would also require a Linux C toolchain/sysroot. For this guard, the important thing is compiling the Rust x86_64 SIMD paths that OpenBench-style builders will exercise.

## Setup

Local requirement:

```bash
rustup target add x86_64-unknown-linux-gnu
```

Then run:

```bash
make x64-check
```

## Validation

Ran locally on Apple Silicon:

```bash
make x64-check
cargo check --no-default-features
```

The Linux x86_64 local checks passed for:
- `x86-64`
- `x86-64-v3`
- `x86-64-v4`

I also verified that this would have caught the recent zerocopy AVX2 failure mode by reintroducing one of the failing AVX2 casts in a throwaway change and running the same Linux `x86-64-v3` check. It reproduced the same zerocopy trait-bound errors that showed up on the OpenBench x86_64 machine.
