### PR TITLE
Add search phase profilebench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 [features]
 default = ["syzygy"]
+search-metrics = []
+search-metrics-time = ["search-metrics"]
+search-metrics-fine-time = ["search-metrics-time"]
 syzygy = []
 spsa = []
 

--- a/docs/search-metrics.md
+++ b/docs/search-metrics.md
@@ -1,0 +1,83 @@
+# Search Metrics
+
+`profilebench` runs the normal bench corpus with named search counters and
+optional phase timing. It exists for branch comparisons where `bench` preserves
+node count but NPS changes.
+
+`dbg_hit` is still useful for temporary probes after the suspect branch or
+formula is known. `profilebench` provides a reusable search-phase map: TT
+probes and cutoffs, pruning counts, qsearch candidates, beta cutoffs,
+reductions, and timing for eval setup, move ordering, child search, qsearch,
+and finalization.
+
+The default build compiles the instrumentation out. Build the profiler explicitly:
+
+```bash
+cargo rustc --release --features search-metrics-time -- -C target-cpu=native
+```
+
+Run the command as one CLI argument when passing parameters:
+
+```bash
+target/release/reckless "profilebench 16 1 12"
+```
+
+The arguments match `bench`: hash, threads, and depth. The output is TSV with
+summary rows, event rows, and timing rows. Event rows always print, including
+zero counts, so two runs can be compared without normalizing missing keys.
+
+On aarch64, timing uses the ARM generic counter (`cntvct_el0`) and reports
+`cntfrq_el0` as `timer_frequency_hz`. Other targets compile through an
+`Instant` fallback.
+
+Use the profiler in this order:
+
+1. Compare `summary.nodes`.
+2. Compare `event` rows.
+3. Compare coarse `phase` rows only when nodes and events match.
+4. Rebuild with `search-metrics-fine-time` after a coarse phase identifies the
+   suspect area.
+
+Matching nodes and matching events mean the tested bench corpus kept the same
+search shape. Different event counts indicate behavior drift. Matching event
+counts with slower NPS point at execution cost, code layout, inlining, cache
+behavior, or register pressure.
+
+Compare two saved outputs with:
+
+```bash
+scripts/compare-profilebench.py base.tsv current.tsv
+```
+
+The script exits non-zero when event counts differ. Timing from different search
+shapes mixes behavior changes with implementation cost.
+
+Example comparison:
+
+```text
+Summary
+-------
+nodes   2722250  2722250  +0      +0.00000%
+nps     1072096  1160058  +87962  +8.20468%
+
+Event Deltas
+------------
+none
+
+Phase Deltas
+------------
+eval_setup  +0.99721 pct  calls 1970483->1970483  ticks/call 10.245->9.745
+move_loop    +0.91541 pct  calls 796153->796153    ticks/call 0.930->1.497
+```
+
+Timing scopes are exclusive. Recursive child search is charged to
+`child_search` rather than to the parent `move_loop`, and nested fine scopes
+pause their parent phase.
+
+The phase map names algorithm concepts such as `eval_setup`,
+`pre_move_pruning`, `move_loop`, and `qsearch_stand_pat`. Some phases name
+mechanical cost centers inside those concepts: `move_picker`, `make_undo`,
+`reduction`, and `tt_access`.
+
+The timed build changes code shape and should not replace normal `bench`, speed
+testing, or external profilers.

--- a/scripts/compare-profilebench.py
+++ b/scripts/compare-profilebench.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Compare two profilebench TSV outputs."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def read_tsv(path: Path) -> dict[tuple[str, str], str]:
+    rows: dict[tuple[str, str], str] = {}
+    with path.open(encoding="utf-8") as file:
+        header = file.readline().rstrip("\n").split("\t")
+        if header != ["kind", "name", "value"]:
+            raise ValueError(f"{path}: expected profilebench TSV header")
+
+        for line in file:
+            kind, name, value = line.rstrip("\n").split("\t")
+            rows[(kind, name)] = value
+
+    return rows
+
+
+def numeric(value: str) -> float | None:
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def print_section(title: str) -> None:
+    print()
+    print(title)
+    print("-" * len(title))
+
+
+def compare(base: dict[tuple[str, str], str], current: dict[tuple[str, str], str]) -> int:
+    keys = sorted(set(base) | set(current))
+    status = 0
+
+    print_section("Summary")
+    for key in keys:
+        kind, name = key
+        if kind != "summary":
+            continue
+        left = base.get(key, "missing")
+        right = current.get(key, "missing")
+        print_delta(name, left, right)
+
+    print_section("Event Deltas")
+    event_changes = 0
+    for key in keys:
+        kind, name = key
+        if kind != "event":
+            continue
+        left = base.get(key, "0")
+        right = current.get(key, "0")
+        if left != right:
+            event_changes += 1
+            print_delta(name, left, right)
+
+    if event_changes == 0:
+        print("none")
+    else:
+        status = 1
+
+    print_section("Phase Deltas")
+    phase_changes = print_phase_deltas(base, current)
+
+    if phase_changes == 0:
+        print("no phase pct delta >= 0.1")
+
+    return status
+
+
+def print_phase_deltas(base: dict[tuple[str, str], str], current: dict[tuple[str, str], str]) -> int:
+    names = {
+        name.rsplit(".", 1)[0]
+        for kind, name in set(base) | set(current)
+        if kind == "phase" and "." in name
+    }
+    rows = []
+
+    for name in names:
+        base_pct = numeric(base.get(("phase", f"{name}.pct"), "0"))
+        current_pct = numeric(current.get(("phase", f"{name}.pct"), "0"))
+        if base_pct is None or current_pct is None:
+            continue
+
+        base_calls = numeric(base.get(("phase", f"{name}.calls"), "0")) or 0.0
+        current_calls = numeric(current.get(("phase", f"{name}.calls"), "0")) or 0.0
+        base_ticks = numeric(base.get(("phase", f"{name}.ticks"), "0")) or 0.0
+        current_ticks = numeric(current.get(("phase", f"{name}.ticks"), "0")) or 0.0
+        base_ticks_per_call = 0.0 if base_calls == 0 else base_ticks / base_calls
+        current_ticks_per_call = 0.0 if current_calls == 0 else current_ticks / current_calls
+        pct_delta = current_pct - base_pct
+        ticks_per_call_delta = current_ticks_per_call - base_ticks_per_call
+
+        if abs(pct_delta) >= 0.1 or abs(ticks_per_call_delta) >= 0.1:
+            rows.append(
+                (
+                    abs(pct_delta),
+                    name,
+                    base_pct,
+                    current_pct,
+                    pct_delta,
+                    base_calls,
+                    current_calls,
+                    base_ticks_per_call,
+                    current_ticks_per_call,
+                    ticks_per_call_delta,
+                )
+            )
+
+    for _, name, base_pct, current_pct, pct_delta, base_calls, current_calls, base_tpc, current_tpc, tpc_delta in sorted(
+        rows, reverse=True
+    ):
+        print(
+            f"{name}\t"
+            f"{base_pct:.5f}\t{current_pct:.5f}\t{pct_delta:+.5f} pct\t"
+            f"calls {base_calls:.0f}->{current_calls:.0f}\t"
+            f"ticks/call {base_tpc:.3f}->{current_tpc:.3f}\t{tpc_delta:+.3f}"
+        )
+
+    return len(rows)
+
+
+def print_delta(name: str, left: str, right: str) -> None:
+    left_num = numeric(left)
+    right_num = numeric(right)
+    if left_num is None or right_num is None:
+        marker = "==" if left == right else "!="
+        print(f"{name}\t{left}\t{right}\t{marker}")
+        return
+
+    delta = right_num - left_num
+    pct = 0.0 if left_num == 0 else 100.0 * delta / left_num
+    print(f"{name}\t{left}\t{right}\t{delta:+.0f}\t{pct:+.5f}%")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base", type=Path)
+    parser.add_argument("current", type=Path)
+    args = parser.parse_args()
+
+    try:
+        return compare(read_tsv(args.base), read_tsv(args.current))
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod board;
 mod evaluation;
 mod history;
 mod lookup;
+mod metrics;
 mod misc;
 mod movepick;
 mod nnue;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,501 @@
+//! Search metrics storage and reporting.
+//!
+//! Search instrumentation has two jobs: count deterministic search-shape events and, in timed
+//! builds, attribute exclusive time to named search phases. The search modules only name events and
+//! phases through macros. This module owns storage, per-thread merging, timing scopes, and TSV
+//! output.
+//!
+//! The storage is deliberately simpler than general-purpose telemetry. Search updates metrics from
+//! the worker thread that owns the corresponding `ThreadData`, and `profilebench` reads metrics
+//! only after all workers join. That single-writer/after-join contract lets the hot path use plain
+//! per-thread counters instead of atomics.
+#![allow(dead_code)]
+
+use std::cell::UnsafeCell;
+
+macro_rules! metric_names {
+    (
+        $(#[$meta:meta])*
+        $visibility:vis enum $name:ident {
+            $($variant:ident => $label:literal,)+
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Copy, Clone, Eq, PartialEq)]
+        $visibility enum $name {
+            $($variant,)+
+        }
+
+        impl $name {
+            $visibility const COUNT: usize = [$(stringify!($variant),)+].len();
+
+            const ALL: [Self; Self::COUNT] = [$(Self::$variant,)+];
+
+            const fn name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $label,)+
+                }
+            }
+        }
+    };
+}
+
+metric_names! {
+    /// Search event counters used to compare behavior-equivalent builds.
+    pub enum Event {
+        RootIteration => "root_iteration",
+        DepthCompleted => "depth_completed",
+        FullNode => "full_node",
+        QsearchNode => "qsearch_node",
+        TtProbe => "tt_probe",
+        TtHit => "tt_hit",
+        TtCutoff => "tt_cutoff",
+        TtFullCutoff => "tt_full_cutoff",
+        TtQsearchCutoff => "tt_qsearch_cutoff",
+        TtWrite => "tt_write",
+        TtLowerWrite => "tt_lower_write",
+        TtUpperWrite => "tt_upper_write",
+        TtExactWrite => "tt_exact_write",
+        TtEvalWrite => "tt_eval_write",
+        StaticEval => "static_eval",
+        TtRawEval => "tt_raw_eval",
+        TtScoreAsEval => "tt_score_as_eval",
+        CorrectionApplied => "correction_applied",
+        TablebaseProbe => "tablebase_probe",
+        TablebaseCutoff => "tablebase_cutoff",
+        TablebasePvLower => "tablebase_pv_lower",
+        TablebasePvUpper => "tablebase_pv_upper",
+        TablebaseNoResult => "tablebase_no_result",
+        RazorTried => "razor_tried",
+        RazorCutoff => "razor_cutoff",
+        ReverseFutilityTried => "reverse_futility_tried",
+        ReverseFutilityCutoff => "reverse_futility_cutoff",
+        NullMoveTried => "null_move_tried",
+        NullMoveCutoff => "null_move_cutoff",
+        ProbCutTried => "probcut_tried",
+        ProbCutCandidate => "probcut_candidate",
+        ProbCutQsearchPass => "probcut_qsearch_pass",
+        ProbCutConfirmed => "probcut_confirmed",
+        ProbCutCutoff => "probcut_cutoff",
+        SingularTried => "singular_tried",
+        SingularVerified => "singular_verified",
+        SingularExtension => "singular_extension",
+        SingularDoubleExtension => "singular_double_extension",
+        SingularTripleExtension => "singular_triple_extension",
+        SingularCutoff => "singular_cutoff",
+        SingularNegativeExtension => "singular_negative_extension",
+        SingularTtMoveSuppressed => "singular_tt_move_suppressed",
+        MoveLoopCandidate => "move_loop_candidate",
+        RootMoveSkipped => "root_move_skipped",
+        MovePruned => "move_pruned",
+        MovePrunedLateMove => "move_pruned_late_move",
+        MovePrunedFutility => "move_pruned_futility",
+        MovePrunedBadNoisy => "move_pruned_bad_noisy",
+        MovePrunedSee => "move_pruned_see",
+        ReducedSearch => "reduced_search",
+        FullDepthSearch => "full_depth_search",
+        PvSearch => "pv_search",
+        Research => "research",
+        BetaCutoff => "beta_cutoff",
+        QsearchStandPatCutoff => "qsearch_stand_pat_cutoff",
+        QsearchCandidate => "qsearch_candidate",
+        QsearchQuietSkip => "qsearch_quiet_skip",
+        QsearchSeePrune => "qsearch_see_prune",
+        QsearchBetaCutoff => "qsearch_beta_cutoff",
+        QsearchTtWrite => "qsearch_tt_write",
+    }
+}
+
+metric_names! {
+    /// Exclusive timing phases for named search concepts.
+    pub enum Phase {
+        RootSearch => "root_search",
+        FullEntry => "full_entry",
+        Proof => "proof",
+        EvalSetup => "eval_setup",
+        PreMovePruning => "pre_move_pruning",
+        Singular => "singular",
+        MoveLoop => "move_loop",
+        ChildSearch => "child_search",
+        Finalization => "finalization",
+        QsearchEntry => "qsearch_entry",
+        QsearchStandPat => "qsearch_stand_pat",
+        QsearchMoveLoop => "qsearch_move_loop",
+        QsearchFinalization => "qsearch_finalization",
+        NullMove => "null_move",
+        ProbCut => "probcut",
+        MovePicker => "move_picker",
+        CandidatePruning => "candidate_pruning",
+        MakeUndo => "make_undo",
+        Reduction => "reduction",
+        HistoryUpdate => "history_update",
+        TtAccess => "tt_access",
+    }
+}
+
+#[repr(align(64))]
+pub struct MetricsShard {
+    events: UnsafeCell<[u64; Event::COUNT]>,
+    phases: UnsafeCell<[PhaseStats; Phase::COUNT]>,
+    stack: UnsafeCell<PhaseStack>,
+}
+
+// Safety: each shard is written by the worker whose `ThreadData::id` indexes it. Metrics are read
+// or reset only outside active search, after worker joins or before the next search begins.
+unsafe impl Sync for MetricsShard {}
+
+impl MetricsShard {
+    const fn new() -> Self {
+        Self {
+            events: UnsafeCell::new([0; Event::COUNT]),
+            phases: UnsafeCell::new([const { PhaseStats::new() }; Phase::COUNT]),
+            stack: UnsafeCell::new(PhaseStack::new()),
+        }
+    }
+
+    #[inline]
+    fn event(&self, event: Event) {
+        unsafe {
+            (*self.events.get())[event as usize] += 1;
+        }
+    }
+
+    #[cfg(feature = "search-metrics-time")]
+    #[inline]
+    fn enter(&self, phase: Phase) {
+        let now = timer::ticks();
+        unsafe {
+            let phases = &mut *self.phases.get();
+            let stack = &mut *self.stack.get();
+
+            if let Some(active) = stack.last_mut() {
+                phases[active.phase as usize].ticks += now.saturating_sub(active.started);
+            }
+
+            phases[phase as usize].calls += 1;
+            stack.push(ActivePhase { phase, started: now });
+        }
+    }
+
+    #[cfg(feature = "search-metrics-time")]
+    #[inline]
+    fn exit(&self, phase: Phase) {
+        let now = timer::ticks();
+        unsafe {
+            let phases = &mut *self.phases.get();
+            let stack = &mut *self.stack.get();
+            let active = stack.pop();
+            debug_assert!(active.phase == phase);
+
+            phases[phase as usize].ticks += now.saturating_sub(active.started);
+
+            if let Some(parent) = stack.last_mut() {
+                parent.started = now;
+            }
+        }
+    }
+
+    fn reset(&self) {
+        unsafe {
+            *self.events.get() = [0; Event::COUNT];
+            *self.phases.get() = [const { PhaseStats::new() }; Phase::COUNT];
+            *self.stack.get() = PhaseStack::new();
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct PhaseStats {
+    calls: u64,
+    ticks: u64,
+}
+
+impl PhaseStats {
+    const fn new() -> Self {
+        Self { calls: 0, ticks: 0 }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct ActivePhase {
+    phase: Phase,
+    started: u64,
+}
+
+struct PhaseStack {
+    data: [ActivePhase; 1024],
+    len: usize,
+}
+
+impl PhaseStack {
+    const fn new() -> Self {
+        Self {
+            data: [ActivePhase { phase: Phase::RootSearch, started: 0 }; 1024],
+            len: 0,
+        }
+    }
+
+    #[inline]
+    fn push(&mut self, phase: ActivePhase) {
+        debug_assert!(self.len < self.data.len());
+        self.data[self.len] = phase;
+        self.len += 1;
+    }
+
+    #[inline]
+    fn pop(&mut self) -> ActivePhase {
+        debug_assert!(self.len > 0);
+        self.len -= 1;
+        self.data[self.len]
+    }
+
+    #[inline]
+    fn last_mut(&mut self) -> Option<&mut ActivePhase> {
+        self.len.checked_sub(1).map(|index| &mut self.data[index])
+    }
+}
+
+pub struct Metrics {
+    shards: Box<[MetricsShard]>,
+}
+
+impl Metrics {
+    pub fn new(shards: usize) -> Self {
+        Self {
+            shards: std::iter::repeat_with(MetricsShard::new).take(shards).collect(),
+        }
+    }
+
+    #[inline]
+    pub fn event(&self, thread: usize, event: Event) {
+        self.shards[thread].event(event);
+    }
+
+    #[cfg(feature = "search-metrics-time")]
+    #[inline]
+    pub fn scope(&self, thread: usize, phase: Phase) -> Scope {
+        let shard = &self.shards[thread] as *const MetricsShard;
+        self.shards[thread].enter(phase);
+        Scope { shard, phase }
+    }
+
+    pub fn reset(&self) {
+        for shard in &self.shards {
+            shard.reset();
+        }
+    }
+
+    pub fn print_tsv(&self, nodes: u64, nps: f64) {
+        self.snapshot().print_tsv(nodes, nps);
+    }
+
+    fn snapshot(&self) -> MetricsSnapshot {
+        let mut events = [0u64; Event::COUNT];
+        #[cfg(feature = "search-metrics-time")]
+        let mut phases = [const { PhaseStats::new() }; Phase::COUNT];
+
+        for shard in &self.shards {
+            unsafe {
+                for (index, value) in (*shard.events.get()).iter().enumerate() {
+                    events[index] += value;
+                }
+
+                #[cfg(feature = "search-metrics-time")]
+                {
+                    for (index, value) in (*shard.phases.get()).iter().enumerate() {
+                        phases[index].calls += value.calls;
+                        phases[index].ticks += value.ticks;
+                    }
+                }
+            }
+        }
+
+        MetricsSnapshot {
+            events,
+            #[cfg(feature = "search-metrics-time")]
+            phases,
+        }
+    }
+}
+
+struct MetricsSnapshot {
+    events: [u64; Event::COUNT],
+
+    #[cfg(feature = "search-metrics-time")]
+    phases: [PhaseStats; Phase::COUNT],
+}
+
+impl MetricsSnapshot {
+    fn print_tsv(&self, nodes: u64, nps: f64) {
+        println!("kind\tname\tvalue");
+        println!("summary\tnodes\t{nodes}");
+        println!("summary\tnps\t{nps:.0}");
+
+        #[cfg(feature = "search-metrics-time")]
+        {
+            println!("summary\ttimer_source\t{}", timer::source());
+            println!("summary\ttimer_frequency_hz\t{}", timer::frequency());
+        }
+
+        for (index, count) in self.events.into_iter().enumerate() {
+            println!("event\t{}\t{count}", event_name(index));
+        }
+
+        #[cfg(feature = "search-metrics-time")]
+        {
+            let total_ticks = self.phases.iter().map(|phase| phase.ticks).sum::<u64>();
+            for (index, stats) in self.phases.into_iter().enumerate() {
+                if stats.calls > 0 || stats.ticks > 0 {
+                    let name = phase_name(index);
+                    let pct = if total_ticks == 0 { 0.0 } else { 100.0 * stats.ticks as f64 / total_ticks as f64 };
+                    println!("phase\t{name}.calls\t{}", stats.calls);
+                    println!("phase\t{name}.ticks\t{}", stats.ticks);
+                    println!("phase\t{name}.pct\t{pct:.5}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "search-metrics-time")]
+pub struct Scope {
+    // Raw pointer avoids borrowing `ThreadData` through `td.shared.metrics` for the full scope.
+    // The pointed-to shard is owned by `SharedContext` and outlives all search scopes.
+    shard: *const MetricsShard,
+    phase: Phase,
+}
+
+#[cfg(feature = "search-metrics-time")]
+impl Drop for Scope {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            (*self.shard).exit(self.phase);
+        }
+    }
+}
+
+const fn event_name(index: usize) -> &'static str {
+    Event::ALL[index].name()
+}
+
+const fn phase_name(index: usize) -> &'static str {
+    Phase::ALL[index].name()
+}
+
+#[cfg(all(feature = "search-metrics-time", target_arch = "aarch64"))]
+mod timer {
+    use std::arch::asm;
+
+    #[inline(always)]
+    pub fn ticks() -> u64 {
+        let value: u64;
+        unsafe {
+            asm!("mrs {}, cntvct_el0", out(reg) value, options(nomem, nostack, preserves_flags));
+        }
+        value
+    }
+
+    pub fn frequency() -> u64 {
+        let value: u64;
+        unsafe {
+            asm!("mrs {}, cntfrq_el0", out(reg) value, options(nomem, nostack, preserves_flags));
+        }
+        value
+    }
+
+    pub const fn source() -> &'static str {
+        "cntvct_el0"
+    }
+}
+
+#[cfg(all(feature = "search-metrics-time", not(target_arch = "aarch64")))]
+mod timer {
+    use std::{
+        sync::OnceLock,
+        time::{Duration, Instant},
+    };
+
+    static START: OnceLock<Instant> = OnceLock::new();
+
+    #[inline]
+    pub fn ticks() -> u64 {
+        START.get_or_init(Instant::now).elapsed().as_nanos().min(u128::from(u64::MAX)) as u64
+    }
+
+    pub const fn frequency() -> u64 {
+        Duration::from_secs(1).as_nanos() as u64
+    }
+
+    pub const fn source() -> &'static str {
+        "instant"
+    }
+}
+
+#[cfg(feature = "search-metrics")]
+#[macro_export]
+macro_rules! counter {
+    ($td:expr, $event:ident $(,)?) => {
+        $td.shared.metrics.event($td.id, $crate::metrics::Event::$event)
+    };
+    ($td:expr, $first:ident, $($event:ident),+ $(,)?) => {
+        $crate::counter!($td, $first);
+        $($crate::counter!($td, $event);)+
+    };
+}
+
+#[cfg(not(feature = "search-metrics"))]
+#[macro_export]
+macro_rules! counter {
+    ($td:expr, $($event:ident),+ $(,)?) => {{
+        let _ = &$td;
+    }};
+}
+
+#[cfg(feature = "search-metrics-time")]
+#[macro_export]
+macro_rules! metric_scope {
+    ($td:expr, $phase:ident) => {
+        $td.shared.metrics.scope($td.id, $crate::metrics::Phase::$phase)
+    };
+}
+
+#[cfg(not(feature = "search-metrics-time"))]
+#[macro_export]
+macro_rules! metric_scope {
+    ($td:expr, $phase:ident) => {
+        ()
+    };
+}
+
+#[cfg(feature = "search-metrics-time")]
+#[macro_export]
+macro_rules! finish_metric_scope {
+    ($scope:expr) => {
+        drop($scope)
+    };
+}
+
+#[cfg(not(feature = "search-metrics-time"))]
+#[macro_export]
+macro_rules! finish_metric_scope {
+    ($scope:expr) => {
+        let _ = &$scope;
+    };
+}
+
+#[cfg(feature = "search-metrics-fine-time")]
+#[macro_export]
+macro_rules! metric_fine_scope {
+    ($td:expr, $phase:ident) => {
+        $td.shared.metrics.scope($td.id, $crate::metrics::Phase::$phase)
+    };
+}
+
+#[cfg(not(feature = "search-metrics-fine-time"))]
+#[macro_export]
+macro_rules! metric_fine_scope {
+    ($td:expr, $phase:ident) => {
+        ()
+    };
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,9 @@
 use std::sync::atomic::Ordering;
 
 use crate::{
+    counter,
     evaluation::correct_eval,
+    finish_metric_scope, metric_fine_scope, metric_scope,
     movepick::{MovePicker, Stage},
     stack::Stack,
     thread::{RootMove, Status, ThreadData},
@@ -53,6 +55,7 @@ impl NodeType for NonPV {
 }
 
 pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
+    let _phase = metric_scope!(td, RootSearch);
     td.completed_depth = 0;
 
     td.pv_table.clear(0);
@@ -77,6 +80,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             td.shared.status.set(Status::STOPPED);
             break;
         }
+        counter!(td, RootIteration);
         best_move_changes /= 2;
 
         td.sel_depth = 0;
@@ -170,6 +174,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
 
         if td.shared.status.get() != Status::STOPPED {
             td.completed_depth = depth;
+            counter!(td, DepthCompleted);
         }
 
         if report == Report::Full
@@ -255,6 +260,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
 fn search<NODE: NodeType>(
     td: &mut ThreadData, mut alpha: i32, mut beta: i32, depth: i32, cut_node: bool, ply: isize,
 ) -> i32 {
+    let entry_phase = metric_scope!(td, FullEntry);
     debug_assert!(ply as usize <= MAX_PLY);
     debug_assert!(-Score::INFINITE <= alpha && alpha < beta && beta <= Score::INFINITE);
     debug_assert!(NODE::PV || alpha == beta - 1);
@@ -311,6 +317,11 @@ fn search<NODE: NodeType>(
         }
     }
 
+    finish_metric_scope!(entry_phase);
+    counter!(td, FullNode);
+
+    let proof_phase = metric_scope!(td, Proof);
+
     #[cfg(feature = "syzygy")]
     let mut max_score = Score::INFINITE;
 
@@ -319,7 +330,11 @@ fn search<NODE: NodeType>(
     let mut depth = depth.min(MAX_PLY as i32 - 1);
 
     let hash = td.board.hash();
-    let entry = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
+    let entry = {
+        counter!(td, TtProbe);
+        let _phase = metric_fine_scope!(td, TtAccess);
+        td.shared.tt.read(hash, td.board.halfmove_clock(), ply)
+    };
 
     let mut tt_depth = 0;
     let mut tt_move = Move::NULL;
@@ -329,6 +344,7 @@ fn search<NODE: NodeType>(
 
     // Search early TT cutoff
     if let Some(entry) = &entry {
+        counter!(td, TtHit);
         tt_depth = entry.depth;
         tt_move = entry.mv;
         tt_score = entry.score;
@@ -345,6 +361,7 @@ fn search<NODE: NodeType>(
                 _ => true,
             }
         {
+            counter!(td, TtCutoff, TtFullCutoff);
             if tt_move.is_quiet() && tt_score >= beta && td.stack[ply - 1].move_count < 4 {
                 let quiet_bonus = (175 * depth - 79).min(1637);
                 let cont_bonus = (114 * depth - 57).min(1284);
@@ -359,64 +376,91 @@ fn search<NODE: NodeType>(
         }
     }
 
-    // Tablebases Probe
     #[cfg(feature = "syzygy")]
-    if !NODE::ROOT
-        && !excluded
-        && !td.shared.stop_probing_tb.load(Ordering::Relaxed)
-        && td.board.halfmove_clock() == 0
-        && td.board.castling().raw() == 0
-        && td.board.occupancies().popcount() <= tb::size()
-        && let Some(outcome) = tb::probe(&td.board)
     {
-        td.shared.tb_hits.increment(td.id);
-
-        let (score, bound) = match outcome {
-            tb::GameOutcome::Win => (tb_win_in(ply), Bound::Lower),
-            tb::GameOutcome::Loss => (tb_loss_in(ply), Bound::Upper),
-            tb::GameOutcome::Draw => (Score::ZERO, Bound::Exact),
-        };
-
-        if bound == Bound::Exact
-            || (bound == Bound::Lower && score >= beta)
-            || (bound == Bound::Upper && score <= alpha)
+        counter!(td, TablebaseProbe);
+        // Tablebases Probe
+        if !NODE::ROOT
+            && !excluded
+            && !td.shared.stop_probing_tb.load(Ordering::Relaxed)
+            && td.board.halfmove_clock() == 0
+            && td.board.castling().raw() == 0
+            && td.board.occupancies().popcount() <= tb::size()
         {
-            let depth = (depth + 6).min(MAX_PLY as i32 - 1);
-            td.shared.tt.write(hash, depth, Score::NONE, score, bound, Move::NULL, ply, tt_pv, false);
-            return score;
-        }
+            if let Some(outcome) = tb::probe(&td.board) {
+                td.shared.tb_hits.increment(td.id);
 
-        if NODE::PV {
-            if bound == Bound::Lower {
-                best_score = score;
-                alpha = alpha.max(best_score);
+                let (score, bound) = match outcome {
+                    tb::GameOutcome::Win => (tb_win_in(ply), Bound::Lower),
+                    tb::GameOutcome::Loss => (tb_loss_in(ply), Bound::Upper),
+                    tb::GameOutcome::Draw => (Score::ZERO, Bound::Exact),
+                };
+
+                if bound == Bound::Exact
+                    || (bound == Bound::Lower && score >= beta)
+                    || (bound == Bound::Upper && score <= alpha)
+                {
+                    let depth = (depth + 6).min(MAX_PLY as i32 - 1);
+                    counter!(td, TablebaseCutoff);
+                    td.shared.tt.write(hash, depth, Score::NONE, score, bound, Move::NULL, ply, tt_pv, false);
+                    return score;
+                }
+
+                if NODE::PV {
+                    if bound == Bound::Lower {
+                        counter!(td, TablebasePvLower);
+                        best_score = score;
+                        alpha = alpha.max(best_score);
+                    } else {
+                        counter!(td, TablebasePvUpper);
+                        max_score = score;
+                    }
+                }
             } else {
-                max_score = score;
+                counter!(td, TablebaseNoResult);
             }
+        } else {
+            counter!(td, TablebaseNoResult);
         }
     }
+    finish_metric_scope!(proof_phase);
 
-    let correction_value = eval_correction(td, ply);
+    let (correction_value, raw_eval, mut eval) = {
+        let _phase = metric_scope!(td, EvalSetup);
+        let correction_value = eval_correction(td, ply);
 
-    let raw_eval;
-    let mut eval;
+        let raw_eval;
+        let eval;
 
-    // Evaluation
-    if in_check {
-        raw_eval = Score::NONE;
-        eval = Score::NONE;
-    } else if excluded {
-        raw_eval = Score::NONE;
-        eval = td.stack[ply].eval;
-    } else if let Some(entry) = &entry {
-        raw_eval = if is_valid(entry.raw_eval) { entry.raw_eval } else { td.nnue.evaluate(&td.board) };
-        eval = correct_eval(td, raw_eval, correction_value);
-    } else {
-        raw_eval = td.nnue.evaluate(&td.board);
-        eval = correct_eval(td, raw_eval, correction_value);
+        // Evaluation
+        if in_check {
+            raw_eval = Score::NONE;
+            eval = Score::NONE;
+        } else if excluded {
+            raw_eval = Score::NONE;
+            eval = td.stack[ply].eval;
+        } else if let Some(entry) = &entry {
+            raw_eval = if is_valid(entry.raw_eval) {
+                counter!(td, TtRawEval);
+                entry.raw_eval
+            } else {
+                counter!(td, StaticEval);
+                td.nnue.evaluate(&td.board)
+            };
+            counter!(td, CorrectionApplied);
+            eval = correct_eval(td, raw_eval, correction_value);
+        } else {
+            counter!(td, StaticEval);
+            raw_eval = td.nnue.evaluate(&td.board);
+            counter!(td, CorrectionApplied);
+            eval = correct_eval(td, raw_eval, correction_value);
 
-        td.shared.tt.write(hash, TtDepth::SOME, raw_eval, Score::NONE, Bound::None, Move::NULL, ply, tt_pv, false);
-    }
+            counter!(td, TtWrite, TtEvalWrite);
+            td.shared.tt.write(hash, TtDepth::SOME, raw_eval, Score::NONE, Bound::None, Move::NULL, ply, tt_pv, false);
+        }
+
+        (correction_value, raw_eval, eval)
+    };
 
     // Prefer the TT entry to tighten the evaluation when its bound aligns with
     // the current alpha-beta window; otherwise, retain the unbounded evaluation
@@ -431,6 +475,7 @@ fn search<NODE: NodeType>(
             _ => true,
         }
     {
+        counter!(td, TtScoreAsEval);
         estimated_score = tt_score;
     }
 
@@ -444,6 +489,7 @@ fn search<NODE: NodeType>(
             _ => true,
         }
     {
+        counter!(td, TtScoreAsEval);
         eval = tt_score;
     }
 
@@ -498,7 +544,10 @@ fn search<NODE: NodeType>(
 
     let improving = improvement > 0;
 
+    let pruning_phase = metric_scope!(td, PreMovePruning);
+
     // Razoring
+    counter!(td, RazorTried);
     if !NODE::PV
         && !in_check
         && estimated_score < alpha - 295 - 261 * depth * depth
@@ -506,10 +555,12 @@ fn search<NODE: NodeType>(
         && !tt_move.is_quiet()
         && tt_bound != Bound::Lower
     {
+        counter!(td, RazorCutoff);
         return qsearch::<NonPV>(td, alpha, beta, ply);
     }
 
     // Reverse Futility Pruning (RFP)
+    counter!(td, ReverseFutilityTried);
     if !tt_pv
         && !in_check
         && !excluded
@@ -524,6 +575,7 @@ fn search<NODE: NodeType>(
         && !is_loss(beta)
         && !is_win(estimated_score)
     {
+        counter!(td, ReverseFutilityCutoff);
         return beta + (estimated_score - beta) / 3;
     }
 
@@ -546,6 +598,8 @@ fn search<NODE: NodeType>(
             && tt_move.is_capture()
             && td.board.piece_on(tt_move.to()).value() >= PieceType::Knight.value())
     {
+        counter!(td, NullMoveTried);
+        let _phase = metric_fine_scope!(td, NullMove);
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
         let r = (5335 + 260 * depth + 493 * (estimated_score - beta).clamp(0, 1003) / 128) / 1024;
@@ -568,6 +622,7 @@ fn search<NODE: NodeType>(
 
         if score >= beta && !is_win(score) {
             if td.nmp_min_ply > 0 || depth < 16 {
+                counter!(td, NullMoveCutoff);
                 return score;
             }
 
@@ -580,6 +635,7 @@ fn search<NODE: NodeType>(
             }
 
             if verified_score >= beta {
+                counter!(td, NullMoveCutoff);
                 return score;
             }
         }
@@ -593,12 +649,15 @@ fn search<NODE: NodeType>(
         && if is_valid(tt_score) { tt_score >= probcut_beta && !is_decisive(tt_score) } else { eval >= beta }
         && !tt_move.is_quiet()
     {
+        counter!(td, ProbCutTried);
+        let _phase = metric_fine_scope!(td, ProbCut);
         let mut move_picker = MovePicker::new_probcut(probcut_beta - eval);
 
         while let Some(mv) = move_picker.next::<NODE>(td, true, ply) {
             if move_picker.stage() == Stage::BadNoisy {
                 break;
             }
+            counter!(td, ProbCutCandidate);
 
             if mv == td.stack[ply].excluded {
                 continue;
@@ -612,13 +671,16 @@ fn search<NODE: NodeType>(
             let mut probcut_depth = (base_depth - (score - probcut_beta) / 319).clamp(0, base_depth);
 
             if score >= probcut_beta && probcut_depth > 0 {
+                counter!(td, ProbCutQsearchPass);
                 let adjusted_beta = (probcut_beta + 260 * (base_depth - probcut_depth)).min(Score::INFINITE);
 
                 score = -search::<NonPV>(td, -adjusted_beta, -adjusted_beta + 1, probcut_depth, false, ply + 1);
+                counter!(td, ProbCutConfirmed);
 
                 if score < adjusted_beta && probcut_beta < adjusted_beta {
                     probcut_depth = base_depth;
                     score = -search::<NonPV>(td, -probcut_beta, -probcut_beta + 1, probcut_depth, false, ply + 1);
+                    counter!(td, ProbCutConfirmed);
                 } else {
                     probcut_beta = adjusted_beta;
                 }
@@ -631,6 +693,7 @@ fn search<NODE: NodeType>(
             }
 
             if score >= probcut_beta {
+                counter!(td, ProbCutCutoff, TtWrite, TtLowerWrite);
                 td.shared.tt.write(hash, probcut_depth + 1, raw_eval, score, Bound::Lower, mv, ply, tt_pv, false);
 
                 if is_decisive(score) {
@@ -640,12 +703,15 @@ fn search<NODE: NodeType>(
             }
         }
     }
+    finish_metric_scope!(pruning_phase);
 
     // Singular Extensions (SE)
     let mut extension = 0;
     let mut singular_score = Score::NONE;
 
     if !NODE::ROOT && !excluded && potential_singularity {
+        counter!(td, SingularTried);
+        let _phase = metric_scope!(td, Singular);
         debug_assert!(is_valid(tt_score));
 
         let singular_margin = if tt_bound == Bound::Exact { (depth as u32).div_ceil(4) as i32 } else { depth }
@@ -657,6 +723,7 @@ fn search<NODE: NodeType>(
         td.stack[ply].mv = Move::NULL;
         singular_score = search::<NonPV>(td, singular_beta - 1, singular_beta, singular_depth, cut_node, ply);
         td.stack[ply].excluded = Move::NULL;
+        counter!(td, SingularVerified);
 
         if td.shared.status.get() == Status::STOPPED {
             return Score::ZERO;
@@ -671,15 +738,25 @@ fn search<NODE: NodeType>(
             extension = 1;
             extension += (singular_score < singular_beta - double_margin) as i32;
             extension += (singular_score < singular_beta - triple_margin) as i32;
+            counter!(td, SingularExtension);
+            if extension >= 2 {
+                counter!(td, SingularDoubleExtension);
+            }
+            if extension >= 3 {
+                counter!(td, SingularTripleExtension);
+            }
         }
         // Multi-Cut
         else if singular_score >= beta && !is_decisive(singular_score) {
+            counter!(td, SingularCutoff);
             return (2 * singular_score + beta) / 3;
         } else if singular_score > tt_score && td.stack[ply].mv != Move::NULL {
+            counter!(td, SingularTtMoveSuppressed);
             tt_move = Move::NULL;
         }
         // Negative Extensions
         else if tt_score >= beta || cut_node {
+            counter!(td, SingularNegativeExtension);
             extension = -2;
         }
     }
@@ -697,313 +774,350 @@ fn search<NODE: NodeType>(
     let mut alpha_raises = 0;
     let mut tt_move_score = Score::NONE;
 
-    while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets, ply) {
-        if mv == td.stack[ply].excluded {
-            continue;
-        }
+    {
+        let _phase = metric_scope!(td, MoveLoop);
 
-        if NODE::ROOT && !td.root_moves[td.pv_index..td.pv_end].iter().any(|rm| rm.mv == mv) {
-            continue;
-        }
-
-        move_count += 1;
-        current_search_count = 0;
-        td.stack[ply].move_count = move_count;
-
-        let is_quiet = mv.is_quiet();
-
-        let history = if is_quiet {
-            td.quiet_history.get(td.board.all_threats(), stm, mv) + td.conthist(ply, 1, mv) + td.conthist(ply, 2, mv)
-        } else {
-            let captured = td.board.type_on(mv.to());
-            td.noisy_history.get(td.board.all_threats(), td.board.moved_piece(mv), mv.to(), captured)
-        };
-
-        if !NODE::ROOT && !is_loss(best_score) {
-            // Late Move Pruning (LMP)
-            if !in_check
-                && !td.board.is_direct_check(mv)
-                && is_quiet
-                && move_count >= (3006 + 70 * improvement / 16 + 1455 * depth * depth + 68 * history / 1024) / 1024
-            {
-                skip_quiets = true;
+        while let Some(mv) = {
+            let _phase = metric_fine_scope!(td, MovePicker);
+            move_picker.next::<NODE>(td, skip_quiets, ply)
+        } {
+            if mv == td.stack[ply].excluded {
                 continue;
             }
 
-            // Futility Pruning (FP)
-            let futility_value = eval
-                + 79 * depth
-                + 64 * history / 1024
-                + 84 * (eval >= beta) as i32
-                + 560 * correction_value.abs() / 1024
-                - 146;
-
-            if !in_check && is_quiet && depth < 15 && futility_value <= alpha && !td.board.is_direct_check(mv) {
-                if !is_decisive(best_score) && best_score < futility_value {
-                    best_score = futility_value;
-                }
-                skip_quiets = true;
+            if NODE::ROOT && !td.root_moves[td.pv_index..td.pv_end].iter().any(|rm| rm.mv == mv) {
+                counter!(td, RootMoveSkipped);
                 continue;
             }
 
-            // Bad Noisy Futility Pruning (BNFP)
-            let noisy_futility_value = eval + 71 * depth + 68 * history / 1024 + 23;
+            counter!(td, MoveLoopCandidate);
+            move_count += 1;
+            current_search_count = 0;
+            td.stack[ply].move_count = move_count;
 
-            if !in_check
-                && depth < 11
-                && move_picker.stage() == Stage::BadNoisy
-                && noisy_futility_value <= alpha
-                && !td.board.is_direct_check(mv)
-            {
-                if !is_decisive(best_score) && best_score < noisy_futility_value {
-                    best_score = noisy_futility_value;
-                }
-                break;
-            }
+            let is_quiet = mv.is_quiet();
 
-            // Static Exchange Evaluation Pruning (SEE Pruning)
-            let threshold = if is_quiet {
-                (-17 * depth * depth + 52 * depth - 21 * history / 1024 + 20).min(0)
+            let history = if is_quiet {
+                td.quiet_history.get(td.board.all_threats(), stm, mv)
+                    + td.conthist(ply, 1, mv)
+                    + td.conthist(ply, 2, mv)
             } else {
-                (-8 * depth * depth - 36 * depth - 32 * history / 1024 + 11).min(0)
+                let captured = td.board.type_on(mv.to());
+                td.noisy_history.get(td.board.all_threats(), td.board.moved_piece(mv), mv.to(), captured)
             };
 
-            if !td.board.see(mv, threshold) {
-                continue;
-            }
-        }
-
-        let initial_nodes = td.nodes();
-
-        make_move(td, ply, mv);
-
-        let mut new_depth = depth - 1 + if move_count == 1 { extension } else { 0 };
-        let mut score = Score::ZERO;
-
-        // Late Move Reductions (LMR)
-        if depth >= 2 && move_count >= 2 {
-            let mut reduction = 225 * (move_count.ilog2() * depth.ilog2()) as i32;
-
-            reduction -= 68 * move_count;
-            reduction -= 3297 * correction_value.abs() / 1024;
-            reduction += 1306 * alpha_raises;
-
-            reduction += 546 * (is_valid(tt_score) && tt_score <= alpha) as i32;
-            reduction += 322 * (is_valid(tt_score) && tt_depth < depth) as i32;
-
-            if is_quiet {
-                reduction += 1806;
-                reduction -= 166 * history / 1024;
-            } else {
-                reduction += 1449;
-                reduction -= 109 * history / 1024;
-            }
-
-            if NODE::PV {
-                reduction -= 424 + 433 * (beta - alpha) / td.root_delta;
-            }
-
-            if tt_pv {
-                reduction -= 361;
-                reduction -= 636 * (is_valid(tt_score) && tt_score > alpha) as i32;
-                reduction -= 830 * (is_valid(tt_score) && tt_depth >= depth) as i32;
-            }
-
-            if !tt_pv && cut_node {
-                reduction += 1818;
-                reduction += 2118 * tt_move.is_null() as i32;
-            }
-
-            if !improving {
-                reduction += (430 - 263 * improvement / 128).min(1096);
-            }
-
-            if td.board.in_check() {
-                reduction -= 1021;
-            }
-
-            if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1515;
-            }
-
-            if is_valid(tt_move_score) && is_valid(singular_score) {
-                let margin = tt_move_score - singular_score;
-                reduction += (512 * (margin - 160) / 128).clamp(0, 2048);
-            }
-
-            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 485 {
-                reduction += 129;
-            }
-
-            reduction += helper_reduction_bias(td);
-
-            let reduced_depth =
-                (new_depth - reduction / 1024).clamp(1, new_depth + (move_count <= 3) as i32 + 1) + 2 * NODE::PV as i32;
-
-            td.stack[ply].reduction = reduction;
-            score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true, ply + 1);
-            td.stack[ply].reduction = 0;
-            current_search_count += 1;
-
-            if score > alpha {
-                if !NODE::ROOT {
-                    new_depth += (score > best_score + 61) as i32;
-                    new_depth += (score > best_score + 801) as i32;
-                    new_depth -= (score < best_score + 5 + reduced_depth) as i32;
+            if !NODE::ROOT && !is_loss(best_score) {
+                let _phase = metric_fine_scope!(td, CandidatePruning);
+                // Late Move Pruning (LMP)
+                if !in_check
+                    && !td.board.is_direct_check(mv)
+                    && is_quiet
+                    && move_count >= (3006 + 70 * improvement / 16 + 1455 * depth * depth + 68 * history / 1024) / 1024
+                {
+                    counter!(td, MovePruned, MovePrunedLateMove);
+                    skip_quiets = true;
+                    continue;
                 }
 
-                if new_depth > reduced_depth {
-                    score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node, ply + 1);
-                    current_search_count += 1;
-                }
-            }
-        }
-        // Full Depth Search (FDS)
-        else if !NODE::PV || move_count >= 2 {
-            let mut reduction = 232 * (move_count.ilog2() * depth.ilog2()) as i32;
+                // Futility Pruning (FP)
+                let futility_value = eval
+                    + 79 * depth
+                    + 64 * history / 1024
+                    + 84 * (eval >= beta) as i32
+                    + 560 * correction_value.abs() / 1024
+                    - 146;
 
-            reduction -= 48 * move_count;
-            reduction -= 2408 * correction_value.abs() / 1024;
-
-            if is_quiet {
-                reduction += 1429;
-                reduction -= 152 * history / 1024;
-            } else {
-                reduction += 1053;
-                reduction -= 67 * history / 1024;
-            }
-
-            if tt_pv {
-                reduction -= 936;
-                reduction -= 1080 * (is_valid(tt_score) && tt_depth >= depth) as i32;
-            }
-
-            if !tt_pv && cut_node {
-                reduction += 1543;
-                reduction += 2058 * tt_move.is_null() as i32;
-            }
-
-            if !improving {
-                reduction += (409 - 254 * improvement / 128).min(1488);
-            }
-
-            if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1360;
-            }
-
-            if is_valid(tt_move_score) && is_valid(singular_score) {
-                let margin = tt_move_score - singular_score;
-                reduction += (400 * (margin - 160) / 128).clamp(0, 2048);
-            }
-
-            if mv == tt_move {
-                reduction -= 3281;
-            }
-
-            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {
-                reduction += 130;
-            }
-
-            reduction += helper_reduction_bias(td);
-
-            let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585) as i32;
-
-            score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
-            current_search_count += 1;
-        }
-
-        // Principal Variation Search (PVS)
-        if NODE::PV && (move_count == 1 || score > alpha) {
-            if mv == tt_move && tt_depth > 1 && td.root_depth > 8 {
-                new_depth = new_depth.max(1);
-            }
-
-            score = -search::<PV>(td, -beta, -alpha, new_depth, false, ply + 1);
-            current_search_count += 1;
-        }
-
-        undo_move(td, mv);
-
-        if td.shared.status.get() == Status::STOPPED {
-            return Score::ZERO;
-        }
-
-        if NODE::ROOT {
-            let current_nodes = td.nodes();
-            let root_move = td.root_moves.iter_mut().find(|v| v.mv == mv).unwrap();
-
-            root_move.nodes += current_nodes - initial_nodes;
-
-            if move_count == 1 || score > alpha {
-                root_move.upperbound = false;
-                root_move.lowerbound = false;
-                match score {
-                    v if v <= alpha => {
-                        root_move.display_score = alpha;
-                        root_move.upperbound = true;
+                if !in_check && is_quiet && depth < 15 && futility_value <= alpha && !td.board.is_direct_check(mv) {
+                    if !is_decisive(best_score) && best_score < futility_value {
+                        best_score = futility_value;
                     }
-                    v if v >= beta => {
-                        root_move.display_score = beta;
-                        root_move.lowerbound = true;
+                    counter!(td, MovePruned, MovePrunedFutility);
+                    skip_quiets = true;
+                    continue;
+                }
+
+                // Bad Noisy Futility Pruning (BNFP)
+                let noisy_futility_value = eval + 71 * depth + 68 * history / 1024 + 23;
+
+                if !in_check
+                    && depth < 11
+                    && move_picker.stage() == Stage::BadNoisy
+                    && noisy_futility_value <= alpha
+                    && !td.board.is_direct_check(mv)
+                {
+                    if !is_decisive(best_score) && best_score < noisy_futility_value {
+                        best_score = noisy_futility_value;
                     }
-                    _ => {
-                        root_move.display_score = score;
-                    }
-                }
-
-                root_move.score = score;
-                root_move.sel_depth = td.sel_depth;
-                root_move.pv.commit_full_root_pv(&td.pv_table, 1);
-
-                if move_count > 1 && td.pv_index == 0 {
-                    td.best_move_changes += 1;
-                }
-            } else {
-                root_move.score = -Score::INFINITE;
-            }
-        }
-
-        if mv == tt_move {
-            tt_move_score = score;
-        }
-
-        if score > best_score {
-            best_score = score;
-
-            if score > alpha {
-                bound = Bound::Exact;
-                best_move = mv;
-
-                if !NODE::ROOT && NODE::PV {
-                    td.pv_table.update(ply as usize, mv);
-                }
-
-                if score >= beta {
-                    bound = Bound::Lower;
-                    td.stack[ply].cutoff_count += 1;
+                    counter!(td, MovePruned, MovePrunedBadNoisy);
                     break;
                 }
 
-                alpha = score;
+                // Static Exchange Evaluation Pruning (SEE Pruning)
+                let threshold = if is_quiet {
+                    (-17 * depth * depth + 52 * depth - 21 * history / 1024 + 20).min(0)
+                } else {
+                    (-8 * depth * depth - 36 * depth - 32 * history / 1024 + 11).min(0)
+                };
 
-                if !(NODE::ROOT && td.pv_index > 0) && mv != tt_move {
-                    td.shared.tt.write(hash, depth, raw_eval, score, Bound::Lower, mv, ply, true, false);
-                }
-
-                if !is_decisive(score) {
-                    alpha_raises += 1;
+                if !td.board.see(mv, threshold) {
+                    counter!(td, MovePruned, MovePrunedSee);
+                    continue;
                 }
             }
-        }
 
-        if mv != best_move && move_count < 32 {
-            if is_quiet {
-                quiet_moves.push(mv);
-            } else {
-                noisy_moves.push(mv);
+            let initial_nodes = td.nodes();
+
+            let _child_phase = metric_scope!(td, ChildSearch);
+            {
+                let _phase = metric_fine_scope!(td, MakeUndo);
+                make_move(td, ply, mv);
+            }
+
+            let mut new_depth = depth - 1 + if move_count == 1 { extension } else { 0 };
+            let mut score = Score::ZERO;
+
+            // Late Move Reductions (LMR)
+            if depth >= 2 && move_count >= 2 {
+                counter!(td, ReducedSearch);
+                let mut reduction = 225 * (move_count.ilog2() * depth.ilog2()) as i32;
+
+                reduction -= 68 * move_count;
+                reduction -= 3297 * correction_value.abs() / 1024;
+                reduction += 1306 * alpha_raises;
+
+                reduction += 546 * (is_valid(tt_score) && tt_score <= alpha) as i32;
+                reduction += 322 * (is_valid(tt_score) && tt_depth < depth) as i32;
+
+                if is_quiet {
+                    reduction += 1806;
+                    reduction -= 166 * history / 1024;
+                } else {
+                    reduction += 1449;
+                    reduction -= 109 * history / 1024;
+                }
+
+                if NODE::PV {
+                    reduction -= 424 + 433 * (beta - alpha) / td.root_delta;
+                }
+
+                if tt_pv {
+                    reduction -= 361;
+                    reduction -= 636 * (is_valid(tt_score) && tt_score > alpha) as i32;
+                    reduction -= 830 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                }
+
+                if !tt_pv && cut_node {
+                    reduction += 1818;
+                    reduction += 2118 * tt_move.is_null() as i32;
+                }
+
+                if !improving {
+                    reduction += (430 - 263 * improvement / 128).min(1096);
+                }
+
+                if td.board.in_check() {
+                    reduction -= 1021;
+                }
+
+                if td.stack[ply + 1].cutoff_count > 2 {
+                    reduction += 1515;
+                }
+
+                if is_valid(tt_move_score) && is_valid(singular_score) {
+                    let margin = tt_move_score - singular_score;
+                    reduction += (512 * (margin - 160) / 128).clamp(0, 2048);
+                }
+
+                if !NODE::PV && td.stack[ply - 1].reduction > reduction + 485 {
+                    reduction += 129;
+                }
+
+                reduction += helper_reduction_bias(td);
+
+                let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + (move_count <= 3) as i32 + 1)
+                    + 2 * NODE::PV as i32;
+
+                td.stack[ply].reduction = reduction;
+                {
+                    let _phase = metric_fine_scope!(td, Reduction);
+                    score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true, ply + 1);
+                }
+                td.stack[ply].reduction = 0;
+                current_search_count += 1;
+
+                if score > alpha {
+                    if !NODE::ROOT {
+                        new_depth += (score > best_score + 61) as i32;
+                        new_depth += (score > best_score + 801) as i32;
+                        new_depth -= (score < best_score + 5 + reduced_depth) as i32;
+                    }
+
+                    if new_depth > reduced_depth {
+                        counter!(td, Research);
+                        score = -search::<NonPV>(td, -alpha - 1, -alpha, new_depth, !cut_node, ply + 1);
+                        current_search_count += 1;
+                    }
+                }
+            }
+            // Full Depth Search (FDS)
+            else if !NODE::PV || move_count >= 2 {
+                counter!(td, FullDepthSearch);
+                let mut reduction = 232 * (move_count.ilog2() * depth.ilog2()) as i32;
+
+                reduction -= 48 * move_count;
+                reduction -= 2408 * correction_value.abs() / 1024;
+
+                if is_quiet {
+                    reduction += 1429;
+                    reduction -= 152 * history / 1024;
+                } else {
+                    reduction += 1053;
+                    reduction -= 67 * history / 1024;
+                }
+
+                if tt_pv {
+                    reduction -= 936;
+                    reduction -= 1080 * (is_valid(tt_score) && tt_depth >= depth) as i32;
+                }
+
+                if !tt_pv && cut_node {
+                    reduction += 1543;
+                    reduction += 2058 * tt_move.is_null() as i32;
+                }
+
+                if !improving {
+                    reduction += (409 - 254 * improvement / 128).min(1488);
+                }
+
+                if td.stack[ply + 1].cutoff_count > 2 {
+                    reduction += 1360;
+                }
+
+                if is_valid(tt_move_score) && is_valid(singular_score) {
+                    let margin = tt_move_score - singular_score;
+                    reduction += (400 * (margin - 160) / 128).clamp(0, 2048);
+                }
+
+                if mv == tt_move {
+                    reduction -= 3281;
+                }
+
+                if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {
+                    reduction += 130;
+                }
+
+                reduction += helper_reduction_bias(td);
+
+                let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585) as i32;
+
+                {
+                    let _phase = metric_fine_scope!(td, Reduction);
+                    score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, !cut_node, ply + 1);
+                }
+                current_search_count += 1;
+            }
+
+            // Principal Variation Search (PVS)
+            if NODE::PV && (move_count == 1 || score > alpha) {
+                counter!(td, PvSearch);
+                if mv == tt_move && tt_depth > 1 && td.root_depth > 8 {
+                    new_depth = new_depth.max(1);
+                }
+
+                score = -search::<PV>(td, -beta, -alpha, new_depth, false, ply + 1);
+                current_search_count += 1;
+            }
+
+            {
+                let _phase = metric_fine_scope!(td, MakeUndo);
+                undo_move(td, mv);
+            }
+
+            if td.shared.status.get() == Status::STOPPED {
+                return Score::ZERO;
+            }
+
+            if NODE::ROOT {
+                let current_nodes = td.nodes();
+                let root_move = td.root_moves.iter_mut().find(|v| v.mv == mv).unwrap();
+
+                root_move.nodes += current_nodes - initial_nodes;
+
+                if move_count == 1 || score > alpha {
+                    root_move.upperbound = false;
+                    root_move.lowerbound = false;
+                    match score {
+                        v if v <= alpha => {
+                            root_move.display_score = alpha;
+                            root_move.upperbound = true;
+                        }
+                        v if v >= beta => {
+                            root_move.display_score = beta;
+                            root_move.lowerbound = true;
+                        }
+                        _ => {
+                            root_move.display_score = score;
+                        }
+                    }
+
+                    root_move.score = score;
+                    root_move.sel_depth = td.sel_depth;
+                    root_move.pv.commit_full_root_pv(&td.pv_table, 1);
+
+                    if move_count > 1 && td.pv_index == 0 {
+                        td.best_move_changes += 1;
+                    }
+                } else {
+                    root_move.score = -Score::INFINITE;
+                }
+            }
+
+            if mv == tt_move {
+                tt_move_score = score;
+            }
+
+            if score > best_score {
+                best_score = score;
+
+                if score > alpha {
+                    bound = Bound::Exact;
+                    best_move = mv;
+
+                    if !NODE::ROOT && NODE::PV {
+                        td.pv_table.update(ply as usize, mv);
+                    }
+
+                    if score >= beta {
+                        counter!(td, BetaCutoff);
+                        bound = Bound::Lower;
+                        td.stack[ply].cutoff_count += 1;
+                        break;
+                    }
+
+                    alpha = score;
+
+                    if !(NODE::ROOT && td.pv_index > 0) && mv != tt_move {
+                        counter!(td, TtWrite, TtLowerWrite);
+                        td.shared.tt.write(hash, depth, raw_eval, score, Bound::Lower, mv, ply, true, false);
+                    }
+
+                    if !is_decisive(score) {
+                        alpha_raises += 1;
+                    }
+                }
+            }
+
+            if mv != best_move && move_count < 32 {
+                if is_quiet {
+                    quiet_moves.push(mv);
+                } else {
+                    noisy_moves.push(mv);
+                }
             }
         }
     }
+
+    let _phase = metric_scope!(td, Finalization);
 
     if move_count == 0 {
         if excluded {
@@ -1014,6 +1128,7 @@ fn search<NODE: NodeType>(
     }
 
     if best_move.is_present() {
+        let _phase = metric_fine_scope!(td, HistoryUpdate);
         let noisy_bonus = (115 * depth).min(778) - 50 - 77 * cut_node as i32;
         let noisy_malus = (176 * depth).min(1343) - 51 - 21 * noisy_moves.len() as i32;
 
@@ -1102,6 +1217,13 @@ fn search<NODE: NodeType>(
     }
 
     if !(excluded || NODE::ROOT && td.pv_index > 0) {
+        counter!(td, TtWrite);
+        match bound {
+            Bound::Lower => counter!(td, TtLowerWrite),
+            Bound::Upper => counter!(td, TtUpperWrite),
+            Bound::Exact => counter!(td, TtExactWrite),
+            Bound::None => {}
+        }
         td.shared.tt.write(hash, depth, raw_eval, best_score, bound, best_move, ply, tt_pv, NODE::PV);
     }
 
@@ -1120,6 +1242,7 @@ fn search<NODE: NodeType>(
 }
 
 fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: isize) -> i32 {
+    let entry_phase = metric_scope!(td, QsearchEntry);
     debug_assert!(!NODE::ROOT);
     debug_assert!(ply as usize <= MAX_PLY);
     debug_assert!(-Score::INFINITE <= alpha && alpha < beta && beta <= Score::INFINITE);
@@ -1155,7 +1278,11 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     }
 
     let hash = td.board.hash();
-    let entry = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
+    let entry = {
+        counter!(td, TtProbe);
+        let _phase = metric_fine_scope!(td, TtAccess);
+        td.shared.tt.read(hash, td.board.halfmove_clock(), ply)
+    };
 
     let mut tt_move = Move::NULL;
     let mut tt_score = Score::NONE;
@@ -1164,6 +1291,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
     // QS early TT cutoff
     if let Some(entry) = &entry {
+        counter!(td, TtHit);
         tt_move = entry.mv;
         tt_score = entry.score;
         tt_bound = entry.bound;
@@ -1177,51 +1305,79 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
                 _ => true,
             }
         {
+            counter!(td, TtCutoff, TtQsearchCutoff);
             return tt_score;
         }
     }
+    finish_metric_scope!(entry_phase);
+    counter!(td, QsearchNode);
 
     let raw_eval;
     let eval;
     let mut best_score;
-    let correction_value = eval_correction(td, ply);
+    let correction_value;
 
-    // Evaluation
-    if in_check {
-        raw_eval = Score::NONE;
-        eval = Score::NONE;
-        best_score = -Score::INFINITE;
-    } else {
-        raw_eval = match &entry {
-            Some(entry) if is_valid(entry.raw_eval) => entry.raw_eval,
-            _ => td.nnue.evaluate(&td.board),
-        };
-        eval = correct_eval(td, raw_eval, correction_value);
-        best_score = eval;
+    {
+        let _stand_pat_phase = metric_scope!(td, QsearchStandPat);
+        correction_value = eval_correction(td, ply);
 
-        if is_valid(tt_score)
-            && (!NODE::PV || !is_decisive(tt_score))
-            && match tt_bound {
-                Bound::Upper => tt_score < best_score,
-                Bound::Lower => tt_score > best_score,
-                _ => true,
+        // Evaluation
+        if in_check {
+            raw_eval = Score::NONE;
+            eval = Score::NONE;
+            best_score = -Score::INFINITE;
+        } else {
+            raw_eval = match &entry {
+                Some(entry) if is_valid(entry.raw_eval) => {
+                    counter!(td, TtRawEval);
+                    entry.raw_eval
+                }
+                _ => {
+                    counter!(td, StaticEval);
+                    td.nnue.evaluate(&td.board)
+                }
+            };
+            counter!(td, CorrectionApplied);
+            eval = correct_eval(td, raw_eval, correction_value);
+            best_score = eval;
+
+            if is_valid(tt_score)
+                && (!NODE::PV || !is_decisive(tt_score))
+                && match tt_bound {
+                    Bound::Upper => tt_score < best_score,
+                    Bound::Lower => tt_score > best_score,
+                    _ => true,
+                }
+            {
+                counter!(td, TtScoreAsEval);
+                best_score = tt_score;
             }
-        {
-            best_score = tt_score;
-        }
-    }
-
-    // Stand Pat
-    if best_score >= beta {
-        if !is_decisive(best_score) && !is_decisive(beta) {
-            best_score = beta + (best_score - beta) / 3;
         }
 
-        if entry.is_none() {
-            td.shared.tt.write(hash, TtDepth::SOME, raw_eval, best_score, Bound::Lower, Move::NULL, ply, tt_pv, false);
-        }
+        // Stand Pat
+        if best_score >= beta {
+            counter!(td, QsearchStandPatCutoff);
+            if !is_decisive(best_score) && !is_decisive(beta) {
+                best_score = beta + (best_score - beta) / 3;
+            }
 
-        return best_score;
+            if entry.is_none() {
+                counter!(td, TtWrite, TtLowerWrite, QsearchTtWrite);
+                td.shared.tt.write(
+                    hash,
+                    TtDepth::SOME,
+                    raw_eval,
+                    best_score,
+                    Bound::Lower,
+                    Move::NULL,
+                    ply,
+                    tt_pv,
+                    false,
+                );
+            }
+
+            return best_score;
+        }
     }
 
     if best_score > alpha {
@@ -1236,48 +1392,57 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let skip_quiets =
         |best_score| !((in_check && is_loss(best_score)) || (tt_move.is_quiet() && tt_bound != Bound::Upper));
 
-    while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
-        move_count += 1;
+    {
+        let _phase = metric_scope!(td, QsearchMoveLoop);
 
-        if !is_loss(best_score) {
-            // Late Move Pruning (LMP)
-            if move_count >= 3 && !td.board.is_direct_check(mv) {
-                break;
-            }
+        while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
+            counter!(td, QsearchCandidate);
+            move_count += 1;
 
-            // Static Exchange Evaluation Pruning (SEE Pruning)
-            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - correction_value.abs().min(64) - 79) {
-                continue;
-            }
-        }
-
-        make_move(td, ply, mv);
-        let score = -qsearch::<NODE>(td, -beta, -alpha, ply + 1);
-        undo_move(td, mv);
-
-        if td.shared.status.get() == Status::STOPPED {
-            return Score::ZERO;
-        }
-
-        if score > best_score {
-            best_score = score;
-
-            if score > alpha {
-                best_move = mv;
-
-                if NODE::PV {
-                    td.pv_table.update(ply as usize, mv);
-                }
-
-                if score >= beta {
+            if !is_loss(best_score) {
+                // Late Move Pruning (LMP)
+                if move_count >= 3 && !td.board.is_direct_check(mv) {
+                    counter!(td, QsearchQuietSkip);
                     break;
                 }
 
-                alpha = score;
+                // Static Exchange Evaluation Pruning (SEE Pruning)
+                if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - correction_value.abs().min(64) - 79) {
+                    counter!(td, QsearchSeePrune);
+                    continue;
+                }
+            }
+
+            make_move(td, ply, mv);
+            let score = -qsearch::<NODE>(td, -beta, -alpha, ply + 1);
+            undo_move(td, mv);
+
+            if td.shared.status.get() == Status::STOPPED {
+                return Score::ZERO;
+            }
+
+            if score > best_score {
+                best_score = score;
+
+                if score > alpha {
+                    best_move = mv;
+
+                    if NODE::PV {
+                        td.pv_table.update(ply as usize, mv);
+                    }
+
+                    if score >= beta {
+                        counter!(td, QsearchBetaCutoff);
+                        break;
+                    }
+
+                    alpha = score;
+                }
             }
         }
     }
 
+    let _phase = metric_scope!(td, QsearchFinalization);
     if in_check && move_count == 0 {
         return mated_in(ply);
     }
@@ -1305,6 +1470,12 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
     let bound = if best_score >= beta { Bound::Lower } else { Bound::Upper };
 
+    counter!(td, TtWrite, QsearchTtWrite);
+    match bound {
+        Bound::Lower => counter!(td, TtLowerWrite),
+        Bound::Upper => counter!(td, TtUpperWrite),
+        Bound::Exact | Bound::None => {}
+    }
     td.shared.tt.write(hash, TtDepth::SOME, raw_eval, best_score, bound, best_move, ply, tt_pv, false);
 
     debug_assert!(alpha < beta);

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -15,6 +15,9 @@ use crate::{
     types::{MAX_MOVES, MAX_PLY, Move, Score, normalize_to_cp},
 };
 
+#[cfg(feature = "search-metrics")]
+use crate::metrics::Metrics;
+
 #[repr(align(64))]
 struct AlignedAtomicU64 {
     inner: AtomicU64,
@@ -107,6 +110,8 @@ pub struct SharedContext {
     pub root_in_tb: AtomicBool,
     pub soft_stop_votes: AtomicUsize,
     pub best_stats: [AtomicU32; MAX_MOVES],
+    #[cfg(feature = "search-metrics")]
+    pub metrics: Metrics,
     pub history: Arc<NumaReplicated<SharedCorrectionHistory>>,
     pub parameters: Arc<NumaReplicated<ParametersHandle>>,
     pub numa_context: Arc<NumaReplicationContext>,
@@ -125,6 +130,8 @@ impl Default for SharedContext {
             root_in_tb: AtomicBool::new(false),
             soft_stop_votes: AtomicUsize::new(0),
             best_stats: [const { AtomicU32::new(0) }; MAX_MOVES],
+            #[cfg(feature = "search-metrics")]
+            metrics: Metrics::new(ThreadPool::available_threads()),
             history: NumaReplicated::new(numa_context.clone()),
             parameters: NumaReplicated::new(numa_context.clone()),
             numa_context,

--- a/src/tools/bench.rs
+++ b/src/tools/bench.rs
@@ -126,3 +126,46 @@ pub fn bench<const PRETTY: bool>(args: &[&str]) {
 
     crate::misc::dbg_print();
 }
+
+pub fn profilebench(args: &[&str]) {
+    #[cfg(feature = "search-metrics")]
+    {
+        run_profilebench(args);
+    }
+
+    #[cfg(not(feature = "search-metrics"))]
+    {
+        let _ = args;
+        eprintln!("profilebench requires the search-metrics feature");
+    }
+}
+
+#[cfg(feature = "search-metrics")]
+fn run_profilebench(args: &[&str]) {
+    #[allow(clippy::get_first)]
+    let hash = args.get(0).and_then(|v| v.parse().ok()).unwrap_or(DEFAULT_HASH);
+    let threads = args.get(1).and_then(|v| v.parse().ok()).unwrap_or(DEFAULT_THREADS);
+    let depth = args.get(2).and_then(|v| v.parse().ok()).unwrap_or(DEFAULT_DEPTH);
+
+    let shared = Arc::new(SharedContext::default());
+    shared.tt.resize(threads, hash);
+    shared.metrics.reset();
+
+    let mut pool = ThreadPool::new(shared.clone());
+    pool.set_count(threads);
+
+    let mut nodes = 0;
+    let time = Instant::now();
+
+    for &position in POSITIONS {
+        let board = Board::from_fen(position).unwrap();
+        let time_manager = TimeManager::new(Limits::Depth(depth), 0, 0);
+
+        pool.execute_searches(time_manager, Report::None, 1, &board, &shared);
+        nodes += shared.nodes.aggregate();
+    }
+
+    let seconds = time.elapsed().as_secs_f64();
+    let nps = nodes as f64 / seconds;
+    shared.metrics.print_tsv(nodes, nps);
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,7 @@ mod bench;
 mod perft;
 
 pub use bench::bench;
+pub use bench::profilebench;
 pub use perft::is_legal_perft;
 pub use perft::perft;
 pub use perft::simple_perft;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -87,6 +87,7 @@ pub fn message_loop(mut buffer: VecDeque<String>) {
                 Mode::Uci => tools::bench::<true>(args),
                 Mode::Cli => tools::bench::<false>(args),
             },
+            ["profilebench", args @ ..] => tools::profilebench(args),
             ["perft", depth] => tools::perft(depth.parse().unwrap(), &mut board),
             ["perft"] => eprintln!("Usage: perft <depth>"),
             ["simpleperft", depth] => tools::simple_perft(depth.parse().unwrap(), &mut board),


### PR DESCRIPTION
## Summary

Adds an opt-in `profilebench` mode for search profiling. It runs the normal bench corpus with named search event counters and optional exclusive phase timing, then prints TSV output for branch-to-branch comparison.

I built this while investigating the large search refactor. The useful case was: node counts matched, but NPS moved, so a purely mechanical benchmark was not enough to say where the cost moved inside the search algorithm. `profilebench` gives a reusable search-phase map before reaching for asm, Instruments, perf, or ad hoc probes.

`dbg_hit` remains useful once the exact formula or branch is known. `profilebench` is the broader first pass: TT probes/cutoffs, pruning counts, qsearch candidates, beta cutoffs, reductions, singular-extension outcomes, and phase timing for eval setup, move ordering, child search, qsearch, finalization, plus mechanical subpoints like move picker, make/undo, reductions, and TT access.

This also makes it possible to chart heuristic behavior over time. For example, singular-extension frequency, double/triple extension rates, pruning rates, or qsearch candidate counts can be compared across commits without adding one-off local instrumentation each time.

Normal builds compile the instrumentation out. Timed builds are enabled through `search-metrics-time`, with `search-metrics-fine-time` for narrower scopes.

## Timing Notes

On Apple/aarch64, the timed build uses the ARM generic counter (`cntvct_el0`) and reports `timer_frequency_hz`. Other platforms use the `Instant` fallback for now. I do not have x86 Linux/Windows hardware locally, so that path could use a quick sanity check from someone with those machines.

The timed build is diagnostic and changes code shape. It should not replace normal `bench`, speed tests, SPRT, or platform profilers. The intended workflow is:

1. Use `bench` to check deterministic node count.
2. Use `profilebench` to check whether search events or phase costs moved.
3. Use asm/perf/Instruments/etc. to explain the suspicious phase mechanically.

## Validation

After rebasing on `main` (`6f3ca282`):

- `cargo fmt --check`
- `cargo check`
- `cargo check --no-default-features`
- `cargo check --features search-metrics`
- `cargo check --features search-metrics-time`
- `cargo check --features search-metrics-fine-time`
- `markdownlint-cli2 docs/search-metrics.md`
- `cargo rustc --release --features search-metrics-time -- -C target-cpu=native`
- `target/release/reckless "profilebench 16 1 12"`

`profilebench 16 1 12` after the rebase reports:

- nodes: `2508171`
- timer source: `cntvct_el0`
- timer frequency: `24000000`
- root iterations: `600`
- completed depths: `600`
