### PR TITLE
Simplify pawn_attacks_setwise

### DIFF
--- a/src/setwise.rs
+++ b/src/setwise.rs
@@ -15,10 +15,7 @@ pub fn pawn_attacks_setwise(bb: Bitboard, color: Color) -> Bitboard {
         Color::Black => (-7, -9),
     };
 
-    let right_attacks = (bb & !Bitboard::file(File::H)).shift(up_right);
-    let left_attacks = (bb & !Bitboard::file(File::A)).shift(up_left);
-
-    right_attacks | left_attacks
+    (bb & !H).shift(up_right) | (bb & !A).shift(up_left)
 }
 
 #[cfg(not(target_feature = "avx2"))]


### PR DESCRIPTION
STC
Elo   | -0.04 +- 1.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 99832 W: 25143 L: 25154 D: 49535
Penta | [250, 10944, 27543, 10925, 254]
https://recklesschess.space/test/14022/