### PR TITLE
Simplify FDS depth reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -857,7 +857,7 @@ fn search<NODE: NodeType>(
             }
         }
         // Full Depth Search (FDS)
-        else if !NODE::PV || move_count > 1 {
+        else if !NODE::PV || move_count >= 2 {
             let mut reduction = 232 * (move_count.ilog2() * depth.ilog2()) as i32;
 
             reduction -= 48 * move_count;
@@ -902,7 +902,7 @@ fn search<NODE: NodeType>(
                 reduction += 130;
             }
 
-            let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585 && new_depth >= 3) as i32;
+            let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585) as i32;
 
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
             current_search_count += 1;


### PR DESCRIPTION
STC
Elo   | 0.47 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 55390 W: 13990 L: 13915 D: 27485
Penta | [144, 6521, 14288, 6600, 142]
https://recklesschess.space/test/13539/

LTC
Elo   | 0.03 +- 1.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 89786 W: 22194 L: 22186 D: 45406
Penta | [29, 10136, 24556, 10142, 30]
https://recklesschess.space/test/13542/

Bench: 3083392