### PR TITLE
Fix reporting bounds

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -936,6 +936,8 @@ fn search<NODE: NodeType>(
             root_move.nodes += current_nodes - initial_nodes;
 
             if move_count == 1 || score > alpha {
+                root_move.upperbound = false;
+                root_move.lowerbound = false;
                 match score {
                     v if v <= alpha => {
                         root_move.display_score = alpha;
@@ -947,8 +949,6 @@ fn search<NODE: NodeType>(
                     }
                     _ => {
                         root_move.display_score = score;
-                        root_move.upperbound = false;
-                        root_move.lowerbound = false;
                     }
                 }
 


### PR DESCRIPTION
In case the rootmove has an upperbound in the previous iteration and a lowerbound in the current iteration both bounds becomes true. this fixes this problem of showing Upperbound when it's actually a Lowerbound.

No functional change.

Bench: 3057983