### PR TITLE
Simplify best move changes tracking

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -65,7 +65,6 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
 
     let mut eval_stability = 0;
     let mut pv_stability = 0;
-    let mut best_move_changes = 0;
     let mut soft_stop_voted = false;
 
     // Iterative Deepening
@@ -77,7 +76,6 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             td.shared.status.set(Status::STOPPED);
             break;
         }
-        best_move_changes /= 2;
 
         td.sel_depth = 0;
         td.root_depth = depth;
@@ -193,8 +191,6 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             pv_stability = 0;
         }
 
-        best_move_changes += td.best_move_changes;
-
         if td.root_moves[0].score != -Score::INFINITE
             && is_loss(td.root_moves[0].score)
             && td.shared.status.get() == Status::STOPPED
@@ -220,7 +216,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
 
             let score_trend = (0.8 + 0.05 * (td.previous_best_score - td.root_moves[0].score) as f32).clamp(0.80, 1.45);
 
-            let best_move_stability = 1.0 + best_move_changes as f32 / 4.0;
+            let best_move_stability = 1.0 + td.best_move_changes as f32 / 4.0;
 
             nodes_factor * pv_stability * eval_stability * score_trend * best_move_stability
         };


### PR DESCRIPTION
STC
Elo   | 0.38 +- 1.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 59884 W: 15278 L: 15213 D: 29393
Penta | [154, 6670, 16255, 6683, 180]
https://recklesschess.space/test/13992/

LTC
Elo   | 0.22 +- 1.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 67668 W: 16709 L: 16666 D: 34293
Penta | [33, 7108, 19519, 7131, 43]
https://recklesschess.space/test/13996/

Bench: 2569711
