### PR TITLE
More cutnode reduction if no best move from singular search

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -818,8 +818,8 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1818;
-                reduction += 1459 * tt_move.is_null() as i32;
-                reduction += 1459 * alternate_move.is_null() as i32;
+                reduction += 2000 * tt_move.is_null() as i32;
+                reduction += 800 * alternate_move.is_null() as i32;
             }
 
             if !improving {
@@ -886,8 +886,8 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1543;
-                reduction += 1429 * tt_move.is_null() as i32;
-                reduction += 1429 * alternate_move.is_null() as i32;
+                reduction += 2000 * tt_move.is_null() as i32;
+                reduction += 800 * alternate_move.is_null() as i32;
             }
 
             if !improving {

--- a/src/search.rs
+++ b/src/search.rs
@@ -654,6 +654,7 @@ fn search<NODE: NodeType>(
     // Singular Extensions (SE)
     let mut extension = 0;
     let mut singular_score = Score::NONE;
+    let mut alternate_move = Move::NULL;
 
     if !NODE::ROOT && !excluded && potential_singularity {
         debug_assert!(is_valid(tt_score));
@@ -666,6 +667,7 @@ fn search<NODE: NodeType>(
         td.stack[ply].excluded = tt_move;
         td.stack[ply].mv = Move::NULL;
         singular_score = search::<NonPV>(td, singular_beta - 1, singular_beta, singular_depth, cut_node, ply);
+        alternate_move = td.stack[ply].mv;
         td.stack[ply].excluded = Move::NULL;
 
         if td.shared.status.get() == Status::STOPPED {
@@ -685,7 +687,7 @@ fn search<NODE: NodeType>(
         // Multi-Cut
         else if singular_score >= beta && !is_decisive(singular_score) {
             return (2 * singular_score + beta) / 3;
-        } else if singular_score > tt_score && td.stack[ply].mv != Move::NULL {
+        } else if singular_score > tt_score && !alternate_move.is_null() {
             tt_move = Move::NULL;
         }
         // Negative Extensions
@@ -836,6 +838,10 @@ fn search<NODE: NodeType>(
                 reduction += (512 * (margin - 160) / 128).clamp(0, 2048);
             }
 
+            if mv == alternate_move {
+                reduction -= 1500;
+            }
+
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 485 {
                 reduction += 129;
             }
@@ -901,6 +907,8 @@ fn search<NODE: NodeType>(
 
             if mv == tt_move {
                 reduction -= 3281;
+            } else if mv == alternate_move {
+                reduction -= 1500;
             }
 
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -818,8 +818,8 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1818;
-                reduction += 1059 * tt_move.is_null() as i32;
-                reduction += 1059 * alternate_move.is_null() as i32;
+                reduction += 1459 * tt_move.is_null() as i32;
+                reduction += 1459 * alternate_move.is_null() as i32;
             }
 
             if !improving {
@@ -886,8 +886,8 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1543;
-                reduction += 1029 * tt_move.is_null() as i32;
-                reduction += 1029 * alternate_move.is_null() as i32;
+                reduction += 1429 * tt_move.is_null() as i32;
+                reduction += 1429 * alternate_move.is_null() as i32;
             }
 
             if !improving {

--- a/src/search.rs
+++ b/src/search.rs
@@ -835,11 +835,7 @@ fn search<NODE: NodeType>(
 
             if is_valid(tt_move_score) && is_valid(singular_score) {
                 let margin = tt_move_score - singular_score;
-                reduction += (512 * (margin - 160) / 128).clamp(0, 2048);
-            }
-
-            if mv == alternate_move {
-                reduction -= 1500;
+                reduction += 512 * (margin - 160) / 128;
             }
 
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 485 {
@@ -902,13 +898,11 @@ fn search<NODE: NodeType>(
 
             if is_valid(tt_move_score) && is_valid(singular_score) {
                 let margin = tt_move_score - singular_score;
-                reduction += (400 * (margin - 160) / 128).clamp(0, 2048);
+                reduction += 400 * (margin - 160) / 128;
             }
 
             if mv == tt_move {
                 reduction -= 3281;
-            } else if mv == alternate_move {
-                reduction -= 1500;
             }
 
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -818,7 +818,8 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1818;
-                reduction += 2118 * tt_move.is_null() as i32;
+                reduction += 1059 * tt_move.is_null() as i32;
+                reduction += 1059 * alternate_move.is_null() as i32;
             }
 
             if !improving {
@@ -835,7 +836,7 @@ fn search<NODE: NodeType>(
 
             if is_valid(tt_move_score) && is_valid(singular_score) {
                 let margin = tt_move_score - singular_score;
-                reduction += 512 * (margin - 160) / 128;
+                reduction += (512 * (margin - 160) / 128).clamp(0, 2048);
             }
 
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 485 {
@@ -885,7 +886,8 @@ fn search<NODE: NodeType>(
 
             if !tt_pv && cut_node {
                 reduction += 1543;
-                reduction += 2058 * tt_move.is_null() as i32;
+                reduction += 1029 * tt_move.is_null() as i32;
+                reduction += 1029 * alternate_move.is_null() as i32;
             }
 
             if !improving {
@@ -898,7 +900,7 @@ fn search<NODE: NodeType>(
 
             if is_valid(tt_move_score) && is_valid(singular_score) {
                 let margin = tt_move_score - singular_score;
-                reduction += 400 * (margin - 160) / 128;
+                reduction += (400 * (margin - 160) / 128).clamp(0, 2048);
             }
 
             if mv == tt_move {


### PR DESCRIPTION
STC
Elo   | 2.61 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32338 W: 8297 L: 8054 D: 15987
Penta | [85, 3678, 8397, 3927, 82]
https://recklesschess.space/test/13720/

LTC
Elo   | 1.11 +- 0.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 141636 W: 35159 L: 34705 D: 71772
Penta | [60, 15697, 38847, 16157, 57]
https://recklesschess.space/test/13721/

Bench: 3009142