### PR TITLE
Add all noisy scoring into evasions and consolidate.

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -155,24 +155,20 @@ impl MovePicker {
     fn score_noisy(&mut self, td: &ThreadData) {
         let threats = td.board.all_threats();
 
-        if td.board.in_check() {
-            for entry in self.list.iter_mut() {
-                let mv = entry.mv;
-                let pt = td.board.piece_on(mv.from()).piece_type();
+        for entry in self.list.iter_mut() {
+            let mv = entry.mv;
+            let captured = td.board.piece_on(mv.capture_sq()).piece_type();
+            let pt = td.board.piece_on(mv.from()).piece_type();
 
-                entry.score = 10000 - 1000 * pt as i32;
+            entry.score =
+                16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
+
+            if mv.is_promotion() && mv.promo_piece_type() == PieceType::Queen {
+                entry.score += 4000;
             }
-        } else {
-            for entry in self.list.iter_mut() {
-                let mv = entry.mv;
-                let captured = td.board.piece_on(mv.capture_sq()).piece_type();
 
-                entry.score =
-                    16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
-
-                if mv.is_promotion() && mv.promo_piece_type() == PieceType::Queen {
-                    entry.score += 4000;
-                }
+            if td.board.in_check() {
+                entry.score += 100000 - 10000 * pt as i32;
             }
         }
     }

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -160,16 +160,10 @@ impl MovePicker {
             let captured = td.board.piece_on(mv.capture_sq()).piece_type();
             let pt = td.board.piece_on(mv.from()).piece_type();
 
-            entry.score =
-                16 * captured.value() + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured);
-
-            if mv.is_promotion() && mv.promo_piece_type() == PieceType::Queen {
-                entry.score += 4000;
-            }
-
-            if td.board.in_check() {
-                entry.score += 100000 - 10000 * pt as i32;
-            }
+            entry.score = 16 * captured.value()
+                + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured)
+                + 4000 * (mv.is_promotion() && mv.promo_piece_type() == PieceType::Queen) as i32
+                + (100000 - 10000 * pt as i32) * td.board.in_check() as i32;
         }
     }
 


### PR DESCRIPTION
Consolidate some scoring.  The difference is probably mostly due to including normal scoring in evasions.  Note scoring for in_check is an order of magnitude higher (intentionally).

STC
Elo   | 4.47 +- 3.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 11960 W: 3099 L: 2945 D: 5916
Penta | [28, 1355, 3071, 1487, 39]
https://recklesschess.space/test/13544/

LTC
Elo   | 4.52 +- 3.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 11308 W: 2876 L: 2729 D: 5703
Penta | [4, 1199, 3104, 1340, 7]
https://recklesschess.space/test/13548/