### PR TITLE
Simplify RFP and NMP if guards

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -521,12 +521,14 @@ fn search<NODE: NodeType>(
     if !tt_pv
         && !in_check
         && !excluded
-        && estimated_score >= beta
         && estimated_score
-            >= beta + 1165 * depth * depth / 128 + 25 * depth - (80 * improving as i32)
-                + 560 * correction_value.abs() / 1024
-                - 59 * (td.board.all_threats() & td.board.colors(stm)).is_empty() as i32
-                + 30
+            >= beta
+                + (1165 * depth * depth / 128 - (80 * improving as i32)
+                    + 25 * depth
+                    + 560 * correction_value.abs() / 1024
+                    - 59 * (td.board.all_threats() & td.board.colors(stm)).is_empty() as i32
+                    + 30)
+                    .max(0)
         && !is_loss(beta)
         && !is_win(estimated_score)
     {
@@ -538,10 +540,13 @@ fn search<NODE: NodeType>(
         && !in_check
         && !excluded
         && !potential_singularity
-        && estimated_score >= beta
         && estimated_score
-            >= beta - 8 * depth + 116 * tt_pv as i32 - 106 * improvement / 1024 + 304
-                - 20 * (td.stack[ply + 1].cutoff_count < 2) as i32
+            >= beta
+                + (-8 * depth + 116 * tt_pv as i32
+                    - 106 * improvement / 1024
+                    - 20 * (td.stack[ply + 1].cutoff_count < 2) as i32
+                    + 304)
+                    .max(0)
         && ply as i32 >= td.nmp_min_ply
         && td.board.has_non_pawns()
         && !is_loss(beta)


### PR DESCRIPTION
STC
```
Elo   | -0.13 +- 1.02 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.00]
Games | N: 116302 W: 29835 L: 29880 D: 56587
Penta | [509, 13020, 31175, 12901, 546]
https://recklesschess.space/test/13533/
```