### PR TITLE
Simplify skip_quiets boolean expression

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1157,14 +1157,12 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let hash = td.board.hash();
     let entry = td.shared.tt.read(hash, td.board.halfmove_clock(), ply);
 
-    let mut tt_move = Move::NULL;
     let mut tt_score = Score::NONE;
     let mut tt_bound = Bound::None;
     let mut tt_pv = NODE::PV;
 
     // QS early TT cutoff
     if let Some(entry) = &entry {
-        tt_move = entry.mv;
         tt_score = entry.score;
         tt_bound = entry.bound;
         tt_pv |= entry.tt_pv;
@@ -1233,8 +1231,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut move_count = 0;
     let mut move_picker = MovePicker::new_qsearch();
 
-    let skip_quiets =
-        |best_score| !((in_check && is_loss(best_score)) || (tt_move.is_quiet() && tt_bound != Bound::Upper));
+    let skip_quiets = |best_score| !in_check || !is_loss(best_score);
 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
         move_count += 1;


### PR DESCRIPTION
STC
Elo   | 4.80 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.15 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 11872 W: 3073 L: 2909 D: 5890
Penta | [24, 1349, 3036, 1493, 34]
https://recklesschess.space/test/13902/

LTC
Elo   | 2.04 +- 2.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 21588 W: 5277 L: 5150 D: 11161
Penta | [8, 2389, 5875, 2512, 10]
https://recklesschess.space/test/13904/