### PR TITLE
Test helper search diversification

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -840,6 +840,8 @@ fn search<NODE: NodeType>(
                 reduction += 129;
             }
 
+            reduction += helper_reduction_bias(td);
+
             let reduced_depth =
                 (new_depth - reduction / 1024).clamp(1, new_depth + (move_count <= 3) as i32 + 1) + 2 * NODE::PV as i32;
 
@@ -906,6 +908,8 @@ fn search<NODE: NodeType>(
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {
                 reduction += 130;
             }
+
+            reduction += helper_reduction_bias(td);
 
             let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585) as i32;
 
@@ -1369,6 +1373,19 @@ fn update_continuation_histories(td: &mut ThreadData, ply: isize, piece: Piece, 
         if entry.mv.is_present() {
             td.continuation_history.update(entry.conthist, piece, sq, bonus);
         }
+    }
+}
+
+fn helper_reduction_bias(td: &ThreadData) -> i32 {
+    if td.id == 0 {
+        return 0;
+    }
+
+    match td.id % 4 {
+        1 => -96,
+        2 => 96,
+        3 => -48,
+        _ => 48,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add a small deterministic LMR/FDS reduction bias to helper threads.
- Keep the main search thread unchanged.
- Use helper offsets of `96`/`48` reduction units, cycling signs by thread id.

## Results

Bench: `3425249`

OpenBench:

- `96/48`: `+1.96 +/- 1.58` Elo, LLR `2.95`, 42,968 games
  https://recklesschess.space/test/13717/
- `512/256` comparison: `-1.39 +/- 2.73` Elo, LLR `-2.35`, 14,486 games
  https://recklesschess.space/test/13732/

## Local Checks

- `cargo fmt --check`
- `cargo check`
