### PR TITLE
Scale noisy history bonus with depth

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1068,7 +1068,7 @@ fn search<NODE: NodeType>(
             }
         } else if prior_move.is_noisy() {
             let captured = td.board.captured_piece().unwrap_or_default().piece_type();
-            let bonus = 60;
+            let bonus = (60 * depth).min(600);
 
             td.noisy_history.update(
                 td.board.prior_threats(),


### PR DESCRIPTION
STC
Elo   | 1.30 +- 1.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.25, 2.89) [0.00, 3.00]
Games | N: 118618 W: 30102 L: 29659 D: 58857
Penta | [301, 13929, 30417, 14350, 312]
https://recklesschess.space/test/14195/

LTC
Elo   | 1.05 +- 1.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.26 (-2.25, 2.89) [0.00, 3.00]
Games | N: 75040 W: 18654 L: 18428 D: 37958
Penta | [30, 8456, 20325, 8676, 33]
https://recklesschess.space/test/14206/

Bench: 2733243