### PR TITLE
Limit prior countermove updates to unexpected all-nodes

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1048,7 +1048,7 @@ fn search<NODE: NodeType>(
         }
     }
 
-    if !NODE::ROOT && bound == Bound::Upper {
+    if !NODE::ROOT && bound == Bound::Upper && (cut_node || NODE::PV) {
         let prior_move = td.stack[ply - 1].mv;
         if prior_move.is_quiet() {
             let factor = 116


### PR DESCRIPTION
STC
Elo   | 1.73 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63646 W: 16397 L: 16080 D: 31169
Penta | [225, 7456, 16166, 7729, 247]
https://recklesschess.space/test/14213/

LTC
Elo   | 5.22 +- 2.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12774 W: 3196 L: 3004 D: 6574
Penta | [8, 1389, 3406, 1571, 13]
https://recklesschess.space/test/14217/

Bench: 2565059