### PR TITLE
Simplify rook ortho attacks into rook offense

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -197,7 +197,8 @@ impl MovePicker {
             let b = bishop_attacks_setwise(bishop_vulnerable, occupancies) & !threats;
             let r = Bitboard::file(td.board.king_square(!side).file()) & !threats;
             let q = (rook_attacks_setwise(queen_orth_vulnerable, occupancies)
-                | bishop_attacks_setwise(queen_diag_vulnerable, occupancies)) & !threats;
+                | bishop_attacks_setwise(queen_diag_vulnerable, occupancies))
+                & !threats;
 
             [p, n, b, r, q, Bitboard(0)]
         };

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -195,13 +195,12 @@ impl MovePicker {
             let p = pawn_attacks_setwise(td.board.colors(!side), !side);
             let n = knight_attacks_setwise(knight_vulnerable);
             let b = bishop_attacks_setwise(bishop_vulnerable, occupancies);
+            let r = Bitboard::file(td.board.king_square(!side).file());
             let q = rook_attacks_setwise(queen_orth_vulnerable, occupancies)
                 | bishop_attacks_setwise(queen_diag_vulnerable, occupancies);
 
-            [p & !threats, n & !threats, b & !threats, Bitboard(0), q & !threats, Bitboard(0)]
+            [p & !threats, n & !threats, b & !threats, r & !threats, q & !threats, Bitboard(0)]
         };
-
-        let king_file = td.board.king_square(!side).file();
 
         // don't move king wall pawns
         let wall_pawns = if Bitboard::HOME_ROWS[side].contains(td.board.king_square(side)) {
@@ -223,7 +222,6 @@ impl MovePicker {
                 + 9325 * td.board.checking_squares(pt).contains(mv.to()) as i32
                 - 7584 * threatened[pt].contains(mv.to()) as i32
                 + 6158 * offense[pt].contains(mv.to()) as i32
-                + 5000 * (pt == PieceType::Rook && king_file == mv.to().file()) as i32
                 - 4000 * wall_pawns.contains(mv.from()) as i32;
         }
     }

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -192,14 +192,14 @@ impl MovePicker {
             let queen_orth_vulnerable = td.board.colored_pieces(!side, PieceType::Bishop) & !threats;
             let queen_diag_vulnerable = td.board.colored_pieces(!side, PieceType::Rook) & !threats;
 
-            let p = pawn_attacks_setwise(td.board.colors(!side), !side);
-            let n = knight_attacks_setwise(knight_vulnerable);
-            let b = bishop_attacks_setwise(bishop_vulnerable, occupancies);
-            let r = Bitboard::file(td.board.king_square(!side).file());
-            let q = rook_attacks_setwise(queen_orth_vulnerable, occupancies)
-                | bishop_attacks_setwise(queen_diag_vulnerable, occupancies);
+            let p = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
+            let n = knight_attacks_setwise(knight_vulnerable) & !threats;
+            let b = bishop_attacks_setwise(bishop_vulnerable, occupancies) & !threats;
+            let r = Bitboard::file(td.board.king_square(!side).file()) & !threats;
+            let q = (rook_attacks_setwise(queen_orth_vulnerable, occupancies)
+                | bishop_attacks_setwise(queen_diag_vulnerable, occupancies)) & !threats;
 
-            [p & !threats, n & !threats, b & !threats, r & !threats, q & !threats, Bitboard(0)]
+            [p, n, b, r, q, Bitboard(0)]
         };
 
         // don't move king wall pawns
@@ -221,7 +221,7 @@ impl MovePicker {
                 + escape[pt] * threatened[pt].contains(mv.from()) as i32
                 + 9325 * td.board.checking_squares(pt).contains(mv.to()) as i32
                 - 7584 * threatened[pt].contains(mv.to()) as i32
-                + 6158 * offense[pt].contains(mv.to()) as i32
+                + 5000 * offense[pt].contains(mv.to()) as i32
                 - 4000 * wall_pawns.contains(mv.from()) as i32;
         }
     }


### PR DESCRIPTION
STC
Elo   | 0.39 +- 1.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 58064 W: 14667 L: 14602 D: 28795
Penta | [158, 6844, 14945, 6945, 140]
https://recklesschess.space/test/13736/

LTC
Elo   | 0.51 +- 1.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 50036 W: 12397 L: 12323 D: 25316
Penta | [17, 5591, 13737, 5647, 26]
https://recklesschess.space/test/13738/