### PR TITLE
Adjust extension margins based on whether we are freshly PV

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -327,6 +327,7 @@ fn search<NODE: NodeType>(
     let mut tt_score = Score::NONE;
     let mut tt_bound = Bound::None;
     let mut tt_pv = NODE::PV;
+    let mut tt_was_pv = false;
 
     // Search early TT cutoff
     if let Some(entry) = &entry {
@@ -335,6 +336,7 @@ fn search<NODE: NodeType>(
         tt_score = entry.score;
         tt_bound = entry.bound;
         tt_pv |= entry.tt_pv;
+        tt_was_pv = entry.tt_pv;
 
         if !NODE::PV
             && !excluded
@@ -659,10 +661,13 @@ fn search<NODE: NodeType>(
         }
 
         if singular_score < singular_beta {
-            let double_margin =
-                204 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 16 * correction_value.abs() / 128;
-            let triple_margin =
-                257 * NODE::PV as i32 - 16 * tt_move.is_quiet() as i32 - 15 * correction_value.abs() / 128 + 32;
+            let double_margin = 196 * NODE::PV as i32 + 58 * (NODE::PV && !tt_was_pv) as i32
+                - 16 * tt_move.is_quiet() as i32
+                - 16 * correction_value.abs() / 128;
+            let triple_margin = 249 * NODE::PV as i32 + 58 * (NODE::PV && !tt_was_pv) as i32
+                - 16 * tt_move.is_quiet() as i32
+                - 15 * correction_value.abs() / 128
+                + 32;
 
             extension = 1;
             extension += (singular_score < singular_beta - double_margin) as i32;


### PR DESCRIPTION
If we are a repeat PV, the likelihood that the TT move is the right way to go is greater.

STC:
Elo   | 3.39 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23042 W: 5954 L: 5729 D: 11359
Penta | [75, 2630, 5901, 2825, 90]
https://recklesschess.space/test/14224/

LTC:
Elo   | 1.70 +- 1.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 57854 W: 14290 L: 14007 D: 29557
Penta | [29, 6344, 15905, 6613, 36]
https://recklesschess.space/test/14236/

Bench 2310239