### PR TITLE
Simplify alpha raises to be a bool rather than a counter

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -694,7 +694,7 @@ fn search<NODE: NodeType>(
     let mut move_picker = MovePicker::new(tt_move);
     let mut skip_quiets = false;
     let mut current_search_count = 0;
-    let mut alpha_raises = 0;
+    let mut alpha_raises = false;
     let mut tt_move_score = Score::NONE;
 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets, ply) {
@@ -786,7 +786,7 @@ fn search<NODE: NodeType>(
 
             reduction -= 68 * move_count;
             reduction -= 3297 * correction_value.abs() / 1024;
-            reduction += 1306 * alpha_raises;
+            reduction += 1306 * alpha_raises as i32;
 
             reduction += 546 * (is_valid(tt_score) && tt_score <= alpha) as i32;
             reduction += 322 * (is_valid(tt_score) && tt_depth < depth) as i32;
@@ -991,7 +991,7 @@ fn search<NODE: NodeType>(
                 }
 
                 if !is_decisive(score) {
-                    alpha_raises += 1;
+                    alpha_raises = true;
                 }
             }
         }


### PR DESCRIPTION
STC
Elo   | 0.21 +- 1.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 70886 W: 17859 L: 17816 D: 35211
Penta | [196, 8334, 18348, 8361, 204]
https://recklesschess.space/test/13903/

LTC
Elo   | 0.55 +- 1.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 48700 W: 12028 L: 11951 D: 24721
Penta | [10, 5519, 13228, 5570, 23]
https://recklesschess.space/test/13909/