### PR TITLE
Use material of 600 instead of non-pawns

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -195,10 +195,6 @@ impl Board {
         self.mailbox[mv.from()]
     }
 
-    pub fn has_non_pawns(&self) -> bool {
-        (self.pieces(PieceType::Pawn) | self.pieces(PieceType::King)) != self.occupancies()
-    }
-
     pub const fn advance_fullmove_counter(&mut self) {
         self.fullmove_number += self.side_to_move() as usize;
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -543,7 +543,7 @@ fn search<NODE: NodeType>(
             >= beta - 8 * depth + 116 * tt_pv as i32 - 106 * improvement / 1024 + 304
                 - 20 * (td.stack[ply + 1].cutoff_count < 2) as i32
         && ply as i32 >= td.nmp_min_ply
-        && td.board.material() > 1000
+        && td.board.material() > 600
         && !is_loss(beta)
         && !(tt_bound == Bound::Lower
             && tt_move.is_capture()

--- a/src/search.rs
+++ b/src/search.rs
@@ -543,7 +543,7 @@ fn search<NODE: NodeType>(
             >= beta - 8 * depth + 116 * tt_pv as i32 - 106 * improvement / 1024 + 304
                 - 20 * (td.stack[ply + 1].cutoff_count < 2) as i32
         && ply as i32 >= td.nmp_min_ply
-        && td.board.has_non_pawns()
+        && td.board.material() > 1000
         && !is_loss(beta)
         && !(tt_bound == Bound::Lower
             && tt_move.is_capture()


### PR DESCRIPTION
Not sure if this is a good idea, but at least the 600 is tunable.

STC
Elo   | 1.86 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 23032 W: 5919 L: 5796 D: 11317
Penta | [40, 2446, 6420, 2571, 39]
https://recklesschess.space/test/13499/

LTC (with Adjudication)
Elo   | 5.43 +- 3.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 9090 W: 2296 L: 2154 D: 4640
Penta | [4, 889, 2620, 1025, 7]
https://recklesschess.space/test/13503/

LTC (NO adjudication)
Elo   | 0.47 +- 1.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 52454 W: 13118 L: 13047 D: 26289
Penta | [30, 5476, 15140, 5555, 26]
https://recklesschess.space/test/13507/
