### PR TITLE
Set-wise knight/bishop/rook attack generation

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -413,27 +413,22 @@ impl Board {
         // This "hack" is used to speed up the implementation of `Board::is_legal`.
         let stm = self.side_to_move();
         let occupancies = self.occupancies() ^ self.colored_pieces(stm, PieceType::King);
-        let mut threats = pawn_attacks_setwise(self.colored_pieces(!stm, PieceType::Pawn), !stm);
-        self.state.piece_threats[PieceType::Pawn] = threats;
 
-        threats = Bitboard(0);
-
-        threats |= knight_attacks_setwise(self.colored_pieces(!stm, PieceType::Knight));
-        self.state.piece_threats[PieceType::Knight] = threats;
-
-        threats = Bitboard(0);
-        threats |= bishop_attacks_setwise(self.colored_pieces(!stm, PieceType::Bishop), occupancies);
-        self.state.piece_threats[PieceType::Bishop] = threats;
-
-        threats |= rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Rook), occupancies);
-        self.state.piece_threats[PieceType::Rook] = threats;
-
-        threats = Bitboard(0);
-        for square in self.colored_pieces(!stm, PieceType::Queen) {
-            threats |= queen_attacks(square, occupancies);
-        }
-        self.state.piece_threats[PieceType::Queen] = threats;
-
+        self.state.piece_threats[PieceType::Pawn] =
+            pawn_attacks_setwise(self.colored_pieces(!stm, PieceType::Pawn), !stm);
+        self.state.piece_threats[PieceType::Knight] =
+            knight_attacks_setwise(self.colored_pieces(!stm, PieceType::Knight));
+        self.state.piece_threats[PieceType::Bishop] =
+            bishop_attacks_setwise(self.colored_pieces(!stm, PieceType::Bishop), occupancies);
+        self.state.piece_threats[PieceType::Rook] =
+            rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Rook), occupancies);
+        self.state.piece_threats[PieceType::Queen] = {
+            let mut threats = Bitboard(0);
+            for square in self.colored_pieces(!stm, PieceType::Queen) {
+                threats |= queen_attacks(square, occupancies);
+            }
+            threats
+        };
         self.state.piece_threats[PieceType::King] = king_attacks(self.king_square(!stm));
 
         self.state.all_threats = self.piece_threats(PieceType::Pawn)

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,8 +1,9 @@
 use crate::{
     lookup::{
         attacks, between, bishop_attacks, cuckoo, cuckoo_a, cuckoo_b, h1, h2, king_attacks, knight_attacks,
-        pawn_attacks, pawn_attacks_setwise, queen_attacks, ray_pass, rook_attacks,
+        pawn_attacks, queen_attacks, ray_pass, rook_attacks,
     },
+    setwise::{bishop_attacks_setwise, knight_attacks_setwise, pawn_attacks_setwise, rook_attacks_setwise},
     types::{
         Bitboard, Castling, CastlingKind, Color, File, Move, PAWN_HOME_RANK, PROMO_RANK, Piece, PieceType, Square,
         ZOBRIST,
@@ -416,21 +417,15 @@ impl Board {
         self.state.piece_threats[PieceType::Pawn] = threats;
 
         threats = Bitboard(0);
-        for square in self.colored_pieces(!stm, PieceType::Knight) {
-            threats |= knight_attacks(square);
-        }
+
+        threats |= knight_attacks_setwise(self.colored_pieces(!stm, PieceType::Knight));
         self.state.piece_threats[PieceType::Knight] = threats;
 
         threats = Bitboard(0);
-        for square in self.colored_pieces(!stm, PieceType::Bishop) {
-            threats |= bishop_attacks(square, occupancies);
-        }
+        threats |= bishop_attacks_setwise(self.colored_pieces(!stm, PieceType::Bishop), occupancies);
         self.state.piece_threats[PieceType::Bishop] = threats;
 
-        threats = Bitboard(0);
-        for square in self.colored_pieces(!stm, PieceType::Rook) {
-            threats |= rook_attacks(square, occupancies);
-        }
+        threats |= rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Rook), occupancies);
         self.state.piece_threats[PieceType::Rook] = threats;
 
         threats = Bitboard(0);

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,4 +1,4 @@
-use crate::types::{Bitboard, Color, File, Piece, PieceType, Square, ZOBRIST};
+use crate::types::{Bitboard, Color, Piece, PieceType, Square, ZOBRIST};
 
 include!(concat!(env!("OUT_DIR"), "/lookup.rs"));
 
@@ -142,18 +142,6 @@ pub fn attacks(piece: Piece, square: Square, occupancies: Bitboard) -> Bitboard 
         PieceType::King => king_attacks(square),
         PieceType::None => Bitboard(0),
     }
-}
-
-pub fn pawn_attacks_setwise(bb: Bitboard, color: Color) -> Bitboard {
-    let (up_right, up_left) = match color {
-        Color::White => (9, 7),
-        Color::Black => (-7, -9),
-    };
-
-    let right_attacks = (bb & !Bitboard::file(File::H)).shift(up_right);
-    let left_attacks = (bb & !Bitboard::file(File::A)).shift(up_left);
-
-    right_attacks | left_attacks
 }
 
 pub fn pawn_attacks(square: Square, color: Color) -> Bitboard {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod nnue;
 mod numa;
 mod parameters;
 mod search;
+mod setwise;
 mod stack;
 mod thread;
 mod threadpool;

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -1,6 +1,7 @@
 use crate::{
-    lookup::{bishop_attacks, king_attacks, knight_attacks, pawn_attacks_setwise, rook_attacks},
+    lookup::king_attacks,
     search::NodeType,
+    setwise::{bishop_attacks_setwise, knight_attacks_setwise, pawn_attacks_setwise, rook_attacks_setwise},
     thread::ThreadData,
     types::{ArrayVec, Bitboard, MAX_MOVES, Move, MoveEntry, MoveList, PieceType},
 };
@@ -170,6 +171,7 @@ impl MovePicker {
     fn score_quiet(&mut self, td: &ThreadData, ply: isize) {
         let threats = td.board.all_threats();
         let side = td.board.side_to_move();
+        let occupancies = td.board.occupancies();
 
         let threatened = {
             let pawn_threats = td.board.piece_threats(PieceType::Pawn);
@@ -183,40 +185,24 @@ impl MovePicker {
 
         // safe squares where we can attack an opponent piece
         let offense = {
-            let mut n = Bitboard(0);
-            let mut b = Bitboard(0);
-            let mut q = Bitboard(0);
-            let pawn_offense = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
+            let knight_vulnerable = (td.board.colored_pieces(!side, PieceType::Bishop) & !threats)
+                | td.board.colored_pieces(!side, PieceType::Rook)
+                | td.board.colored_pieces(!side, PieceType::Queen);
+            let bishop_vulnerable = td.board.colored_pieces(!side, PieceType::Rook);
+            let queen_orth_vulnerable = td.board.colored_pieces(!side, PieceType::Bishop) & !threats;
+            let queen_diag_vulnerable = td.board.colored_pieces(!side, PieceType::Rook) & !threats;
 
-            for square in td.board.colored_pieces(!side, PieceType::Bishop) & !threats {
-                n |= knight_attacks(square);
-                q |= rook_attacks(square, td.board.occupancies());
-            }
+            let p = pawn_attacks_setwise(td.board.colors(!side), !side);
+            let n = knight_attacks_setwise(knight_vulnerable);
+            let b = bishop_attacks_setwise(bishop_vulnerable, occupancies);
+            let q = rook_attacks_setwise(queen_orth_vulnerable, occupancies)
+                | bishop_attacks_setwise(queen_diag_vulnerable, occupancies);
 
-            for square in td.board.colored_pieces(!side, PieceType::Rook) {
-                n |= knight_attacks(square);
-                b |= bishop_attacks(square, td.board.occupancies());
-
-                if !threats.contains(square) {
-                    q |= bishop_attacks(square, td.board.occupancies());
-                }
-            }
-            for square in td.board.colored_pieces(!side, PieceType::Queen) {
-                n |= knight_attacks(square);
-            }
-
-            [pawn_offense, n & !threats, b & !threats, Bitboard(0), q & !threats, Bitboard(0)]
+            [p & !threats, n & !threats, b & !threats, Bitboard(0), q & !threats, Bitboard(0)]
         };
 
         // King ring diag attacks and ortho attacks
-        let king_ring_ortho = {
-            let mut king_ring_ortho = Bitboard(0);
-            for square in king_attacks(td.board.king_square(!side)) {
-                king_ring_ortho |= rook_attacks(square, td.board.occupancies());
-            }
-            king_ring_ortho &= !threats;
-            king_ring_ortho
-        };
+        let king_ring_ortho = rook_attacks_setwise(king_attacks(td.board.king_square(!side)), occupancies) & !threats;
 
         // don't move king wall pawns
         let wall_pawns = if Bitboard::HOME_ROWS[side].contains(td.board.king_square(side)) {

--- a/src/setwise.rs
+++ b/src/setwise.rs
@@ -1,0 +1,149 @@
+use crate::types::{Bitboard, Color, File, Rank};
+
+const A: Bitboard = Bitboard::file(File::A);
+const B: Bitboard = Bitboard::file(File::B);
+const G: Bitboard = Bitboard::file(File::G);
+const H: Bitboard = Bitboard::file(File::H);
+const R1: Bitboard = Bitboard::rank(Rank::R1);
+const R2: Bitboard = Bitboard::rank(Rank::R2);
+const R7: Bitboard = Bitboard::rank(Rank::R7);
+const R8: Bitboard = Bitboard::rank(Rank::R8);
+
+pub fn pawn_attacks_setwise(bb: Bitboard, color: Color) -> Bitboard {
+    let (up_right, up_left) = match color {
+        Color::White => (9, 7),
+        Color::Black => (-7, -9),
+    };
+
+    let right_attacks = (bb & !Bitboard::file(File::H)).shift(up_right);
+    let left_attacks = (bb & !Bitboard::file(File::A)).shift(up_left);
+
+    right_attacks | left_attacks
+}
+
+#[cfg(not(target_feature = "avx2"))]
+#[inline]
+pub fn knight_attacks_setwise(bb: Bitboard) -> Bitboard {
+    (bb & !(A | B | R8)).shift(6)
+        | (bb & !(A | R7 | R8)).shift(15)
+        | (bb & !(H | R7 | R8)).shift(17)
+        | (bb & !(G | H | R8)).shift(10)
+        | (bb & !(G | H | R1)).shift(-6)
+        | (bb & !(H | R1 | R2)).shift(-15)
+        | (bb & !(A | R1 | R2)).shift(-17)
+        | (bb & !(A | B | R1)).shift(-10)
+}
+
+#[cfg(target_feature = "avx2")]
+#[inline]
+pub fn knight_attacks_setwise(bb: Bitboard) -> Bitboard {
+    use core::arch::x86_64::*;
+
+    unsafe {
+        let mask_a = _mm256_set_epi64x(
+            !(A | B | R8).0 as i64,
+            !(A | R7 | R8).0 as i64,
+            !(H | R7 | R8).0 as i64,
+            !(G | H | R8).0 as i64,
+        );
+        let mask_b = _mm256_set_epi64x(
+            !(G | H | R1).0 as i64,
+            !(H | R1 | R2).0 as i64,
+            !(A | R1 | R2).0 as i64,
+            !(A | B | R1).0 as i64,
+        );
+
+        let bb = _mm256_set1_epi64x(bb.0 as i64);
+        let a = _mm256_and_si256(bb, mask_a);
+        let b = _mm256_and_si256(bb, mask_b);
+        let a = _mm256_sllv_epi64(a, _mm256_set_epi64x(6, 15, 17, 10));
+        let b = _mm256_srlv_epi64(b, _mm256_set_epi64x(6, 15, 17, 10));
+        fold_to_bitboard(_mm256_or_si256(a, b))
+    }
+}
+
+#[cfg(not(target_feature = "avx512f"))]
+#[inline]
+pub fn bishop_attacks_setwise(bb: Bitboard, occupancies: Bitboard) -> Bitboard {
+    use crate::lookup::bishop_attacks;
+
+    let mut result = Bitboard(0);
+    for square in bb {
+        result |= bishop_attacks(square, occupancies);
+    }
+    result
+}
+
+#[cfg(target_feature = "avx512f")]
+#[inline]
+pub fn bishop_attacks_setwise(bb: Bitboard, occupancies: Bitboard) -> Bitboard {
+    use std::arch::x86_64::*;
+
+    unsafe {
+        let attackers = _mm256_set1_epi64x(bb.0 as i64);
+        let rotates1 = _mm256_set_epi64x(-9, -7, 7, 9);
+        let rotates2 = _mm256_add_epi64(rotates1, rotates1);
+        let rotates4 = _mm256_add_epi64(rotates2, rotates2);
+
+        let mask = _mm256_set_epi64x(!(R8 | H).0 as i64, !(R8 | A).0 as i64, !(R1 | H).0 as i64, !(R1 | A).0 as i64);
+
+        let generate = attackers;
+        let propagate = _mm256_and_si256(_mm256_set1_epi64x(!occupancies.0 as i64), mask);
+        let generate = _mm256_or_si256(generate, _mm256_and_si256(propagate, _mm256_rolv_epi64(generate, rotates1)));
+        let propagate = _mm256_and_si256(propagate, _mm256_rolv_epi64(propagate, rotates1));
+        let generate = _mm256_or_si256(generate, _mm256_and_si256(propagate, _mm256_rolv_epi64(generate, rotates2)));
+        let propagate = _mm256_and_si256(propagate, _mm256_rolv_epi64(propagate, rotates2));
+        let generate = _mm256_or_si256(generate, _mm256_and_si256(propagate, _mm256_rolv_epi64(generate, rotates4)));
+        let attacks = _mm256_and_si256(_mm256_rolv_epi64(generate, rotates1), mask);
+
+        fold_to_bitboard(attacks)
+    }
+}
+
+#[cfg(not(target_feature = "avx512f"))]
+#[inline]
+pub fn rook_attacks_setwise(bb: Bitboard, occupancies: Bitboard) -> Bitboard {
+    use crate::lookup::rook_attacks;
+
+    let mut result = Bitboard(0);
+    for square in bb {
+        result |= rook_attacks(square, occupancies);
+    }
+    result
+}
+
+#[cfg(target_feature = "avx512f")]
+#[inline]
+pub fn rook_attacks_setwise(bb: Bitboard, occupancies: Bitboard) -> Bitboard {
+    use std::arch::x86_64::*;
+
+    unsafe {
+        let attackers = _mm256_set1_epi64x(bb.0 as i64);
+        let rotates1 = _mm256_set_epi64x(-8, -1, 1, 8);
+        let rotates2 = _mm256_add_epi64(rotates1, rotates1);
+        let rotates4 = _mm256_add_epi64(rotates2, rotates2);
+
+        let mask = _mm256_set_epi64x(!R8.0 as i64, !H.0 as i64, !A.0 as i64, !R1.0 as i64);
+
+        let generate = attackers;
+        let propagate = _mm256_and_si256(_mm256_set1_epi64x(!occupancies.0 as i64), mask);
+        let generate = _mm256_or_si256(generate, _mm256_and_si256(propagate, _mm256_rolv_epi64(generate, rotates1)));
+        let propagate = _mm256_and_si256(propagate, _mm256_rolv_epi64(propagate, rotates1));
+        let generate = _mm256_or_si256(generate, _mm256_and_si256(propagate, _mm256_rolv_epi64(generate, rotates2)));
+        let propagate = _mm256_and_si256(propagate, _mm256_rolv_epi64(propagate, rotates2));
+        let generate = _mm256_or_si256(generate, _mm256_and_si256(propagate, _mm256_rolv_epi64(generate, rotates4)));
+        let attacks = _mm256_and_si256(_mm256_rolv_epi64(generate, rotates1), mask);
+
+        fold_to_bitboard(attacks)
+    }
+}
+
+#[cfg(target_feature = "avx2")]
+#[inline]
+unsafe fn fold_to_bitboard(vector: core::arch::x86_64::__m256i) -> Bitboard {
+    use core::arch::x86_64::*;
+
+    let vector = _mm_or_si128(_mm256_castsi256_si128(vector), _mm256_extracti128_si256::<1>(vector));
+    let result = _mm_extract_epi64::<0>(vector) | _mm_extract_epi64::<1>(vector);
+    Bitboard(result as u64)
+}


### PR DESCRIPTION
Locally 1.03 ± 0.02 times faster.

VSTC (AVX512)
Elo   | 1.64 +- 1.32 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 69852 W: 18158 L: 17829 D: 33865
Penta | [355, 7623, 18657, 7920, 371]
https://recklesschess.space/test/13592/

No functional change.

Bench: 2900111