### PR TITLE
Remove generate quiets phase in MP.

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -11,7 +11,6 @@ pub enum Stage {
     HashMove,
     GenerateNoisy,
     GoodNoisy,
-    GenerateQuiet,
     Quiet,
     BadNoisy,
 }
@@ -101,14 +100,10 @@ impl MovePicker {
             if skip_quiets {
                 self.stage = Stage::BadNoisy;
             } else {
-                self.stage = Stage::GenerateQuiet;
+                self.stage = Stage::Quiet;
+                td.board.append_quiet_moves(&mut self.list);
+                self.score_quiet(td, ply);
             }
-        }
-
-        if self.stage == Stage::GenerateQuiet {
-            self.stage = Stage::Quiet;
-            td.board.append_quiet_moves(&mut self.list);
-            self.score_quiet(td, ply);
         }
 
         if self.stage == Stage::Quiet {


### PR DESCRIPTION
After noisy moves, if skip_quiets is not set we always generate quiets.  Thus, this generate_quiets stage doesn't really serve any purpose.

STC
Elo   | 0.38 +- 1.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.13 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 62150 W: 15609 L: 15541 D: 31000
Penta | [162, 6723, 17244, 6777, 169]
https://recklesschess.space/test/13971/

bench 2527042