### PR TITLE
Such a capture_sq method can simplify some things.

### DIFF
--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -27,13 +27,9 @@ impl super::Board {
             return true;
         }
 
-        // Note: no need to set the "to" square
         let mut occupancies = self.occupancies();
         occupancies.clear(mv.from());
-
-        if mv.is_en_passant() {
-            occupancies.clear(mv.to() ^ 8);
-        }
+        occupancies.clear(mv.capture_sq()); //consider EP
 
         let mut attackers = self.attackers_to(mv.to(), occupancies) & occupancies;
         let mut stm = !self.side_to_move();
@@ -89,11 +85,7 @@ impl super::Board {
     }
 
     fn move_value(&self, mv: Move) -> i32 {
-        if mv.is_en_passant() {
-            return PieceType::Pawn.value();
-        }
-
-        let capture = self.piece_on(mv.to()).piece_type();
+        let capture = self.piece_on(mv.capture_sq()).piece_type();
         let mut value = capture.value();
 
         if mv.is_promotion() {

--- a/src/board/see.rs
+++ b/src/board/see.rs
@@ -27,9 +27,13 @@ impl super::Board {
             return true;
         }
 
+        // No need to set the to square for SEE
         let mut occupancies = self.occupancies();
         occupancies.clear(mv.from());
-        occupancies.clear(mv.capture_sq()); //consider EP
+
+        if mv.is_en_passant() {
+            occupancies.clear(mv.to() ^ 8);
+        }
 
         let mut attackers = self.attackers_to(mv.to(), occupancies) & occupancies;
         let mut stm = !self.side_to_move();

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -165,8 +165,7 @@ impl MovePicker {
         } else {
             for entry in self.list.iter_mut() {
                 let mv = entry.mv;
-                let captured =
-                    if entry.mv.is_en_passant() { PieceType::Pawn } else { td.board.piece_on(mv.to()).piece_type() };
+                let captured = td.board.piece_on(mv.capture_sq()).piece_type();
 
                 entry.score =
                     16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -98,6 +98,10 @@ impl Move {
         matches!(self.kind(), MoveKind::EnPassant)
     }
 
+    pub fn capture_sq(self) -> Square {
+        self.to() ^ (self.is_en_passant() as u8 * 8)
+    }
+
     pub const fn is_castling(self) -> bool {
         matches!(self.kind(), MoveKind::Castling)
     }


### PR DESCRIPTION
STC
Elo   | 1.00 +- 1.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 37104 W: 9455 L: 9348 D: 18301
Penta | [83, 4001, 10285, 4092, 91]
https://recklesschess.space/test/13523/