### PR TITLE
Improve consistency of aspiration windows

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -131,8 +131,8 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
 
                 match score {
                     s if s <= alpha => {
-                        beta = (3 * alpha + beta) / 4;
                         alpha = (score - delta).max(-Score::INFINITE);
+                        beta = (alpha + delta).min(beta);
                         delta += 28 * delta / 128;
                     }
                     s if s >= beta => {


### PR DESCRIPTION
STC
Elo   | 2.72 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 19030 W: 4935 L: 4786 D: 9309
Penta | [87, 2179, 4826, 2344, 79]
https://recklesschess.space/test/14225/

LTC
Elo   | 1.19 +- 1.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 31726 W: 7841 L: 7732 D: 16153
Penta | [19, 3599, 8519, 3706, 20]
https://recklesschess.space/test/14233/

Bench: 2324318
