### PR TITLE
Remove redundant PV condition in FDS reduction term

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -895,7 +895,7 @@ fn search<NODE: NodeType>(
                 reduction -= 3281;
             }
 
-            if !NODE::PV && td.stack[ply - 1].reduction > reduction + 562 {
+            if td.stack[ply - 1].reduction > reduction + 562 {
                 reduction += 130;
             }
 


### PR DESCRIPTION
The condition is redundant.

Change non-functional