### PR TITLE
Simplify quiet history updates in qsearch

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1133,7 +1133,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         }
     }
 
-    let stm = td.board.side_to_move();
     let in_check = td.board.in_check();
 
     if NODE::PV {
@@ -1282,21 +1281,16 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         return mated_in(ply);
     }
 
-    if best_score >= beta {
-        let is_noisy = best_move.is_noisy();
-        let bonus = if is_noisy { 106 } else { 172 };
+    if best_score >= beta && best_move.is_noisy() {
+        let bonus = 106;
 
-        if is_noisy {
-            td.noisy_history.update(
-                td.board.all_threats(),
-                td.board.moved_piece(best_move),
-                best_move.to(),
-                td.board.type_on(best_move.to()),
-                bonus,
-            );
-        } else {
-            td.quiet_history.update(td.board.all_threats(), stm, best_move, bonus);
-        }
+        td.noisy_history.update(
+            td.board.all_threats(),
+            td.board.moved_piece(best_move),
+            best_move.to(),
+            td.board.type_on(best_move.to()),
+            bonus,
+        );
     }
 
     if best_score >= beta && !is_decisive(best_score) && !is_decisive(beta) {


### PR DESCRIPTION
STC
Elo   | 5.00 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 11110 W: 2934 L: 2774 D: 5402
Penta | [27, 1246, 2864, 1376, 42]
https://recklesschess.space/test/13868/

LTC
Elo   | 0.85 +- 1.65 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 38984 W: 9686 L: 9591 D: 19707
Penta | [15, 4341, 10684, 4438, 14]
https://recklesschess.space/test/13886/

Bench: 2623027
