### PR TITLE
Remove redundant work regarding probing TB at Root

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -58,16 +58,6 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
     td.pv_table.clear(0);
     td.nnue.full_refresh(&td.board);
 
-    td.root_moves = td.board.generate_all_moves().iter().map(|v| RootMove { mv: v.mv, ..Default::default() }).collect();
-
-    td.root_in_tb = false;
-    td.stop_probing_tb = false;
-
-    #[cfg(feature = "syzygy")]
-    if td.board.castling().raw() == 0 && td.board.occupancies().popcount() <= tb::size() {
-        tb::rank_rootmoves(td);
-    }
-
     td.multi_pv = td.multi_pv.min(td.root_moves.len());
 
     let mut average = vec![td.previous_best_score; td.multi_pv];
@@ -373,7 +363,7 @@ fn search<NODE: NodeType>(
     #[cfg(feature = "syzygy")]
     if !NODE::ROOT
         && !excluded
-        && !td.stop_probing_tb
+        && !td.shared.stop_probing_tb.load(Ordering::Relaxed)
         && td.board.halfmove_clock() == 0
         && td.board.castling().raw() == 0
         && td.board.occupancies().popcount() <= tb::size()

--- a/src/tb.rs
+++ b/src/tb.rs
@@ -1,4 +1,4 @@
-use std::{ffi, mem, ptr};
+use std::{ffi, mem, ptr, sync::atomic::Ordering};
 
 use crate::{
     bindings::{
@@ -146,8 +146,8 @@ pub fn rank_rootmoves(td: &mut ThreadData) {
         if dtz_success != 0 {
             let c_rootmoves: &TbRootMoves = &*tb_ptr;
             update_rootmoves(&mut td.root_moves, c_rootmoves);
-            td.root_in_tb = true;
-            td.stop_probing_tb = true;
+            td.shared.stop_probing_tb.store(true, Ordering::Relaxed);
+            td.shared.root_in_tb.store(true, Ordering::Relaxed);
             return;
         }
 
@@ -172,10 +172,10 @@ pub fn rank_rootmoves(td: &mut ThreadData) {
         if wdl_success != 0 {
             let c_rootmoves: &TbRootMoves = &*tb_ptr;
             update_rootmoves(&mut td.root_moves, c_rootmoves);
-            td.root_in_tb = true;
+            td.shared.root_in_tb.store(true, Ordering::Relaxed);
 
             // Keep probing in search if DTZ is not available and we are winning
-            td.stop_probing_tb = td.root_moves[0].tb_score <= Score::ZERO;
+            td.shared.stop_probing_tb.store(td.root_moves[0].tb_score <= Score::ZERO, Ordering::Relaxed);
         }
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,6 +1,6 @@
 use std::sync::{
     Arc,
-    atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
 };
 
 use crate::{
@@ -103,6 +103,8 @@ pub struct SharedContext {
     pub status: Status,
     pub nodes: Counter,
     pub tb_hits: Counter,
+    pub stop_probing_tb: AtomicBool,
+    pub root_in_tb: AtomicBool,
     pub soft_stop_votes: AtomicUsize,
     pub best_stats: [AtomicU32; MAX_MOVES],
     pub history: Arc<NumaReplicated<SharedCorrectionHistory>>,
@@ -119,6 +121,8 @@ impl Default for SharedContext {
             status: Status::default(),
             nodes: Counter::default(),
             tb_hits: Counter::default(),
+            stop_probing_tb: AtomicBool::new(false),
+            root_in_tb: AtomicBool::new(false),
             soft_stop_votes: AtomicUsize::new(0),
             best_stats: [const { AtomicU32::new(0) }; MAX_MOVES],
             history: NumaReplicated::new(numa_context.clone()),
@@ -150,8 +154,6 @@ pub struct ThreadData {
     pub completed_depth: i32,
     pub nmp_min_ply: i32,
     pub previous_best_score: i32,
-    pub root_in_tb: bool,
-    pub stop_probing_tb: bool,
     pub multi_pv: usize,
     pub pv_index: usize,
     pub pv_start: usize,
@@ -185,8 +187,6 @@ impl ThreadData {
             completed_depth: 0,
             nmp_min_ply: 0,
             previous_best_score: 0,
-            root_in_tb: false,
-            stop_probing_tb: false,
             multi_pv: 1,
             pv_index: 0,
             pv_start: 0,
@@ -226,7 +226,7 @@ impl ThreadData {
             let mut upperbound = root_move.upperbound;
             let mut lowerbound = root_move.lowerbound;
 
-            if self.root_in_tb && score.abs() <= Score::TB_WIN {
+            if self.shared.root_in_tb.load(Ordering::Relaxed) && score.abs() <= Score::TB_WIN {
                 score = root_move.tb_score;
                 upperbound = false;
                 lowerbound = false;

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -8,11 +8,13 @@ use std::{
     thread::Scope,
 };
 
+#[cfg(feature = "syzygy")]
+use crate::tb;
 use crate::{
     board::Board,
     numa::NumaReplicatedAccessToken,
     search::{self, Report},
-    thread::{SharedContext, Status, ThreadData},
+    thread::{RootMove, SharedContext, Status, ThreadData},
     time::TimeManager,
 };
 
@@ -96,12 +98,25 @@ impl ThreadPool {
             let (t1, rest) = self.vector.split_first_mut().unwrap();
             let (w1, rest_workers) = self.workers.split_first().unwrap();
 
+            t1.shared.root_in_tb.store(false, Ordering::Relaxed);
+            t1.shared.stop_probing_tb.store(false, Ordering::Relaxed);
+
+            t1.board = (*board).clone();
+            t1.root_moves =
+                t1.board.generate_all_moves().iter().map(|v| RootMove { mv: v.mv, ..Default::default() }).collect();
+
+            #[cfg(feature = "syzygy")]
+            if t1.board.castling().raw() == 0 && t1.board.occupancies().popcount() <= tb::size() {
+                tb::rank_rootmoves(t1);
+            }
+
             let tm = time_manager.clone();
+            let root_moves = t1.root_moves.clone();
+
             handlers.push(scope.spawn_into(
                 move || {
                     t1.multi_pv = multi_pv;
                     t1.time_manager = tm;
-                    t1.board = (*board).clone();
 
                     search::start(t1, report, thread_count);
                     shared.status.set(Status::STOPPED);
@@ -111,11 +126,13 @@ impl ThreadPool {
 
             for (index, (t, w)) in rest.iter_mut().zip(rest_workers).enumerate() {
                 let tm = time_manager.clone();
+                let root_moves = root_moves.clone();
                 handlers.push(scope.spawn_into(
                     move || {
                         t.id = index + 1;
                         t.time_manager = tm;
                         t.board = (*board).clone();
+                        t.root_moves = root_moves;
 
                         search::start(t, Report::None, thread_count);
                     },


### PR DESCRIPTION
Instead of having every thread read the tablebases and figure out the same thing, only the main thread handles ranking the root moves and then shares the result with the others. This cuts down on wasted time from duplicate tablebase reads.

Elo   | 1.38 +- 2.01 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=256MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 27134 W: 6901 L: 6793 D: 13440
Penta | [13, 3087, 7276, 3161, 30]
https://recklesschess.space/test/13757/

Bench: 3425249