### PR TITLE
Bucket correction history by halfmove clock

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -76,11 +76,15 @@ impl Board {
         self.fullmove_number
     }
 
+    pub fn halfmove_clock_bucket(&self) -> usize {
+        (self.halfmove_clock().saturating_sub(8) as usize / 8).min(15)
+    }
+
     pub fn hash(&self) -> u64 {
         // To mitigate Graph History Interaction (GHI) problems, the hash key is changed
         // every 8 plies to distinguish between positions that would otherwise appear
         // identical to the transposition table.
-        self.state.key ^ ZOBRIST.halfmove_clock[(self.halfmove_clock().saturating_sub(8) as usize / 8).min(15)]
+        self.state.key ^ ZOBRIST.halfmove_clock[self.halfmove_clock_bucket()]
     }
 
     pub const fn pawn_key(&self) -> u64 {

--- a/src/history.rs
+++ b/src/history.rs
@@ -118,7 +118,7 @@ impl Default for NoisyHistory {
 
 pub struct CorrectionHistory {
     // [side_to_move][key]
-    entries: Box<[[AtomicI16; Self::SIZE]; 2]>,
+    entries: Box<[[[AtomicI16; Self::SIZE]; 2]; 16]>,
 }
 
 impl CorrectionHistory {
@@ -127,20 +127,22 @@ impl CorrectionHistory {
     const SIZE: usize = 65536;
     const MASK: usize = Self::SIZE - 1;
 
-    pub fn get(&self, stm: Color, key: u64) -> i32 {
-        self.entries[stm][key as usize & Self::MASK].load(Ordering::Relaxed) as i32
+    pub fn get(&self, stm: Color, key: u64, bucket: usize) -> i32 {
+        self.entries[bucket][stm][key as usize & Self::MASK].load(Ordering::Relaxed) as i32
     }
 
-    pub fn update(&self, stm: Color, key: u64, bonus: i32) {
-        let current = self.entries[stm][key as usize & Self::MASK].load(Ordering::Relaxed) as i32;
+    pub fn update(&self, stm: Color, key: u64, bucket: usize, bonus: i32) {
+        let current = self.entries[bucket][stm][key as usize & Self::MASK].load(Ordering::Relaxed) as i32;
         let new = current + bonus - bonus.abs() * current / Self::MAX_HISTORY;
-        self.entries[stm][key as usize & Self::MASK].store(new as i16, Ordering::Relaxed);
+        self.entries[bucket][stm][key as usize & Self::MASK].store(new as i16, Ordering::Relaxed);
     }
 
     pub fn clear(&self) {
-        for entries in self.entries.iter() {
-            for entry in entries {
-                entry.store(0, Ordering::Relaxed);
+        for bucket in self.entries.iter() {
+            for entries in bucket.iter() {
+                for entry in entries {
+                    entry.store(0, Ordering::Relaxed);
+                }
             }
         }
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -117,7 +117,7 @@ impl Default for NoisyHistory {
 }
 
 pub struct CorrectionHistory {
-    // [side_to_move][key]
+    // [bucket][side_to_move][key]
     entries: Box<[[[AtomicI16; Self::SIZE]; 2]; 16]>,
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1315,11 +1315,12 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
 
 fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
     let stm = td.board.side_to_move();
+    let bucket = td.board.halfmove_clock_bucket();
     let corrhist = td.corrhist();
 
-    (corrhist.pawn.get(stm, td.board.pawn_key())
-        + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White))
-        + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black))
+    (corrhist.pawn.get(stm, td.board.pawn_key(), bucket)
+        + corrhist.non_pawn[Color::White].get(stm, td.board.non_pawn_key(Color::White), bucket)
+        + corrhist.non_pawn[Color::Black].get(stm, td.board.non_pawn_key(Color::Black), bucket)
         + td.continuation_corrhist.get(
             td.stack[ply - 2].contcorrhist,
             td.stack[ply - 1].piece,
@@ -1335,13 +1336,14 @@ fn eval_correction(td: &ThreadData, ply: isize) -> i32 {
 
 fn update_correction_histories(td: &mut ThreadData, depth: i32, diff: i32, ply: isize) {
     let stm = td.board.side_to_move();
+    let bucket = td.board.halfmove_clock_bucket();
     let corrhist = td.corrhist();
     let bonus = (142 * depth * diff / 128).clamp(-4771, 3001);
 
-    corrhist.pawn.update(stm, td.board.pawn_key(), bonus);
+    corrhist.pawn.update(stm, td.board.pawn_key(), bucket, bonus);
 
-    corrhist.non_pawn[Color::White].update(stm, td.board.non_pawn_key(Color::White), bonus);
-    corrhist.non_pawn[Color::Black].update(stm, td.board.non_pawn_key(Color::Black), bonus);
+    corrhist.non_pawn[Color::White].update(stm, td.board.non_pawn_key(Color::White), bucket, bonus);
+    corrhist.non_pawn[Color::Black].update(stm, td.board.non_pawn_key(Color::Black), bucket, bonus);
 
     if td.stack[ply - 1].mv.is_present() && td.stack[ply - 2].mv.is_present() {
         td.continuation_corrhist.update(


### PR DESCRIPTION
STC
Elo   | 1.27 +- 1.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 115972 W: 29128 L: 28705 D: 58139
Penta | [315, 12946, 31048, 13355, 322]
https://recklesschess.space/test/13850/

LTC
Elo   | 2.30 +- 1.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.06 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36864 W: 9189 L: 8945 D: 18730
Penta | [23, 3949, 10241, 4199, 20]
https://recklesschess.space/test/13862/

 Bench: 2838290