### PR TITLE
Overhaul NUMA support and implement NNUE weight replication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [features]
 default = ["syzygy"]
 syzygy = []
-numa = []
 spsa = []
 
 [profile.dev]

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,9 +1,6 @@
 use std::sync::atomic::{AtomicI16, Ordering};
 
-use crate::{
-    numa::NumaValue,
-    types::{Bitboard, Color, Move, Piece, PieceType, Square},
-};
+use crate::types::{Bitboard, Color, Move, Piece, PieceType, Square};
 
 type FromToHistory<T> = [[T; 64]; 64];
 type PieceToHistory<T> = [[T; 64]; 13];
@@ -123,8 +120,6 @@ pub struct CorrectionHistory {
     // [side_to_move][key]
     entries: Box<[[AtomicI16; Self::SIZE]; 2]>,
 }
-
-unsafe impl NumaValue for CorrectionHistory {}
 
 impl CorrectionHistory {
     const MAX_HISTORY: i32 = 14605;

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -261,9 +261,9 @@ impl Network {
                 forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
 
-            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
-            let l2_out = forward::propagate_l2(l1_out, bucket, parameters);
-            let l3_out = forward::propagate_l3(l2_out, bucket, parameters);
+            let l1_out = forward::propagate_l1(&ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l2_out = forward::propagate_l2(&l1_out, bucket, parameters);
+            let l3_out = forward::propagate_l3(&l2_out, bucket, parameters);
 
             (l3_out * NETWORK_SCALE as f32) as i32
         }
@@ -279,9 +279,9 @@ impl Network {
             let ft_out =
                 forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
-            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
-            let l2_out = forward::propagate_l2(l1_out, bucket, parameters);
-            let l3_out = forward::propagate_l3(l2_out, bucket, parameters);
+            let l1_out = forward::propagate_l1(&ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l2_out = forward::propagate_l2(&l1_out, bucket, parameters);
+            let l3_out = forward::propagate_l3(&l2_out, bucket, parameters);
             (l3_out * NETWORK_SCALE as f32) as i32
         }
     }

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -2,12 +2,15 @@ mod accumulator;
 
 pub use accumulator::threats::initialize;
 
+use std::sync::Arc;
+
 use crate::{
     board::{Board, BoardObserver},
     nnue::accumulator::{
         AccumulatorCache, PstAccumulator, ThreatAccumulator,
         threats::{push_threats_on_change, push_threats_on_move, push_threats_on_mutate},
     },
+    numa::NumaReplicable,
     types::{Color, MAX_PLY, Move, Piece, PieceType, Square},
 };
 
@@ -97,6 +100,7 @@ struct SparseEntry {
 
 #[derive(Clone)]
 pub struct Network {
+    parameters: Arc<ParametersHandle>,
     index: usize,
     pst_stack: Box<[PstAccumulator]>,
     threat_stack: Box<[ThreatAccumulator]>,
@@ -105,6 +109,32 @@ pub struct Network {
 }
 
 impl Network {
+    pub fn new(parameters: Arc<ParametersHandle>) -> Self {
+        let mut nnz_table = vec![SparseEntry { indexes: [0; 8], count: 0 }; 256];
+
+        for (byte, entry) in nnz_table.iter_mut().enumerate() {
+            let mut count = 0;
+
+            for bit in 0..8 {
+                if (byte & (1 << bit)) != 0 {
+                    entry.indexes[count] = bit as u16;
+                    count += 1;
+                }
+            }
+
+            entry.count = count;
+        }
+
+        Self {
+            parameters: parameters.clone(),
+            index: 0,
+            pst_stack: vec![PstAccumulator::new(&parameters); MAX_PLY].into_boxed_slice(),
+            threat_stack: vec![ThreatAccumulator::new(); MAX_PLY].into_boxed_slice(),
+            cache: AccumulatorCache::new(&parameters),
+            nnz_table: nnz_table.into_boxed_slice(),
+        }
+    }
+
     pub fn push(&mut self, mv: Move, board: &Board) {
         debug_assert!(mv.is_present());
 
@@ -124,11 +154,13 @@ impl Network {
     }
 
     pub fn full_refresh(&mut self, board: &Board) {
-        self.pst_stack[self.index].refresh(board, Color::White, &mut self.cache);
-        self.pst_stack[self.index].refresh(board, Color::Black, &mut self.cache);
+        let parameters = self.parameters.as_ref();
 
-        self.threat_stack[self.index].refresh(board, Color::White);
-        self.threat_stack[self.index].refresh(board, Color::Black);
+        self.pst_stack[self.index].refresh(board, Color::White, &mut self.cache, parameters);
+        self.pst_stack[self.index].refresh(board, Color::Black, &mut self.cache, parameters);
+
+        self.threat_stack[self.index].refresh(board, Color::White, parameters);
+        self.threat_stack[self.index].refresh(board, Color::Black, parameters);
     }
 
     pub fn evaluate(&mut self, board: &Board) -> i32 {
@@ -142,12 +174,12 @@ impl Network {
 
             match self.can_update_pst(pov) {
                 Some(index) => self.update_pst_accumulator(index, board, pov),
-                None => self.pst_stack[self.index].refresh(board, pov, &mut self.cache),
+                None => self.pst_stack[self.index].refresh(board, pov, &mut self.cache, self.parameters.as_ref()),
             }
 
             match self.can_update_threats(pov) {
                 Some(index) => self.update_threat_accumulator(index, board, pov),
-                None => self.threat_stack[self.index].refresh(board, pov),
+                None => self.threat_stack[self.index].refresh(board, pov, self.parameters.as_ref()),
             }
         }
 
@@ -156,20 +188,22 @@ impl Network {
 
     fn update_pst_accumulator(&mut self, accurate: usize, board: &Board, pov: Color) {
         let king = board.king_square(pov);
+        let parameters = self.parameters.as_ref();
 
         for i in accurate..self.index {
             if let (prev, [current, ..]) = self.pst_stack.split_at_mut(i + 1) {
-                current.update(&prev[i], board, king, pov);
+                current.update(&prev[i], board, king, pov, parameters);
             }
         }
     }
 
     fn update_threat_accumulator(&mut self, accurate: usize, board: &Board, pov: Color) {
         let king = board.king_square(pov);
+        let parameters = self.parameters.as_ref();
 
         for i in accurate..self.index {
             if let (prev, [current, ..]) = self.threat_stack.split_at_mut(i + 1) {
-                unsafe { current.update(&prev[i], king, pov) };
+                unsafe { current.update(&prev[i], king, pov, parameters) };
             }
         }
     }
@@ -220,15 +254,16 @@ impl Network {
 
     fn output_transformer(&self, board: &Board) -> i32 {
         let bucket = OUTPUT_BUCKETS_LAYOUT[board.occupancies().popcount()];
+        let parameters = self.parameters.as_ref();
 
         unsafe {
             let ft_out =
                 forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
 
-            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket);
-            let l2_out = forward::propagate_l2(l1_out, bucket);
-            let l3_out = forward::propagate_l3(l2_out, bucket);
+            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l2_out = forward::propagate_l2(l1_out, bucket, parameters);
+            let l3_out = forward::propagate_l3(l2_out, bucket, parameters);
 
             (l3_out * NETWORK_SCALE as f32) as i32
         }
@@ -238,13 +273,15 @@ impl Network {
         self.full_refresh(board);
         self.evaluate(board); // just to update internal state
 
+        let parameters = self.parameters.as_ref();
+
         unsafe {
             let ft_out =
                 forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
-            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket);
-            let l2_out = forward::propagate_l2(l1_out, bucket);
-            let l3_out = forward::propagate_l3(l2_out, bucket);
+            let l1_out = forward::propagate_l1(ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l2_out = forward::propagate_l2(l1_out, bucket, parameters);
+            let l3_out = forward::propagate_l3(l2_out, bucket, parameters);
             (l3_out * NETWORK_SCALE as f32) as i32
         }
     }
@@ -271,33 +308,6 @@ impl Network {
     }
 }
 
-impl Default for Network {
-    fn default() -> Self {
-        let mut nnz_table = vec![SparseEntry { indexes: [0; 8], count: 0 }; 256];
-
-        for (byte, entry) in nnz_table.iter_mut().enumerate() {
-            let mut count = 0;
-
-            for bit in 0..8 {
-                if (byte & (1 << bit)) != 0 {
-                    entry.indexes[count] = bit as u16;
-                    count += 1;
-                }
-            }
-
-            entry.count = count;
-        }
-
-        Self {
-            index: 0,
-            pst_stack: vec![PstAccumulator::new(); MAX_PLY].into_boxed_slice(),
-            threat_stack: vec![ThreatAccumulator::new(); MAX_PLY].into_boxed_slice(),
-            cache: AccumulatorCache::default(),
-            nnz_table: nnz_table.into_boxed_slice(),
-        }
-    }
-}
-
 impl BoardObserver for Network {
     fn on_piece_move(&mut self, board: &Board, piece: Piece, from: Square, to: Square) {
         push_threats_on_move(&mut self.threat_stack[self.index], board, piece, from, to);
@@ -313,7 +323,7 @@ impl BoardObserver for Network {
 }
 
 #[repr(C)]
-struct Parameters {
+pub struct Parameters {
     ft_threat_weights: Aligned<[[i8; L1_SIZE]; 66864]>,
     ft_piece_weights: Aligned<[[i16; L1_SIZE]; INPUT_BUCKETS * 768]>,
     ft_biases: Aligned<[i16; L1_SIZE]>,
@@ -325,10 +335,68 @@ struct Parameters {
     l3_biases: Aligned<[f32; OUTPUT_BUCKETS]>,
 }
 
-static PARAMETERS: Parameters = unsafe { std::mem::transmute(*include_bytes!(env!("MODEL"))) };
+impl Parameters {
+    fn embedded() -> &'static Parameters {
+        static EMBEDDED: Parameters = unsafe { std::mem::transmute(*include_bytes!(env!("MODEL"))) };
+        &EMBEDDED
+    }
+
+    fn allocate_owned() -> Arc<Self> {
+        let mut boxed = Box::<std::mem::MaybeUninit<Parameters>>::new(std::mem::MaybeUninit::uninit());
+        let ptr = boxed.as_mut_ptr();
+        std::mem::forget(boxed);
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(Self::embedded() as *const Parameters, ptr, 1);
+            Arc::from(Box::from_raw(ptr))
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ParametersHandle {
+    inner: ParametersStorage,
+}
+
+#[derive(Clone)]
+enum ParametersStorage {
+    Embedded(&'static Parameters),
+    Owned(Arc<Parameters>),
+}
+
+impl ParametersHandle {
+    fn embedded() -> Self {
+        Self { inner: ParametersStorage::Embedded(Parameters::embedded()) }
+    }
+
+    fn owned(parameters: Arc<Parameters>) -> Self {
+        Self { inner: ParametersStorage::Owned(parameters) }
+    }
+}
+
+impl std::ops::Deref for ParametersHandle {
+    type Target = Parameters;
+
+    fn deref(&self) -> &Self::Target {
+        match &self.inner {
+            ParametersStorage::Embedded(parameters) => parameters,
+            ParametersStorage::Owned(parameters) => parameters.as_ref(),
+        }
+    }
+}
+
+impl NumaReplicable for ParametersHandle {
+    fn allocate() -> Arc<Self> {
+        Arc::new(Self::owned(Parameters::allocate_owned()))
+    }
+
+    fn allocate_shared() -> Option<Arc<Self>> {
+        Arc::new(Self::embedded()).into()
+    }
+}
 
 #[repr(align(64))]
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 struct Aligned<T> {
     data: T,
 }

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -33,7 +33,7 @@ pub struct CacheEntry {
 impl CacheEntry {
     pub fn new(parameters: &Parameters) -> Self {
         Self {
-            values: parameters.ft_biases.clone(),
+            values: parameters.ft_biases,
             pieces: [Bitboard::default(); PieceType::NUM],
             colors: [Bitboard::default(); Color::NUM],
         }

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -1,4 +1,4 @@
-use super::{Aligned, L1_SIZE, PARAMETERS, simd};
+use super::{Aligned, L1_SIZE, Parameters, simd};
 use crate::{
     nnue::INPUT_BUCKETS,
     types::{Bitboard, Color, PieceType},
@@ -10,22 +10,30 @@ pub mod threats;
 pub use psq::PstAccumulator;
 pub use threats::ThreatAccumulator;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct AccumulatorCache {
     entries: Box<[[[CacheEntry; INPUT_BUCKETS]; 2]; 2]>,
 }
 
-#[derive(Clone)]
+impl AccumulatorCache {
+    pub fn new(parameters: &Parameters) -> Self {
+        Self {
+            entries: Box::new([[[CacheEntry::new(parameters); INPUT_BUCKETS]; 2]; 2]),
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
 pub struct CacheEntry {
     values: Aligned<[i16; L1_SIZE]>,
     pieces: [Bitboard; PieceType::NUM],
     colors: [Bitboard; Color::NUM],
 }
 
-impl Default for CacheEntry {
-    fn default() -> Self {
+impl CacheEntry {
+    pub fn new(parameters: &Parameters) -> Self {
         Self {
-            values: PARAMETERS.ft_biases.clone(),
+            values: parameters.ft_biases.clone(),
             pieces: [Bitboard::default(); PieceType::NUM],
             colors: [Bitboard::default(); Color::NUM],
         }

--- a/src/nnue/accumulator/psq.rs
+++ b/src/nnue/accumulator/psq.rs
@@ -176,6 +176,7 @@ impl PstAccumulator {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add2_sub2(
         &mut self, prev: &Self, add1: PstFeature, add2: PstFeature, sub1: PstFeature, sub2: PstFeature, pov: Color,
         parameters: &Parameters,

--- a/src/nnue/accumulator/psq.rs
+++ b/src/nnue/accumulator/psq.rs
@@ -1,7 +1,7 @@
-use super::{Aligned, L1_SIZE, PARAMETERS};
+use super::{Aligned, L1_SIZE};
 use crate::{
     board::Board,
-    nnue::{AccumulatorCache, INPUT_BUCKETS_LAYOUT, accumulator::CacheEntry, simd},
+    nnue::{AccumulatorCache, INPUT_BUCKETS_LAYOUT, Parameters, accumulator::CacheEntry, simd},
     types::{ArrayVec, Bitboard, Color, Move, MoveKind, Piece, PieceType, Square},
 };
 
@@ -22,15 +22,15 @@ pub struct PstAccumulator {
 }
 
 impl PstAccumulator {
-    pub fn new() -> Self {
+    pub fn new(parameters: &Parameters) -> Self {
         Self {
-            values: Aligned::new([PARAMETERS.ft_biases.data; 2]),
+            values: Aligned::new([parameters.ft_biases.data; 2]),
             delta: PstDelta { mv: Move::NULL, piece: Piece::None, captured: Piece::None },
             accurate: [false; 2],
         }
     }
 
-    pub fn refresh(&mut self, board: &Board, pov: Color, cache: &mut AccumulatorCache) {
+    pub fn refresh(&mut self, board: &Board, pov: Color, cache: &mut AccumulatorCache, parameters: &Parameters) {
         let king = board.king_square(pov);
 
         let entry = &mut cache.entries[pov][(king.is_kingside()) as usize]
@@ -57,7 +57,7 @@ impl PstAccumulator {
             }
         }
 
-        unsafe { apply_changes(entry, adds, subs) };
+        unsafe { apply_changes(entry, adds, subs, parameters) };
 
         entry.pieces = board.pieces_bbs();
         entry.colors = board.colors_bbs();
@@ -102,7 +102,7 @@ impl PstAccumulator {
         }
     }
 
-    pub fn update(&mut self, prev: &Self, board: &Board, king: Square, pov: Color) {
+    pub fn update(&mut self, prev: &Self, board: &Board, king: Square, pov: Color, parameters: &Parameters) {
         let PstDelta { mv, piece, captured } = self.delta;
 
         let resulting_piece = if mv.is_promotion() { mv.promo_piece_type() } else { piece.piece_type() };
@@ -117,11 +117,11 @@ impl PstAccumulator {
                 let add2 = pst_index(piece.color(), PieceType::Rook, rook_to, king, pov);
                 let sub2 = pst_index(piece.color(), PieceType::Rook, rook_from, king, pov);
 
-                self.add2_sub2(prev, add1, add2, sub1, sub2, pov);
+                self.add2_sub2(prev, add1, add2, sub1, sub2, pov, parameters);
             }
             MoveKind::EnPassant => {
                 let sub2 = pst_index(!piece.color(), PieceType::Pawn, mv.to() ^ 8, king, pov);
-                self.add1_sub2(prev, add1, sub1, sub2, pov);
+                self.add1_sub2(prev, add1, sub1, sub2, pov, parameters);
             }
             MoveKind::Capture
             | MoveKind::PromotionCaptureN
@@ -129,20 +129,20 @@ impl PstAccumulator {
             | MoveKind::PromotionCaptureR
             | MoveKind::PromotionCaptureQ => {
                 let sub2 = pst_index(!piece.color(), captured.piece_type(), mv.to(), king, pov);
-                self.add1_sub2(prev, add1, sub1, sub2, pov);
+                self.add1_sub2(prev, add1, sub1, sub2, pov, parameters);
             }
-            _ => self.add1_sub1(prev, add1, sub1, pov),
+            _ => self.add1_sub1(prev, add1, sub1, pov, parameters),
         }
 
         self.accurate[pov] = true;
     }
 
-    fn add1_sub1(&mut self, prev: &Self, add1: PstFeature, sub1: PstFeature, pov: Color) {
+    fn add1_sub1(&mut self, prev: &Self, add1: PstFeature, sub1: PstFeature, pov: Color, parameters: &Parameters) {
         let vacc = self.values[pov].as_mut_ptr();
         let vprev = prev.values[pov].as_ptr();
 
-        let vadd1 = PARAMETERS.ft_piece_weights[add1 as usize].as_ptr();
-        let vsub1 = PARAMETERS.ft_piece_weights[sub1 as usize].as_ptr();
+        let vadd1 = parameters.ft_piece_weights[add1 as usize].as_ptr();
+        let vsub1 = parameters.ft_piece_weights[sub1 as usize].as_ptr();
 
         for i in (0..L1_SIZE).step_by(simd::I16_LANES) {
             unsafe {
@@ -154,13 +154,16 @@ impl PstAccumulator {
         }
     }
 
-    fn add1_sub2(&mut self, prev: &Self, add1: PstFeature, sub1: PstFeature, sub2: PstFeature, pov: Color) {
+    fn add1_sub2(
+        &mut self, prev: &Self, add1: PstFeature, sub1: PstFeature, sub2: PstFeature, pov: Color,
+        parameters: &Parameters,
+    ) {
         let vacc = self.values[pov].as_mut_ptr();
         let vprev = prev.values[pov].as_ptr();
 
-        let vadd1 = PARAMETERS.ft_piece_weights[add1 as usize].as_ptr();
-        let vsub1 = PARAMETERS.ft_piece_weights[sub1 as usize].as_ptr();
-        let vsub2 = PARAMETERS.ft_piece_weights[sub2 as usize].as_ptr();
+        let vadd1 = parameters.ft_piece_weights[add1 as usize].as_ptr();
+        let vsub1 = parameters.ft_piece_weights[sub1 as usize].as_ptr();
+        let vsub2 = parameters.ft_piece_weights[sub2 as usize].as_ptr();
 
         for i in (0..L1_SIZE).step_by(simd::I16_LANES) {
             unsafe {
@@ -175,14 +178,15 @@ impl PstAccumulator {
 
     fn add2_sub2(
         &mut self, prev: &Self, add1: PstFeature, add2: PstFeature, sub1: PstFeature, sub2: PstFeature, pov: Color,
+        parameters: &Parameters,
     ) {
         let vacc = self.values[pov].as_mut_ptr();
         let vprev = prev.values[pov].as_ptr();
 
-        let vadd1 = PARAMETERS.ft_piece_weights[add1 as usize].as_ptr();
-        let vadd2 = PARAMETERS.ft_piece_weights[add2 as usize].as_ptr();
-        let vsub1 = PARAMETERS.ft_piece_weights[sub1 as usize].as_ptr();
-        let vsub2 = PARAMETERS.ft_piece_weights[sub2 as usize].as_ptr();
+        let vadd1 = parameters.ft_piece_weights[add1 as usize].as_ptr();
+        let vadd2 = parameters.ft_piece_weights[add2 as usize].as_ptr();
+        let vsub1 = parameters.ft_piece_weights[sub1 as usize].as_ptr();
+        let vsub2 = parameters.ft_piece_weights[sub2 as usize].as_ptr();
 
         for i in (0..L1_SIZE).step_by(simd::I16_LANES) {
             unsafe {
@@ -199,7 +203,9 @@ impl PstAccumulator {
 const REGISTERS: usize = 8;
 const _: () = assert!(L1_SIZE.is_multiple_of(REGISTERS * simd::I16_LANES));
 
-unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<PstFeature, 64>, subs: ArrayVec<PstFeature, 64>) {
+unsafe fn apply_changes(
+    entry: &mut CacheEntry, adds: ArrayVec<PstFeature, 64>, subs: ArrayVec<PstFeature, 64>, parameters: &Parameters,
+) {
     let mut registers: [_; REGISTERS] = std::mem::zeroed();
 
     for offset in (0..L1_SIZE).step_by(REGISTERS * simd::I16_LANES) {
@@ -210,7 +216,7 @@ unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<PstFeature, 64>, 
         }
 
         for &add in adds.iter() {
-            let weights = PARAMETERS.ft_piece_weights[add as usize].as_ptr().add(offset);
+            let weights = parameters.ft_piece_weights[add as usize].as_ptr().add(offset);
 
             for (i, register) in registers.iter_mut().enumerate() {
                 *register = simd::add_i16(*register, *weights.add(i * simd::I16_LANES).cast());
@@ -218,7 +224,7 @@ unsafe fn apply_changes(entry: &mut CacheEntry, adds: ArrayVec<PstFeature, 64>, 
         }
 
         for &sub in subs.iter() {
-            let weights = PARAMETERS.ft_piece_weights[sub as usize].as_ptr().add(offset);
+            let weights = parameters.ft_piece_weights[sub as usize].as_ptr().add(offset);
 
             for (i, register) in registers.iter_mut().enumerate() {
                 *register = simd::sub_i16(*register, *weights.add(i * simd::I16_LANES).cast());

--- a/src/nnue/accumulator/threats.rs
+++ b/src/nnue/accumulator/threats.rs
@@ -1,7 +1,8 @@
-use super::{Aligned, L1_SIZE, PARAMETERS, simd};
+use super::{Aligned, L1_SIZE, simd};
 use crate::{
     board::Board,
     lookup::attacks,
+    nnue::Parameters,
     types::{ArrayVec, Color, Piece, Square},
 };
 
@@ -70,7 +71,7 @@ impl ThreatAccumulator {
         }
     }
 
-    pub fn refresh(&mut self, board: &Board, pov: Color) {
+    pub fn refresh(&mut self, board: &Board, pov: Color, parameters: &Parameters) {
         let king = board.king_square(pov);
 
         let mut adds = ArrayVec::<usize, 8196>::new();
@@ -105,8 +106,8 @@ impl ThreatAccumulator {
                     let add1 = adds[add_idx];
                     let add2 = adds[add_idx + 1];
 
-                    let vadd1 = PARAMETERS.ft_threat_weights[add1].as_ptr().add(offset);
-                    let vadd2 = PARAMETERS.ft_threat_weights[add2].as_ptr().add(offset);
+                    let vadd1 = parameters.ft_threat_weights[add1].as_ptr().add(offset);
+                    let vadd2 = parameters.ft_threat_weights[add2].as_ptr().add(offset);
 
                     for (i, register) in registers.iter_mut().enumerate() {
                         let add1_weights = simd::convert_i8_i16(*vadd1.add(i * simd::I16_LANES).cast());
@@ -118,7 +119,7 @@ impl ThreatAccumulator {
                 }
 
                 while add_idx < adds.len() {
-                    let vadd = PARAMETERS.ft_threat_weights[adds[add_idx]].as_ptr().add(offset);
+                    let vadd = parameters.ft_threat_weights[adds[add_idx]].as_ptr().add(offset);
 
                     for (i, register) in registers.iter_mut().enumerate() {
                         let add_weights = simd::convert_i8_i16(*vadd.add(i * simd::I16_LANES).cast());
@@ -137,7 +138,7 @@ impl ThreatAccumulator {
         self.accurate[pov] = true;
     }
 
-    pub unsafe fn update(&mut self, prev: &Self, king: Square, pov: Color) {
+    pub unsafe fn update(&mut self, prev: &Self, king: Square, pov: Color, parameters: &Parameters) {
         let mut adds = ArrayVec::<usize, 256>::new();
         let mut subs = ArrayVec::<usize, 256>::new();
 
@@ -175,8 +176,8 @@ impl ThreatAccumulator {
                 let add = adds[add_idx];
                 let sub = subs[sub_idx];
 
-                let vadd = PARAMETERS.ft_threat_weights[add].as_ptr().add(offset);
-                let vsub = PARAMETERS.ft_threat_weights[sub].as_ptr().add(offset);
+                let vadd = parameters.ft_threat_weights[add].as_ptr().add(offset);
+                let vsub = parameters.ft_threat_weights[sub].as_ptr().add(offset);
 
                 for (i, register) in registers.iter_mut().enumerate() {
                     let add_weights = simd::convert_i8_i16(*vadd.add(i * simd::I16_LANES).cast());
@@ -189,7 +190,7 @@ impl ThreatAccumulator {
             }
 
             while add_idx < adds.len() {
-                let vadd = PARAMETERS.ft_threat_weights[adds[add_idx]].as_ptr().add(offset);
+                let vadd = parameters.ft_threat_weights[adds[add_idx]].as_ptr().add(offset);
 
                 for (i, register) in registers.iter_mut().enumerate() {
                     let add_weights = simd::convert_i8_i16(*vadd.add(i * simd::I16_LANES).cast());
@@ -200,7 +201,7 @@ impl ThreatAccumulator {
             }
 
             while sub_idx < subs.len() {
-                let vsub = PARAMETERS.ft_threat_weights[subs[sub_idx]].as_ptr().add(offset);
+                let vsub = parameters.ft_threat_weights[subs[sub_idx]].as_ptr().add(offset);
 
                 for (i, register) in registers.iter_mut().enumerate() {
                     let sub_weights = simd::convert_i8_i16(*vsub.add(i * simd::I16_LANES).cast());

--- a/src/nnue/forward/scalar.rs
+++ b/src/nnue/forward/scalar.rs
@@ -25,7 +25,7 @@ pub fn activate_ft(pst: &PstAccumulator, threat: &ThreatAccumulator, stm: Color)
 }
 
 pub unsafe fn propagate_l1(
-    ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
+    ft_out: &Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
 ) -> Aligned<[f32; L2_SIZE]> {
     const CHUNKS: usize = 4;
 
@@ -62,7 +62,7 @@ pub unsafe fn propagate_l1(
 }
 
 pub fn propagate_l2(
-    l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+    l1_out: &Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
 ) -> Aligned<[f32; L3_SIZE]> {
     let mut output = Aligned::new([0.0; L3_SIZE]);
 
@@ -79,7 +79,7 @@ pub fn propagate_l2(
     output
 }
 
-pub fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
+pub fn propagate_l3(l2_out: &Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
     let mut output = 0.0;
     for i in 0..L3_SIZE {
         output = parameters.l3_weights[bucket][i].mul_add(l2_out[i], output);

--- a/src/nnue/forward/scalar.rs
+++ b/src/nnue/forward/scalar.rs
@@ -1,6 +1,6 @@
 use crate::{
     nnue::{
-        Aligned, DEQUANT_MULTIPLIER, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, PARAMETERS, SparseEntry,
+        Aligned, DEQUANT_MULTIPLIER, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, Parameters, SparseEntry,
         accumulator::{PstAccumulator, ThreatAccumulator},
     },
     types::Color,
@@ -24,7 +24,9 @@ pub fn activate_ft(pst: &PstAccumulator, threat: &ThreatAccumulator, stm: Color)
     output
 }
 
-pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize) -> Aligned<[f32; L2_SIZE]> {
+pub unsafe fn propagate_l1(
+    ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
+) -> Aligned<[f32; L2_SIZE]> {
     const CHUNKS: usize = 4;
 
     let mut pre_activations = [0i32; L2_SIZE];
@@ -34,7 +36,7 @@ pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: 
     for i in 0..nnz.len() {
         let index = *nnz.get_unchecked(i) as usize;
         let input = packed.get_unchecked(index);
-        let weights = &PARAMETERS.l1_weights[bucket][index * L2_SIZE * CHUNKS..];
+        let weights = &parameters.l1_weights[bucket][index * L2_SIZE * CHUNKS..];
 
         for j in 0..L2_SIZE {
             let mut vector = 0;
@@ -53,34 +55,36 @@ pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: 
     let mut output = Aligned::new([0.0; L2_SIZE]);
 
     for i in 0..L2_SIZE {
-        output[i] = (pre_activations[i] as f32 * DEQUANT_MULTIPLIER + PARAMETERS.l1_biases[bucket][i]).clamp(0.0, 1.0);
+        output[i] = (pre_activations[i] as f32 * DEQUANT_MULTIPLIER + parameters.l1_biases[bucket][i]).clamp(0.0, 1.0);
     }
 
     output
 }
 
-pub fn propagate_l2(l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize) -> Aligned<[f32; L3_SIZE]> {
+pub fn propagate_l2(
+    l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+) -> Aligned<[f32; L3_SIZE]> {
     let mut output = Aligned::new([0.0; L3_SIZE]);
 
     for i in 0..L2_SIZE {
         for j in 0..L3_SIZE {
-            output[j] += PARAMETERS.l2_weights[bucket][i][j] * l1_out[i];
+            output[j] += parameters.l2_weights[bucket][i][j] * l1_out[i];
         }
     }
 
     for i in 0..L3_SIZE {
-        output[i] += PARAMETERS.l2_biases[bucket][i];
+        output[i] += parameters.l2_biases[bucket][i];
         output[i] = output[i].clamp(0.0, 1.0);
     }
     output
 }
 
-pub fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize) -> f32 {
+pub fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
     let mut output = 0.0;
     for i in 0..L3_SIZE {
-        output = PARAMETERS.l3_weights[bucket][i].mul_add(l2_out[i], output);
+        output = parameters.l3_weights[bucket][i].mul_add(l2_out[i], output);
     }
-    output + PARAMETERS.l3_biases[bucket]
+    output + parameters.l3_biases[bucket]
 }
 
 pub unsafe fn find_nnz(ft_out: &Aligned<[u8; L1_SIZE]>, _: &[SparseEntry]) -> (Aligned<[u16; L1_SIZE / 4]>, usize) {

--- a/src/nnue/forward/vectorized.rs
+++ b/src/nnue/forward/vectorized.rs
@@ -53,7 +53,7 @@ pub unsafe fn activate_ft(pst: &PstAccumulator, threat: &ThreatAccumulator, stm:
 }
 
 pub unsafe fn propagate_l1(
-    ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
+    ft_out: &Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
 ) -> Aligned<[f32; L2_SIZE]> {
     const CHUNKS: usize = 4;
 
@@ -110,7 +110,7 @@ pub unsafe fn propagate_l1(
 }
 
 pub unsafe fn propagate_l2(
-    l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+    l1_out: &Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
 ) -> Aligned<[f32; L3_SIZE]> {
     let mut output = Aligned::new(parameters.l2_biases[bucket]);
 
@@ -136,7 +136,7 @@ pub unsafe fn propagate_l2(
     output
 }
 
-pub unsafe fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
+pub unsafe fn propagate_l3(l2_out: &Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
     const LANES: usize = 16 / simd::F32_LANES;
 
     let input = l2_out.as_ptr();

--- a/src/nnue/forward/vectorized.rs
+++ b/src/nnue/forward/vectorized.rs
@@ -1,6 +1,6 @@
 use crate::{
     nnue::{
-        Aligned, DEQUANT_MULTIPLIER, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, PARAMETERS, SparseEntry,
+        Aligned, DEQUANT_MULTIPLIER, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, Parameters, SparseEntry,
         accumulator::{PstAccumulator, ThreatAccumulator},
         simd,
     },
@@ -52,7 +52,9 @@ pub unsafe fn activate_ft(pst: &PstAccumulator, threat: &ThreatAccumulator, stm:
     output
 }
 
-pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize) -> Aligned<[f32; L2_SIZE]> {
+pub unsafe fn propagate_l1(
+    ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
+) -> Aligned<[f32; L2_SIZE]> {
     const CHUNKS: usize = 4;
 
     let mut pre_activations = Aligned::new([simd::zeroed(); L2_SIZE / simd::F32_LANES]);
@@ -68,8 +70,8 @@ pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: 
         let input1 = simd::splat_i32(*packed.get_unchecked(index1));
         let input2 = simd::splat_i32(*packed.get_unchecked(index2));
 
-        let weights1 = PARAMETERS.l1_weights[bucket].as_ptr().add(index1 * L2_SIZE * CHUNKS);
-        let weights2 = PARAMETERS.l1_weights[bucket].as_ptr().add(index2 * L2_SIZE * CHUNKS);
+        let weights1 = parameters.l1_weights[bucket].as_ptr().add(index1 * L2_SIZE * CHUNKS);
+        let weights2 = parameters.l1_weights[bucket].as_ptr().add(index2 * L2_SIZE * CHUNKS);
 
         for j in (0..L2_SIZE).step_by(simd::F32_LANES) {
             let weights1 = *weights1.add(j * CHUNKS).cast();
@@ -83,7 +85,7 @@ pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: 
     if let Some(last) = pairs.remainder().first() {
         let index = *last as usize;
         let input = simd::splat_i32(*packed.get_unchecked(index));
-        let weights = PARAMETERS.l1_weights[bucket].as_ptr().add(index * L2_SIZE * CHUNKS);
+        let weights = parameters.l1_weights[bucket].as_ptr().add(index * L2_SIZE * CHUNKS);
 
         for j in (0..L2_SIZE).step_by(simd::F32_LANES) {
             let weights = *weights.add(j * CHUNKS).cast();
@@ -99,7 +101,7 @@ pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: 
     let dequant = simd::splat_f32(DEQUANT_MULTIPLIER);
 
     for i in (0..L2_SIZE).step_by(simd::F32_LANES) {
-        let biases = *PARAMETERS.l1_biases[bucket].as_ptr().add(i).cast();
+        let biases = *parameters.l1_biases[bucket].as_ptr().add(i).cast();
         let vector = simd::mul_add_f32(simd::convert_to_f32(pre_activations[i / simd::F32_LANES]), dequant, biases);
         *output.as_mut_ptr().add(i).cast() = simd::clamp_f32(vector, zero, one);
     }
@@ -107,12 +109,14 @@ pub unsafe fn propagate_l1(ft_out: Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: 
     output
 }
 
-pub unsafe fn propagate_l2(l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize) -> Aligned<[f32; L3_SIZE]> {
-    let mut output = Aligned::new(PARAMETERS.l2_biases[bucket]);
+pub unsafe fn propagate_l2(
+    l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+) -> Aligned<[f32; L3_SIZE]> {
+    let mut output = Aligned::new(parameters.l2_biases[bucket]);
 
     for i in 0..L2_SIZE {
         let input = simd::splat_f32(l1_out[i]);
-        let weights = PARAMETERS.l2_weights[bucket][i].as_ptr();
+        let weights = parameters.l2_weights[bucket][i].as_ptr();
 
         for j in (0..L3_SIZE).step_by(simd::F32_LANES) {
             let weights = *weights.add(j).cast();
@@ -132,11 +136,11 @@ pub unsafe fn propagate_l2(l1_out: Aligned<[f32; L2_SIZE]>, bucket: usize) -> Al
     output
 }
 
-pub unsafe fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize) -> f32 {
+pub unsafe fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
     const LANES: usize = 16 / simd::F32_LANES;
 
     let input = l2_out.as_ptr();
-    let weights = PARAMETERS.l3_weights[bucket].as_ptr();
+    let weights = parameters.l3_weights[bucket].as_ptr();
 
     let mut output = [simd::zero_f32(); LANES];
 
@@ -149,7 +153,7 @@ pub unsafe fn propagate_l3(l2_out: Aligned<[f32; L3_SIZE]>, bucket: usize) -> f3
         }
     }
 
-    simd::horizontal_sum(output) + PARAMETERS.l3_biases[bucket]
+    simd::horizontal_sum(output) + parameters.l3_biases[bucket]
 }
 
 #[cfg(all(not(target_feature = "neon"), not(target_feature = "avx512vbmi2")))]

--- a/src/numa.rs
+++ b/src/numa.rs
@@ -1,170 +1,376 @@
-#[cfg(feature = "numa")]
-use std::{collections::HashMap, sync::OnceLock};
+#![allow(dead_code)]
+#![allow(unused_mut)]
+#![allow(unused_imports)]
 
-#[cfg(feature = "numa")]
-static MAPPING: OnceLock<HashMap<usize, Vec<usize>>> = OnceLock::new();
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    sync::{
+        Arc, LazyLock, Mutex, RwLock,
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
+    thread,
+};
 
-#[cfg(feature = "numa")]
-fn mapping() -> HashMap<usize, Vec<usize>> {
-    fn initialize() -> HashMap<usize, Vec<usize>> {
-        let mut map = HashMap::new();
+pub trait NumaReplicable: Send + Sync + 'static {
+    fn allocate() -> Arc<Self>;
 
-        let max_node = unsafe { api::numa_max_node() as usize };
-        for node in 0..=max_node {
-            let mask = unsafe { api::numa_allocate_cpumask() };
-            unsafe { api::numa_node_to_cpus(node as i32, mask) };
+    fn allocate_shared() -> Option<Arc<Self>> {
+        None
+    }
+}
 
-            let mut cpus = Vec::new();
-            for cpu in 0..libc::CPU_SETSIZE {
-                if unsafe { api::numa_bitmask_isbitset(mask, cpu) } != 0 {
-                    cpus.push(cpu as usize);
+type CpuIndex = usize;
+type NumaIndex = usize;
+
+static SYSTEM_THREADS: LazyLock<CpuIndex> =
+    LazyLock::new(|| thread::available_parallelism().map(|x| x.get()).unwrap_or(1).max(1));
+
+#[cfg(all(target_os = "linux", not(target_os = "android")))]
+static PROCESSOR_AFFINITY: LazyLock<BTreeSet<CpuIndex>> = LazyLock::new(get_process_affinity);
+
+#[cfg(all(target_os = "linux", not(target_os = "android")))]
+fn get_process_affinity() -> BTreeSet<CpuIndex> {
+    use libc::{CPU_ISSET, CPU_SETSIZE, CPU_ZERO, cpu_set_t, sched_getaffinity};
+
+    let mut mask: cpu_set_t = unsafe { std::mem::zeroed() };
+    unsafe { CPU_ZERO(&mut mask) };
+
+    let status = unsafe { sched_getaffinity(0, std::mem::size_of::<cpu_set_t>(), &mut mask as *mut cpu_set_t) };
+    if status != 0 {
+        panic!("sched_getaffinity failed");
+    }
+
+    (0..(CPU_SETSIZE as usize)).filter(|&cpu| unsafe { CPU_ISSET(cpu, &mask) }).collect::<BTreeSet<CpuIndex>>()
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct NumaReplicatedAccessToken {
+    index: NumaIndex,
+}
+
+impl NumaReplicatedAccessToken {
+    pub fn new(index: NumaIndex) -> Self {
+        Self { index }
+    }
+}
+
+#[derive(Clone)]
+pub struct NumaConfig {
+    nodes: Vec<BTreeSet<CpuIndex>>,
+    node_by_cpu: BTreeMap<CpuIndex, NumaIndex>,
+    highest_cpu_index: CpuIndex,
+}
+
+impl Default for NumaConfig {
+    fn default() -> Self {
+        let mut cfg = Self::empty();
+        for cpu in 0..*SYSTEM_THREADS {
+            cfg.add_cpu_to_node(0, cpu);
+        }
+        cfg
+    }
+}
+
+impl NumaConfig {
+    pub fn empty() -> Self {
+        Self {
+            nodes: Vec::new(),
+            node_by_cpu: BTreeMap::new(),
+            highest_cpu_index: 0,
+        }
+    }
+
+    pub fn from_system() -> Self {
+        // Fallback for unsupported systems.
+        #[cfg(not(all(target_os = "linux", not(target_os = "android"))))]
+        return Self::default();
+
+        #[cfg(all(target_os = "linux", not(target_os = "android")))]
+        {
+            let mut cfg = NumaConfig::from_system_numa();
+            cfg.remove_empty_numa_nodes();
+            cfg
+        }
+    }
+
+    pub fn num_numa_nodes(&self) -> NumaIndex {
+        self.nodes.len()
+    }
+
+    pub fn requires_memory_replication(&self) -> bool {
+        self.nodes.len() > 1
+    }
+
+    pub fn suggests_binding_threads(&self, threads: CpuIndex) -> bool {
+        if !self.requires_memory_replication() || threads <= 1 {
+            return false;
+        }
+
+        let largest_node_size = self.nodes.iter().map(|node| node.len()).max().unwrap_or(0);
+
+        let is_node_sufficient = |node: &BTreeSet<CpuIndex>| {
+            const NODE_THRESHOLD: f64 = 0.6;
+            (node.len() as f64) / (largest_node_size as f64) > NODE_THRESHOLD
+        };
+
+        let sufficient_nodes = self.nodes.iter().filter(|node| is_node_sufficient(node)).count();
+        threads > largest_node_size / 2 || threads >= 4 * sufficient_nodes
+    }
+
+    pub fn distribute_threads_among_numa_nodes(&self, num_threads: CpuIndex) -> Vec<NumaIndex> {
+        if self.nodes.len() == 1 {
+            return vec![0; num_threads];
+        }
+
+        let mut nodes = Vec::new();
+        let mut occupation = vec![0usize; self.nodes.len()];
+
+        for _ in 0..num_threads {
+            let mut best_node = 0;
+            let mut best_fill = f32::MAX;
+
+            for node in 0..self.nodes.len() {
+                let fill = (occupation[node] + 1) as f32 / self.nodes[node].len() as f32;
+                if fill < best_fill {
+                    best_node = node;
+                    best_fill = fill;
                 }
             }
 
-            unsafe { api::numa_bitmask_free(mask) };
+            nodes.push(best_node);
+            occupation[best_node] += 1;
+        }
 
-            if !cpus.is_empty() {
-                map.insert(node, cpus);
+        nodes
+    }
+
+    pub fn bind_current_thread_to_numa_node(&self, node: NumaIndex) -> NumaReplicatedAccessToken {
+        assert!(node < self.nodes.len() && !self.nodes[node].is_empty());
+
+        #[cfg(all(target_os = "linux", not(target_os = "android")))]
+        {
+            use libc::{CPU_SET, CPU_ZERO, cpu_set_t, sched_setaffinity, sched_yield};
+
+            let mut mask: cpu_set_t = unsafe { std::mem::zeroed() };
+            unsafe { CPU_ZERO(&mut mask) };
+
+            for cpu in &self.nodes[node] {
+                unsafe { CPU_SET(*cpu, &mut mask) };
+            }
+
+            let status = unsafe { sched_setaffinity(0, std::mem::size_of::<cpu_set_t>(), &mask as *const cpu_set_t) };
+            if status != 0 {
+                panic!("sched_setaffinity failed");
+            }
+
+            unsafe { sched_yield() };
+        }
+
+        NumaReplicatedAccessToken::new(node)
+    }
+
+    pub fn execute_on_numa_node<F: FnOnce() + Send + 'static>(&self, n: NumaIndex, f: F) {
+        let cfg = self.clone();
+        let handle = thread::spawn(move || {
+            cfg.bind_current_thread_to_numa_node(n);
+            f();
+        });
+        handle.join().unwrap();
+    }
+
+    fn add_cpu_to_node(&mut self, node: NumaIndex, cpu: CpuIndex) {
+        if self.nodes.len() <= node {
+            self.nodes.resize_with(node + 1, BTreeSet::new);
+        }
+
+        self.nodes[node].insert(cpu);
+        self.node_by_cpu.insert(cpu, node);
+        self.highest_cpu_index = self.highest_cpu_index.max(cpu);
+    }
+
+    fn remove_empty_numa_nodes(&mut self) {
+        self.nodes.retain(|cpus| !cpus.is_empty());
+
+        self.node_by_cpu.clear();
+        for (node, cpus) in self.nodes.iter().enumerate() {
+            for &cpu in cpus {
+                self.node_by_cpu.insert(cpu, node);
             }
         }
 
-        map
+        self.highest_cpu_index = self.node_by_cpu.keys().copied().max().unwrap_or(0);
     }
 
-    MAPPING.get_or_init(initialize).clone()
-}
+    fn from_system_numa() -> Self {
+        let mut cfg = NumaConfig::empty();
 
-#[cfg(feature = "numa")]
-pub fn bind_thread(id: usize) {
-    fn num_cpus() -> usize {
-        mapping().values().map(|cpus| cpus.len()).sum()
-    }
+        #[cfg(all(target_os = "linux", not(target_os = "android")))]
+        {
+            let fallback = || {
+                let mut cfg = NumaConfig::empty();
+                for cpu in 0..*SYSTEM_THREADS {
+                    if PROCESSOR_AFFINITY.contains(&cpu) {
+                        cfg.add_cpu_to_node(0, cpu);
+                    }
+                }
+                cfg
+            };
 
-    let id = id % num_cpus();
-    let node = mapping().iter().find_map(|(node, cpus)| cpus.contains(&id).then_some(*node)).unwrap_or(0);
+            let Ok(node_ids) = fs::read_to_string("/sys/devices/system/node/online").map(remove_whitespace) else {
+                return fallback();
+            };
 
-    unsafe {
-        api::numa_run_on_node(node as i32);
-        api::numa_set_preferred(node as i32);
-    }
-}
-
-/// Marker trait for types that can be safely replicated per NUMA node.
-///
-/// # Safety
-///
-/// Implementing `NumaValue` asserts that `T` may be replicated per NUMA node
-/// and safely accessed concurrently (i.e., `&T` must be `Sync`).
-pub unsafe trait NumaValue: Sync {}
-
-pub struct NumaReplicator<T: NumaValue> {
-    allocated: Vec<*mut T>,
-}
-
-unsafe impl<T: NumaValue> Send for NumaReplicator<T> {}
-unsafe impl<T: NumaValue> Sync for NumaReplicator<T> {}
-
-impl<T: NumaValue> NumaReplicator<T> {
-    #[cfg(feature = "numa")]
-    pub unsafe fn new<S: Fn() -> T>(source: S) -> Self {
-        if api::numa_available() < 0 {
-            panic!("NUMA is not available on this system");
-        }
-
-        let mut allocated = Vec::new();
-        let mut nodes = Vec::new();
-
-        for (node, cpus) in mapping() {
-            if cpus.is_empty() {
-                continue;
+            if node_ids.is_empty() {
+                return fallback();
             }
 
-            let ptr = api::numa_alloc_onnode(std::mem::size_of::<T>(), node as i32);
-            if ptr.is_null() {
-                panic!("Failed to allocate memory on NUMA node {node}");
+            for node in parse_cpu_indices(&node_ids) {
+                let path = format!("/sys/devices/system/node/node{node}/cpulist");
+                let cpu_ids = fs::read_to_string(&path);
+                if cpu_ids.is_err() {
+                    return fallback();
+                }
+
+                let cpu_ids = remove_whitespace(cpu_ids.unwrap());
+                for cpu in parse_cpu_indices(&cpu_ids) {
+                    if PROCESSOR_AFFINITY.contains(&cpu) {
+                        cfg.add_cpu_to_node(node, cpu);
+                    }
+                }
             }
-
-            let tptr = ptr as *mut T;
-            std::ptr::write(tptr, source());
-
-            allocated.push(tptr);
-            nodes.push(node);
         }
 
-        Self { allocated }
-    }
-
-    #[cfg(not(feature = "numa"))]
-    pub unsafe fn new<S: Fn() -> T>(source: S) -> Self {
-        let ptr = std::alloc::alloc(std::alloc::Layout::new::<T>()).cast::<T>();
-        assert!(!ptr.is_null(), "Failed to allocate memory for NumaReplicator");
-
-        std::ptr::write(ptr, source());
-
-        Self { allocated: vec![ptr] }
-    }
-
-    #[cfg(feature = "numa")]
-    pub unsafe fn get(&self) -> &T {
-        let cpu = libc::sched_getcpu();
-        let node = api::numa_node_of_cpu(cpu);
-
-        let index = mapping().iter().enumerate().find_map(|(i, (n, _))| (*n as i32 == node).then_some(i)).unwrap_or(0);
-        &*self.allocated[index]
-    }
-
-    #[cfg(not(feature = "numa"))]
-    pub unsafe fn get(&self) -> &T {
-        &*self.allocated[0]
-    }
-
-    pub unsafe fn get_all(&self) -> Vec<&T> {
-        self.allocated.iter().map(|&ptr| &*ptr).collect()
+        cfg
     }
 }
 
-impl<T: NumaValue> Drop for NumaReplicator<T> {
-    fn drop(&mut self) {
-        for &ptr in &self.allocated {
-            unsafe {
-                std::ptr::drop_in_place(ptr);
+fn parse_cpu_indices(cpu_ids: &str) -> Vec<usize> {
+    if cpu_ids.is_empty() {
+        return Vec::new();
+    }
 
-                #[cfg(feature = "numa")]
-                api::numa_free(ptr as *mut libc::c_void, std::mem::size_of::<T>());
-
-                #[cfg(not(feature = "numa"))]
-                std::alloc::dealloc(ptr.cast::<u8>(), std::alloc::Layout::new::<T>());
+    let mut indices = Vec::new();
+    for segment in cpu_ids.split(',').filter(|s| !s.is_empty()) {
+        let parts: Vec<_> = segment.split('-').collect();
+        match parts.len() {
+            1 => indices.push(parts[0].parse::<usize>().unwrap()),
+            2 => {
+                let first = parts[0].parse::<usize>().unwrap();
+                let last = parts[1].parse::<usize>().unwrap();
+                for cpu in first..=last {
+                    indices.push(cpu);
+                }
             }
+            _ => {}
         }
+    }
+    indices
+}
+
+fn remove_whitespace(s: String) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+pub trait NumaReplicatedBase: Send + Sync {
+    fn on_numa_config_changed(&self);
+    fn get_numa_config(&self) -> NumaConfig;
+}
+
+pub struct NumaReplicationContext {
+    config: RwLock<NumaConfig>,
+    thread_count: AtomicUsize,
+    tracked: Mutex<Vec<Arc<dyn NumaReplicatedBase>>>,
+}
+
+impl NumaReplicationContext {
+    pub fn new(cfg: NumaConfig) -> Self {
+        Self {
+            config: RwLock::new(cfg),
+            thread_count: AtomicUsize::new(1),
+            tracked: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn attach(&self, obj: Arc<dyn NumaReplicatedBase>) {
+        self.tracked.lock().unwrap().push(obj);
+    }
+
+    pub fn get_numa_config(&self) -> NumaConfig {
+        self.config.read().unwrap().clone()
+    }
+
+    pub fn set_thread_count(&self, threads: usize) {
+        let previous = self.thread_count.swap(threads, Ordering::Release);
+        if previous == threads {
+            return;
+        }
+
+        let tracked = self.tracked.lock().unwrap().clone();
+        for obj in tracked {
+            obj.on_numa_config_changed();
+        }
+    }
+
+    pub fn get_thread_count(&self) -> usize {
+        self.thread_count.load(Ordering::Acquire)
     }
 }
 
-#[allow(dead_code)]
-#[cfg(feature = "numa")]
-mod api {
-    use libc::{c_int, c_void, size_t};
+pub struct NumaReplicated<T: NumaReplicable> {
+    ctx: Arc<NumaReplicationContext>,
+    instances: RwLock<Vec<Arc<T>>>,
+}
 
-    #[repr(C)]
-    pub struct Bitmask {
-        size: c_int,
-        maskp: *mut u32,
+impl<T: NumaReplicable> NumaReplicated<T> {
+    pub fn new(ctx: Arc<NumaReplicationContext>) -> Arc<Self> {
+        let obj = Arc::new(Self { ctx, instances: RwLock::new(Vec::new()) });
+        obj.replicate_instances();
+        obj.ctx.attach(obj.clone());
+        obj
     }
 
-    #[link(name = "numa")]
-    unsafe extern "C" {
-        pub fn numa_available() -> c_int;
-        pub fn numa_max_node() -> c_int;
-        pub fn numa_node_of_cpu(cpu: c_int) -> c_int;
+    pub fn get(&self, token: NumaReplicatedAccessToken) -> Arc<T> {
+        self.instances.read().unwrap()[token.index].clone()
+    }
 
-        pub fn numa_alloc_onnode(size: size_t, node: c_int) -> *mut c_void;
-        pub fn numa_free(mem: *mut c_void, size: size_t);
+    pub fn all(&self) -> Vec<Arc<T>> {
+        self.instances.read().unwrap().clone()
+    }
 
-        pub fn numa_run_on_node(node: i32) -> i32;
-        pub fn numa_set_preferred(node: i32);
+    fn replicate_instances(&self) {
+        let cfg = self.ctx.get_numa_config();
+        let mut instances = Vec::<Arc<T>>::new();
 
-        pub fn numa_node_to_cpus(node: c_int, mask: *mut Bitmask) -> c_int;
-        pub fn numa_allocate_cpumask() -> *mut Bitmask;
-        pub fn numa_bitmask_free(mask: *mut Bitmask);
-        pub fn numa_bitmask_isbitset(mask: *const Bitmask, n: c_int) -> c_int;
+        let allocate_on_node = |node| {
+            let (tx, rx) = mpsc::channel();
+            cfg.execute_on_numa_node(node, move || {
+                tx.send(T::allocate()).expect("failed to send NUMA replicated instance");
+            });
+            rx.recv().expect("failed to receive NUMA replicated instance")
+        };
+
+        if cfg.suggests_binding_threads(self.ctx.get_thread_count()) {
+            for node in 0..cfg.num_numa_nodes() {
+                instances.push(allocate_on_node(node));
+            }
+        } else if let Some(shared) = T::allocate_shared() {
+            instances.push(shared);
+        } else {
+            instances.push(allocate_on_node(0));
+        }
+
+        *self.instances.write().unwrap() = instances;
+    }
+}
+
+impl<T: NumaReplicable> NumaReplicatedBase for NumaReplicated<T> {
+    fn on_numa_config_changed(&self) {
+        self.replicate_instances();
+    }
+
+    fn get_numa_config(&self) -> NumaConfig {
+        self.ctx.get_numa_config()
     }
 }

--- a/src/numa.rs
+++ b/src/numa.rs
@@ -131,7 +131,7 @@ impl NumaConfig {
             let mut best_node = 0;
             let mut best_fill = f32::MAX;
 
-            for node in 0..self.nodes.len() {
+            for (node, _) in self.nodes.iter().enumerate() {
                 let fill = (occupation[node] + 1) as f32 / self.nodes[node].len() as f32;
                 if fill < best_fill {
                     best_node = node;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -123,7 +123,7 @@ impl Default for SharedContext {
             best_stats: [const { AtomicU32::new(0) }; MAX_MOVES],
             history: NumaReplicated::new(numa_context.clone()),
             parameters: NumaReplicated::new(numa_context.clone()),
-            numa_context: numa_context,
+            numa_context,
         }
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -6,8 +6,8 @@ use std::sync::{
 use crate::{
     board::Board,
     history::{ContinuationCorrectionHistory, ContinuationHistory, CorrectionHistory, NoisyHistory, QuietHistory},
-    nnue::Network,
-    numa::{NumaReplicator, NumaValue},
+    nnue::{Network, ParametersHandle},
+    numa::{NumaConfig, NumaReplicable, NumaReplicated, NumaReplicatedAccessToken, NumaReplicationContext},
     stack::Stack,
     threadpool::ThreadPool,
     time::{Limits, TimeManager},
@@ -92,7 +92,11 @@ pub struct SharedCorrectionHistory {
     pub non_pawn: [CorrectionHistory; 2],
 }
 
-unsafe impl NumaValue for SharedCorrectionHistory {}
+impl NumaReplicable for SharedCorrectionHistory {
+    fn allocate() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+}
 
 pub struct SharedContext {
     pub tt: TranspositionTable,
@@ -101,13 +105,14 @@ pub struct SharedContext {
     pub tb_hits: Counter,
     pub soft_stop_votes: AtomicUsize,
     pub best_stats: [AtomicU32; MAX_MOVES],
-    pub history: *const SharedCorrectionHistory,
-    pub replicator: NumaReplicator<SharedCorrectionHistory>,
+    pub history: Arc<NumaReplicated<SharedCorrectionHistory>>,
+    pub parameters: Arc<NumaReplicated<ParametersHandle>>,
+    pub numa_context: Arc<NumaReplicationContext>,
 }
 
 impl Default for SharedContext {
     fn default() -> Self {
-        let replicator = unsafe { NumaReplicator::new(SharedCorrectionHistory::default) };
+        let numa_context = Arc::new(NumaReplicationContext::new(NumaConfig::from_system()));
 
         Self {
             tt: TranspositionTable::default(),
@@ -116,18 +121,17 @@ impl Default for SharedContext {
             tb_hits: Counter::default(),
             soft_stop_votes: AtomicUsize::new(0),
             best_stats: [const { AtomicU32::new(0) }; MAX_MOVES],
-            history: unsafe { replicator.get() },
-            replicator,
+            history: NumaReplicated::new(numa_context.clone()),
+            parameters: NumaReplicated::new(numa_context.clone()),
+            numa_context: numa_context,
         }
     }
 }
 
-unsafe impl Send for SharedContext {}
-unsafe impl Sync for SharedContext {}
-
 pub struct ThreadData {
     pub id: usize,
     pub shared: Arc<SharedContext>,
+    pub corrhist: Arc<SharedCorrectionHistory>,
     pub board: Board,
     pub time_manager: TimeManager,
     pub stack: Box<Stack>,
@@ -155,14 +159,18 @@ pub struct ThreadData {
 }
 
 impl ThreadData {
-    pub fn new(shared: Arc<SharedContext>) -> Self {
+    pub fn new(shared: Arc<SharedContext>, numa_token: NumaReplicatedAccessToken) -> Self {
+        let corrhist = shared.history.get(numa_token);
+        let parameters = shared.parameters.get(numa_token);
+
         Self {
             id: 0,
             shared,
+            corrhist,
             board: Board::starting_position(),
             time_manager: TimeManager::new(Limits::Infinite, 0, 0),
             stack: Stack::new(),
-            nnue: Network::default(),
+            nnue: Network::new(parameters),
             root_moves: Vec::new(),
             pv_table: PrincipalVariationTable::default(),
             noisy_history: NoisyHistory::default(),
@@ -191,7 +199,7 @@ impl ThreadData {
     }
 
     pub fn corrhist(&self) -> &SharedCorrectionHistory {
-        unsafe { &*self.shared.history }
+        &self.corrhist
     }
 
     pub fn conthist(&self, ply: isize, index: isize, mv: Move) -> i32 {

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -10,6 +10,7 @@ use std::{
 
 use crate::{
     board::Board,
+    numa::NumaReplicatedAccessToken,
     search::{self, Report},
     thread::{SharedContext, Status, ThreadData},
     time::TimeManager,
@@ -31,6 +32,8 @@ impl ThreadPool {
     }
 
     pub fn new(shared: Arc<SharedContext>) -> Self {
+        shared.numa_context.set_thread_count(1);
+
         let workers = make_worker_threads(1);
         let data = make_thread_data(shared, &workers, Board::starting_position().into());
 
@@ -41,6 +44,8 @@ impl ThreadPool {
         let threads = threads.clamp(1, ThreadPool::available_threads());
         let shared = self.vector[0].shared.clone();
         let board = Arc::new(self.vector[0].board.clone());
+
+        shared.numa_context.set_thread_count(threads);
 
         self.workers.drain(..).for_each(WorkerThread::join);
         self.workers = make_worker_threads(threads);
@@ -67,6 +72,8 @@ impl ThreadPool {
 
     pub fn clear(&mut self) {
         let shared = self.vector[0].shared.clone();
+
+        shared.numa_context.set_thread_count(self.workers.len());
 
         std::mem::drop(self.vector.drain(..));
         self.vector = make_thread_data(shared, &self.workers, Board::starting_position().into());
@@ -224,17 +231,10 @@ impl<'scope, 'env> ScopeExt<'scope, 'env> for Scope<'scope, 'env> {
     }
 }
 
-fn make_worker_thread(id: Option<usize>) -> WorkerThread {
+fn make_worker_thread() -> WorkerThread {
     let (sender, receiver) = make_work_channel();
 
     let handle = std::thread::spawn(move || {
-        #[cfg(feature = "numa")]
-        if let Some(id) = id {
-            crate::numa::bind_thread(id);
-        }
-        #[cfg(not(feature = "numa"))]
-        let _ = id;
-
         while let Ok(work) = receiver.receiver.recv() {
             work();
             let (lock, cvar) = &*receiver.completion_signal;
@@ -249,28 +249,32 @@ fn make_worker_thread(id: Option<usize>) -> WorkerThread {
 }
 
 fn make_worker_threads(num_threads: usize) -> Vec<WorkerThread> {
-    #[cfg(feature = "numa")]
-    {
-        let concurrency = std::thread::available_parallelism().map_or(1, |n| n.get());
-        (0..num_threads).map(|id| make_worker_thread((num_threads >= concurrency / 2).then_some(id))).collect()
-    }
-    #[cfg(not(feature = "numa"))]
-    {
-        (0..num_threads).map(|_| make_worker_thread(None)).collect()
-    }
+    std::iter::repeat_with(make_worker_thread).take(num_threads).collect()
 }
 
 fn make_thread_data(shared: Arc<SharedContext>, worker_threads: &[WorkerThread], board: Arc<Board>) -> Vec<ThreadData> {
     std::thread::scope(|scope| -> Vec<ThreadData> {
+        let cfg = shared.numa_context.get_numa_config();
+        let should_bind = cfg.suggests_binding_threads(worker_threads.len());
+        let numa_nodes = cfg.distribute_threads_among_numa_nodes(worker_threads.len());
+
         let handles = worker_threads
             .iter()
-            .map(|worker| {
+            .enumerate()
+            .map(|(index, worker)| {
                 let (tx, rx) = std::sync::mpsc::channel();
                 let shared = shared.clone();
+                let cfg = cfg.clone();
                 let board = board.clone();
+                let numa_node = numa_nodes[index];
                 let join_handle = scope.spawn_into(
                     move || {
-                        let mut td = Box::new(ThreadData::new(shared));
+                        let token = if should_bind {
+                            cfg.bind_current_thread_to_numa_node(numa_node)
+                        } else {
+                            NumaReplicatedAccessToken::new(0)
+                        };
+                        let mut td = Box::new(ThreadData::new(shared, token));
                         td.board = (*board).clone();
                         tx.send(td).unwrap();
                     },

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -174,7 +174,7 @@ fn reset(threads: &mut ThreadPool, shared: &Arc<SharedContext>) {
     threads.clear();
     shared.tt.clear(threads.len());
 
-    for corrhist in unsafe { shared.replicator.get_all() } {
+    for corrhist in shared.history.all() {
         corrhist.pawn.clear();
         corrhist.non_pawn[Color::White].clear();
         corrhist.non_pawn[Color::Black].clear();


### PR DESCRIPTION
* Replicate NNUE weights per NUMA domain
* Overhaul NUMA support based on Stockfish implementation
* Remove libnuma dependency

STC non-regression 1th
Elo   | 1.59 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 26216 W: 6723 L: 6603 D: 12890
Penta | [61, 2819, 7246, 2903, 79]
https://recklesschess.space/test/13481/

Bench: 3425249

