### PR TITLE
Double in_check scoring for noisy moves.

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -163,7 +163,7 @@ impl MovePicker {
             entry.score = 16 * captured.value()
                 + td.noisy_history.get(threats, td.board.moved_piece(mv), mv.to(), captured)
                 + 4000 * (mv.is_promotion() && mv.promo_piece_type() == PieceType::Queen) as i32
-                + (100000 - 10000 * pt as i32) * td.board.in_check() as i32;
+                + (200000 - 20000 * pt as i32) * td.board.in_check() as i32;
         }
     }
 


### PR DESCRIPTION
STC
Elo   | 2.13 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 42494 W: 10734 L: 10474 D: 21286
Penta | [90, 4846, 11118, 5100, 93]
https://recklesschess.space/test/13566/

LTC
Elo   | 2.34 +- 1.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34390 W: 8615 L: 8383 D: 17392
Penta | [11, 3776, 9392, 4002, 14]
https://recklesschess.space/test/13584/

bench 3344311