### PR TITLE
Add noise to LMR and FDS reduction to improve thread divergence

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -830,6 +830,8 @@ fn search<NODE: NodeType>(
                 reduction += 129;
             }
 
+            reduction += (td.nodes() % 64) as i32 - 32;
+
             reduction += helper_reduction_bias(td);
 
             let reduced_depth =
@@ -898,6 +900,8 @@ fn search<NODE: NodeType>(
             if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {
                 reduction += 130;
             }
+
+            reduction += (td.nodes() % 64) as i32 - 32;
 
             reduction += helper_reduction_bias(td);
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -830,9 +830,7 @@ fn search<NODE: NodeType>(
                 reduction += 129;
             }
 
-            reduction += (td.nodes() % 64) as i32 - 32;
-
-            reduction += helper_reduction_bias(td);
+            reduction += ((td.nodes() + td.id as u64 * 23) % 128) as i32 - 64;
 
             let reduced_depth =
                 (new_depth - reduction / 1024).clamp(1, new_depth + (move_count <= 3) as i32 + 1) + 2 * NODE::PV as i32;
@@ -901,9 +899,7 @@ fn search<NODE: NodeType>(
                 reduction += 130;
             }
 
-            reduction += (td.nodes() % 64) as i32 - 32;
-
-            reduction += helper_reduction_bias(td);
+            reduction += ((td.nodes() + td.id as u64 * 23) % 128) as i32 - 64;
 
             let reduced_depth = new_depth - (reduction >= 2864) as i32 - (reduction >= 5585) as i32;
 
@@ -1366,19 +1362,6 @@ fn update_continuation_histories(td: &mut ThreadData, ply: isize, piece: Piece, 
         if entry.mv.is_present() {
             td.continuation_history.update(entry.conthist, piece, sq, bonus);
         }
-    }
-}
-
-fn helper_reduction_bias(td: &ThreadData) -> i32 {
-    if td.id == 0 {
-        return 0;
-    }
-
-    match td.id % 4 {
-        1 => -96,
-        2 => 96,
-        3 => -48,
-        _ => 48,
     }
 }
 


### PR DESCRIPTION
1 Thread non-regression bounds
Elo   | -0.10 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 111828 W: 28169 L: 28201 D: 55458
Penta | [282, 13240, 28923, 13166, 303]
https://recklesschess.space/test/13918/

8 Threads gainer bounds
Elo   | 3.19 +- 2.37 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=256MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 4.00]
Games | N: 19470 W: 4929 L: 4750 D: 9791
Penta | [20, 2115, 5290, 2286, 24]
https://recklesschess.space/test/13911/

Bench: 2568610