### PR TITLE
Simplify away one of the lmr depth checks

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -843,7 +843,6 @@ fn search<NODE: NodeType>(
             if score > alpha {
                 if !NODE::ROOT {
                     new_depth += (score > best_score + 61) as i32;
-                    new_depth += (score > best_score + 801) as i32;
                     new_depth -= (score < best_score + 5 + reduced_depth) as i32;
                 }
 


### PR DESCRIPTION
STC
Elo   | 2.26 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 21054 W: 5360 L: 5223 D: 10471
Penta | [55, 2418, 5452, 2539, 63]
https://recklesschess.space/test/13915/

LTC
Elo   | 0.93 +- 1.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 36822 W: 9136 L: 9037 D: 18649
Penta | [22, 4079, 10106, 4186, 18]
https://recklesschess.space/test/13922/