### PR TITLE
Simplify away reduction reset on aspiration window fail low

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -133,7 +133,6 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
                     s if s <= alpha => {
                         beta = (3 * alpha + beta) / 4;
                         alpha = (score - delta).max(-Score::INFINITE);
-                        reduction = 0;
                         delta += 28 * delta / 128;
                     }
                     s if s >= beta => {


### PR DESCRIPTION
STC
Elo   | -0.00 +- 1.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 94586 W: 23935 L: 23935 D: 46716
Penta | [307, 11190, 24322, 11144, 330]
https://recklesschess.space/test/14196/

LTC
Elo   | 0.74 +- 1.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 42294 W: 10492 L: 10402 D: 21400
Penta | [12, 4797, 11452, 4861, 25]
https://recklesschess.space/test/14220/

Bench: 2360886