### PR TITLE
simplify some threat generation.

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -1,7 +1,7 @@
 use crate::{
     lookup::{
         attacks, between, bishop_attacks, cuckoo, cuckoo_a, cuckoo_b, h1, h2, king_attacks, knight_attacks,
-        pawn_attacks, queen_attacks, ray_pass, rook_attacks,
+        pawn_attacks, ray_pass, rook_attacks,
     },
     setwise::{bishop_attacks_setwise, knight_attacks_setwise, pawn_attacks_setwise, rook_attacks_setwise},
     types::{
@@ -426,13 +426,9 @@ impl Board {
             bishop_attacks_setwise(self.colored_pieces(!stm, PieceType::Bishop), occupancies);
         self.state.piece_threats[PieceType::Rook] =
             rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Rook), occupancies);
-        self.state.piece_threats[PieceType::Queen] = {
-            let mut threats = Bitboard(0);
-            for square in self.colored_pieces(!stm, PieceType::Queen) {
-                threats |= queen_attacks(square, occupancies);
-            }
-            threats
-        };
+        self.state.piece_threats[PieceType::Queen] =
+            bishop_attacks_setwise(self.colored_pieces(!stm, PieceType::Queen), occupancies)
+            | rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Queen), occupancies);
         self.state.piece_threats[PieceType::King] = king_attacks(self.king_square(!stm));
 
         self.state.all_threats = self.piece_threats(PieceType::Pawn)

--- a/src/board.rs
+++ b/src/board.rs
@@ -428,7 +428,7 @@ impl Board {
             rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Rook), occupancies);
         self.state.piece_threats[PieceType::Queen] =
             bishop_attacks_setwise(self.colored_pieces(!stm, PieceType::Queen), occupancies)
-            | rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Queen), occupancies);
+                | rook_attacks_setwise(self.colored_pieces(!stm, PieceType::Queen), occupancies);
         self.state.piece_threats[PieceType::King] = king_attacks(self.king_square(!stm));
 
         self.state.all_threats = self.piece_threats(PieceType::Pawn)


### PR DESCRIPTION
STC
Elo   | 1.38 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 28758 W: 7171 L: 7057 D: 14530
Penta | [47, 3124, 7953, 3178, 77]
https://recklesschess.space/test/13741/

bench 3057983