### PR TITLE
LTC SPSA session 160k games

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -208,17 +208,23 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
         }
 
         let multiplier = || {
-            let nodes_factor = (2.7168 - 2.2669 * (td.root_moves[0].nodes as f32 / td.nodes() as f32)).max(0.5630_f32);
+            let nodes = {
+                let fraction = td.root_moves[0].nodes as f32 / td.nodes() as f32;
+                (2.7641 - 2.2683 * fraction).max(0.5641)
+            };
 
-            let pv_stability = (1.25 - 0.05 * pv_stability as f32).max(0.85);
+            let score_trend = {
+                let difference = (td.previous_best_score - td.root_moves[0].score) as f32;
+                (0.7386 + 0.0499 * difference).clamp(0.7961, 1.4722)
+            };
 
-            let eval_stability = (1.2 - 0.04 * eval_stability as f32).max(0.88);
+            let pv_stability = (1.2915 - 0.0507 * pv_stability as f32).max(0.8068);
 
-            let score_trend = (0.8 + 0.05 * (td.previous_best_score - td.root_moves[0].score) as f32).clamp(0.80, 1.45);
+            let eval_stability = (1.2048 - 0.0417 * eval_stability as f32).max(0.8327);
 
-            let best_move_stability = 1.0 + td.best_move_changes as f32 / 4.0;
+            let best_move_stability = 1.0724 + (0.2160 * td.best_move_changes as f32).ln_1p();
 
-            nodes_factor * pv_stability * eval_stability * score_trend * best_move_stability
+            nodes * pv_stability * eval_stability * score_trend * best_move_stability
         };
 
         if td.time_manager.soft_limit(td, multiplier) {

--- a/src/time.rs
+++ b/src/time.rs
@@ -33,8 +33,8 @@ impl TimeManager {
                 hard = ms;
             }
             Limits::Fischer(main, inc) => {
-                let soft_scale = 0.066 - 0.042 * (-0.045 * fullmove_number as f64).exp();
-                let hard_scale = 0.742;
+                let soft_scale = 0.0599 - 0.0485 * (-0.0459 * fullmove_number as f64).exp();
+                let hard_scale = 0.7524;
 
                 let soft_bound = (soft_scale * main.saturating_sub(move_overhead) as f64 + 0.75 * inc as f64) as u64;
                 let hard_bound = (hard_scale * main.saturating_sub(move_overhead) as f64 + 0.75 * inc as f64) as u64;


### PR DESCRIPTION
STC
Elo   | 3.33 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23770 W: 6132 L: 5904 D: 11734
Penta | [67, 2624, 6280, 2842, 72]
https://recklesschess.space/test/14126/

LTC
Elo   | 4.32 +- 2.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15112 W: 3790 L: 3602 D: 7720
Penta | [11, 1501, 4337, 1703, 4]
https://recklesschess.space/test/14127/

Bench: 2982858