### PR TITLE
Some cleanups in attacks.

### DIFF
--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -19,8 +19,11 @@ pub enum Color {
 pub fn shift_dir(mut bb: u64, dir: i8) -> u64 {
     let file_offset = dir & 0x7;
 
-    if file_offset == FILE_B { bb &= !H_FILE; }
-    if file_offset == FILE_H { bb &= !A_FILE; }
+    if file_offset == FILE_B {
+        bb &= !H_FILE;
+    } else if file_offset == FILE_H {
+        bb &= !A_FILE;
+    }
 
     if dir < 0 { bb >> -dir } else { bb << dir }
 }
@@ -34,11 +37,7 @@ pub fn shift_dirs(bb: u64, dirs: &[i8]) -> u64 {
 }
 
 pub fn pawn_attacks(square: u8, color: Color) -> u64 {
-    if matches!(color, Color::White) {
-        shift_dirs(1 << square, &[7, 9])
-    } else {
-        shift_dirs(1 << square, &[-7, -9])
-    }
+    if matches!(color, Color::White) { shift_dirs(1 << square, &[7, 9]) } else { shift_dirs(1 << square, &[-7, -9]) }
 }
 
 pub fn king_attacks(square: u8) -> u64 {

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -18,10 +18,26 @@ pub enum Color {
     Black,
 }
 
+const FILE_B: i8 = 1;
+const FILE_H: i8 = 7;
+const NORTH: i8 = 8;
+const SOUTH: i8 = -8;
+const EAST: i8 = 1;
+const WEST: i8 = -1;
+
+pub const fn shift(mut bb: u64, dir: i8) -> u64 {
+    let file_offset = dir & 0x7;
+
+    if file_offset == FILE_B { bb &= !H_FILE; }
+    if file_offset == FILE_H { bb &= !A_FILE; }
+
+    if dir < 0 { bb >> -dir } else { bb << dir }
+}
+
 pub const fn pawn_attacks(square: u8, color: Color) -> u64 {
     let bitboard = 1 << square;
     if matches!(color, Color::White) {
-        (bitboard & !A_FILE) << 7 | (bitboard & !H_FILE) << 9
+        shift(bitboard, 7) | shift(bitboard, 9)
     } else {
         (bitboard & !H_FILE) >> 7 | (bitboard & !A_FILE) >> 9
     }

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -15,6 +15,7 @@ pub enum Color {
     Black,
 }
 
+// Only step east/west one step at a time
 pub fn shift_dir(mut bb: u64, dir: i8) -> u64 {
     let file_offset = dir & 0x7;
 
@@ -50,27 +51,20 @@ pub fn knight_attacks(square: u8) -> u64 {
     targets & !king_attacks(square)
 }
 
-pub fn sliding_attacks(square: u8, occupancies: u64, directions: &[(i8, i8)]) -> u64 {
-    directions.iter().fold(0, |output, &direction| output | generate_sliding_attacks(square, occupancies, direction))
+pub fn sliding_attacks(square: u8, occupancies: u64, directions: &[i8]) -> u64 {
+    directions.iter().fold(0, |output, &direction| output | generate_slide(square, occupancies, direction))
 }
 
-fn generate_sliding_attacks(square: u8, occupancies: u64, direction: (i8, i8)) -> u64 {
-    let mut output = 0;
+fn generate_slide(square: u8, occupancies: u64, direction: i8) -> u64 {
+    let mut targets = shift_dir(1 << square, direction);
 
-    let mut rank = (square / 8) as i8 + direction.0;
-    let mut file = (square % 8) as i8 + direction.1;
-
-    while (0..8).contains(&file) && (0..8).contains(&rank) {
-        let bitboard = 1 << (rank * 8 + file);
-        output |= bitboard;
-
-        if (bitboard & occupancies) != 0 {
+    for _i in 0..8 {
+        if targets & occupancies != 0 {
             break;
         }
-
-        rank += direction.0;
-        file += direction.1;
+        //targets &= !occupancies;
+        targets = targets | shift_dir(targets, direction);
     }
 
-    output
+    targets
 }

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -6,20 +6,14 @@
 #![allow(clippy::precedence)]
 
 const A_FILE: u64 = 0x101010101010101;
-const B_FILE: u64 = A_FILE << 1;
 const H_FILE: u64 = A_FILE << 7;
-const G_FILE: u64 = A_FILE << 6;
-
-const AB_FILE: u64 = A_FILE | B_FILE;
-const GH_FILE: u64 = G_FILE | H_FILE;
+const FILE_B: i8 = 1;
+const FILE_H: i8 = 7;
 
 pub enum Color {
     White,
     Black,
 }
-
-const FILE_B: i8 = 1;
-const FILE_H: i8 = 7;
 
 pub fn shift_dir(mut bb: u64, dir: i8) -> u64 {
     let file_offset = dir & 0x7;
@@ -39,37 +33,21 @@ pub fn shift_dirs(bb: u64, dirs: &[i8]) -> u64 {
 }
 
 pub fn pawn_attacks(square: u8, color: Color) -> u64 {
-    let sq_bb = 1 << square;
     if matches!(color, Color::White) {
-        shift_dirs(sq_bb, &[7, 9])
+        shift_dirs(1 << square, &[7, 9])
     } else {
-        shift_dirs(sq_bb, &[-7, -9])
+        shift_dirs(1 << square, &[-7, -9])
     }
 }
 
-pub const fn king_attacks(square: u8) -> u64 {
-    let bitboard = 1 << square;
-
-    (bitboard >> 8 | bitboard << 8)
-        | (bitboard & !A_FILE) >> 9
-        | (bitboard & !A_FILE) >> 1
-        | (bitboard & !A_FILE) << 7
-        | (bitboard & !H_FILE) >> 7
-        | (bitboard & !H_FILE) << 1
-        | (bitboard & !H_FILE) << 9
+pub fn king_attacks(square: u8) -> u64 {
+    shift_dirs(1 << square, &[7, 8, 9, 1, -7, -8, -9, -1])
 }
 
-pub const fn knight_attacks(square: u8) -> u64 {
-    let bitboard = 1 << square;
-
-    (bitboard & !A_FILE) >> 17
-        | (bitboard & !A_FILE) << 15
-        | (bitboard & !H_FILE) >> 15
-        | (bitboard & !H_FILE) << 17
-        | (bitboard & !AB_FILE) >> 10
-        | (bitboard & !AB_FILE) << 6
-        | (bitboard & !GH_FILE) >> 6
-        | (bitboard & !GH_FILE) << 10
+pub fn knight_attacks(square: u8) -> u64 {
+    let targets = shift_dirs(1 << square, &[7, 9, -7, -9]);
+    let targets = shift_dirs(targets, &[8, 1, -8, -1]);
+    targets & !king_attacks(square)
 }
 
 pub fn sliding_attacks(square: u8, occupancies: u64, directions: &[(i8, i8)]) -> u64 {

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -31,17 +31,18 @@ pub fn shift_dir(mut bb: u64, dir: i8) -> u64 {
 }
 
 pub fn shift_dirs(mut bb: u64, dirs: &[i8]) -> u64 {
+    let mut bb2 = 0;
     for dir in dirs {
-        bb |= shift_dir(bb, *dir);
+        bb2 |= shift_dir(bb, *dir);
     }
-    bb
+    bb2
 }
 
 pub fn pawn_attacks(square: u8, color: Color) -> u64 {
     let sq_bb = 1 << square;
     if matches!(color, Color::White) {
-        shift_dir(sq_bb, 7) | shift_dir(sq_bb, 9)
-        //shift_dirs(sq_bb, &[7, 9]) & !sq_bb
+        //shift_dir(sq_bb, 7) | shift_dir(sq_bb, 9)
+        shift_dirs(sq_bb, &[7, 9]) & !sq_bb
     } else {
         (sq_bb & !H_FILE) >> 7 | (sq_bb & !A_FILE) >> 9
     }

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -41,10 +41,9 @@ pub fn shift_dirs(bb: u64, dirs: &[i8]) -> u64 {
 pub fn pawn_attacks(square: u8, color: Color) -> u64 {
     let sq_bb = 1 << square;
     if matches!(color, Color::White) {
-        //shift_dir(sq_bb, 7) | shift_dir(sq_bb, 9)
         shift_dirs(sq_bb, &[7, 9])
     } else {
-        (sq_bb & !H_FILE) >> 7 | (sq_bb & !A_FILE) >> 9
+        shift_dirs(sq_bb, &[-7, -9])
     }
 }
 

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -20,12 +20,8 @@ pub enum Color {
 
 const FILE_B: i8 = 1;
 const FILE_H: i8 = 7;
-const NORTH: i8 = 8;
-const SOUTH: i8 = -8;
-const EAST: i8 = 1;
-const WEST: i8 = -1;
 
-pub fn shift(mut bb: u64, dir: i8) -> u64 {
+pub fn shift_dir(mut bb: u64, dir: i8) -> u64 {
     let file_offset = dir & 0x7;
 
     if file_offset == FILE_B { bb &= !H_FILE; }
@@ -36,17 +32,18 @@ pub fn shift(mut bb: u64, dir: i8) -> u64 {
 
 pub fn shift_dirs(mut bb: u64, dirs: &[i8]) -> u64 {
     for dir in dirs {
-        bb |= shift(bb, *dir);
+        bb |= shift_dir(bb, *dir);
     }
     bb
 }
 
 pub fn pawn_attacks(square: u8, color: Color) -> u64 {
-    let bitboard = 1 << square;
+    let sq_bb = 1 << square;
     if matches!(color, Color::White) {
-        shift(bitboard, 7) | shift(bitboard, 9)
+        shift_dir(sq_bb, 7) | shift_dir(sq_bb, 9)
+        //shift_dirs(sq_bb, &[7, 9]) & !sq_bb
     } else {
-        (bitboard & !H_FILE) >> 7 | (bitboard & !A_FILE) >> 9
+        (sq_bb & !H_FILE) >> 7 | (sq_bb & !A_FILE) >> 9
     }
 }
 

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -25,7 +25,7 @@ const SOUTH: i8 = -8;
 const EAST: i8 = 1;
 const WEST: i8 = -1;
 
-pub const fn shift(mut bb: u64, dir: i8) -> u64 {
+pub fn shift(mut bb: u64, dir: i8) -> u64 {
     let file_offset = dir & 0x7;
 
     if file_offset == FILE_B { bb &= !H_FILE; }
@@ -34,7 +34,14 @@ pub const fn shift(mut bb: u64, dir: i8) -> u64 {
     if dir < 0 { bb >> -dir } else { bb << dir }
 }
 
-pub const fn pawn_attacks(square: u8, color: Color) -> u64 {
+pub fn shift_dirs(mut bb: u64, dirs: &[i8]) -> u64 {
+    for dir in dirs {
+        bb |= shift(bb, *dir);
+    }
+    bb
+}
+
+pub fn pawn_attacks(square: u8, color: Color) -> u64 {
     let bitboard = 1 << square;
     if matches!(color, Color::White) {
         shift(bitboard, 7) | shift(bitboard, 9)

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -30,19 +30,19 @@ pub fn shift_dir(mut bb: u64, dir: i8) -> u64 {
     if dir < 0 { bb >> -dir } else { bb << dir }
 }
 
-pub fn shift_dirs(mut bb: u64, dirs: &[i8]) -> u64 {
-    let mut bb2 = 0;
+pub fn shift_dirs(bb: u64, dirs: &[i8]) -> u64 {
+    let mut targets = 0;
     for dir in dirs {
-        bb2 |= shift_dir(bb, *dir);
+        targets |= shift_dir(bb, *dir);
     }
-    bb2
+    targets
 }
 
 pub fn pawn_attacks(square: u8, color: Color) -> u64 {
     let sq_bb = 1 << square;
     if matches!(color, Color::White) {
         //shift_dir(sq_bb, 7) | shift_dir(sq_bb, 9)
-        shift_dirs(sq_bb, &[7, 9]) & !sq_bb
+        shift_dirs(sq_bb, &[7, 9])
     } else {
         (sq_bb & !H_FILE) >> 7 | (sq_bb & !A_FILE) >> 9
     }

--- a/build/attacks.rs
+++ b/build/attacks.rs
@@ -62,7 +62,6 @@ fn generate_slide(square: u8, occupancies: u64, direction: i8) -> u64 {
         if targets & occupancies != 0 {
             break;
         }
-        //targets &= !occupancies;
         targets = targets | shift_dir(targets, direction);
     }
 

--- a/build/maps.rs
+++ b/build/maps.rs
@@ -26,20 +26,20 @@ pub fn generate_pawn_map() -> [[u64; 64]; 2] {
 
 pub fn generate_diagonal_tables() -> [[u64; 64]; 2] {
     [
-        generate_map(|square| sliding_attacks(square, 0, &[(1, 1), (-1, -1)])),
-        generate_map(|square| sliding_attacks(square, 0, &[(1, -1), (-1, 1)])),
+        generate_map(|square| sliding_attacks(square, 0, &[9, -9])),
+        generate_map(|square| sliding_attacks(square, 0, &[7, -7])),
     ]
 }
 
 pub fn generate_rook_map() -> Vec<u64> {
-    generate_sliding_map(ROOK_MAP_SIZE, &ROOK_MAGICS, &[(1, 0), (-1, 0), (0, 1), (0, -1)])
+    generate_sliding_map(ROOK_MAP_SIZE, &ROOK_MAGICS, &[8, -8, 1, -1])
 }
 
 pub fn generate_bishop_map() -> Vec<u64> {
-    generate_sliding_map(BISHOP_MAP_SIZE, &BISHOP_MAGICS, &[(1, 1), (1, -1), (-1, 1), (-1, -1)])
+    generate_sliding_map(BISHOP_MAP_SIZE, &BISHOP_MAGICS, &[9, 7, -7, -9])
 }
 
-fn generate_sliding_map(size: usize, magics: &[MagicEntry], directions: &[(i8, i8)]) -> Vec<u64> {
+fn generate_sliding_map(size: usize, magics: &[MagicEntry], directions: &[i8]) -> Vec<u64> {
     let mut map = vec![0; size];
 
     for square in 0..64 {


### PR DESCRIPTION
Use single directions instead of pairs, and add a directions shifter taking an array of directions.

Not tested.

bench 2982858