### PR TITLE
Simplify interpolation function in fail high adjustments

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1087,8 +1087,7 @@ fn search<NODE: NodeType>(
     tt_pv |= !NODE::ROOT && bound == Bound::Upper && move_count > 2 && td.stack[ply - 1].tt_pv;
 
     if !NODE::ROOT && best_score >= beta && !is_decisive(best_score) && !is_decisive(alpha) {
-        let weight = depth.min(8);
-        best_score = (best_score * weight + beta) / (weight + 1);
+        best_score = (best_score * 5 + beta) / 6;
     }
 
     #[cfg(feature = "syzygy")]


### PR DESCRIPTION
STC
Elo   | -0.11 +- 1.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 115512 W: 29007 L: 29043 D: 57462
Penta | [331, 13775, 29573, 13753, 324]
https://recklesschess.space/test/13955/

LTC
Elo   | 2.08 +- 2.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 20916 W: 5210 L: 5085 D: 10621
Penta | [8, 2300, 5717, 2425, 8]
https://recklesschess.space/test/13963/

Bench: 2569711
