### PR TITLE
Simplify King ortho MP scoring.

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -208,15 +208,7 @@ impl MovePicker {
             [pawn_offense, n & !threats, b & !threats, Bitboard(0), q & !threats, Bitboard(0)]
         };
 
-        // King ring diag attacks and ortho attacks
-        let king_ring_ortho = {
-            let mut king_ring_ortho = Bitboard(0);
-            for square in king_attacks(td.board.king_square(!side)) {
-                king_ring_ortho |= rook_attacks(square, td.board.occupancies());
-            }
-            king_ring_ortho &= !threats;
-            king_ring_ortho
-        };
+        let king_file = td.board.king_square(!side).file();
 
         // don't move king wall pawns
         let wall_pawns = if Bitboard::HOME_ROWS[side].contains(td.board.king_square(side)) {
@@ -238,7 +230,7 @@ impl MovePicker {
                 + 9325 * td.board.checking_squares(pt).contains(mv.to()) as i32
                 - 7584 * threatened[pt].contains(mv.to()) as i32
                 + 6158 * offense[pt].contains(mv.to()) as i32
-                + 5000 * (pt == PieceType::Rook && king_ring_ortho.contains(mv.to())) as i32
+                + 5000 * (pt == PieceType::Rook && king_file == mv.to().file()) as i32
                 - 4000 * wall_pawns.contains(mv.from()) as i32;
         }
     }


### PR DESCRIPTION
Just check if the rook is on the same file as the king.

STC
Elo   | 0.73 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 43724 W: 11075 L: 10983 D: 21666
Penta | [141, 5186, 11100, 5310, 125]
https://recklesschess.space/test/13604/

LTC
Elo   | 2.90 +- 2.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.04 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 16800 W: 4242 L: 4102 D: 8456
Penta | [7, 1838, 4567, 1984, 4]
https://recklesschess.space/test/13617/

bench 3057983