### PR TITLE
Simplify away new depth extension

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -772,7 +772,7 @@ fn search<NODE: NodeType>(
 
         make_move(td, ply, mv);
 
-        let mut new_depth = depth - 1 + if move_count == 1 { extension } else { (extension > 0) as i32 };
+        let mut new_depth = depth - 1 + if move_count == 1 { extension } else { 0 };
         let mut score = Score::ZERO;
 
         // Late Move Reductions (LMR)


### PR DESCRIPTION
STC
Elo   | -0.29 +- 0.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 173426 W: 43623 L: 43770 D: 86033
Penta | [540, 20612, 44487, 20603, 471]
https://recklesschess.space/test/13814/

LTC
Elo   | 0.58 +- 1.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 47590 W: 11640 L: 11561 D: 24389
Penta | [14, 5267, 13162, 5330, 22]
https://recklesschess.space/test/13818/

Bench: 2722250
