### PR TITLE
Always replace better wins found in TT

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -220,17 +220,28 @@ impl TranspositionTable {
             entry.mv = mv;
         }
 
-        if !force && key == entry.key && depth + 4 + 2 * tt_pv as i32 <= entry.depth() && entry.flags.age() == tt_age {
-            return;
-        }
-
         // Adjust mate distance from "plies from the root" to "plies from the current position"
         if is_decisive(score) && is_valid(score) {
             score += score.signum() * ply as i32;
         }
 
+        let is_better_win = is_win(score) && is_win(entry.score as i32) && score >= entry.score as i32;
+
+        if !force
+            && key == entry.key
+            && depth + 4 + 2 * tt_pv as i32 <= entry.depth()
+            && entry.flags.age() == tt_age
+            && !is_better_win
+        {
+            return;
+        }
+
         entry.key = key;
-        entry.offset_depth = TtDepth::to_tt(depth);
+        entry.offset_depth = if is_better_win && key == entry.key {
+            TtDepth::to_tt(depth).max(entry.offset_depth.saturating_sub(1))
+        } else {
+            TtDepth::to_tt(depth)
+        };
         entry.score = score as i16;
         entry.raw_eval = raw_eval as i16;
         entry.flags = Flags::new(bound, tt_pv, tt_age);

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -225,7 +225,7 @@ impl TranspositionTable {
             score += score.signum() * ply as i32;
         }
 
-        let is_better_win = is_win(score) && is_win(entry.score as i32) && score >= entry.score as i32;
+        let is_better_win = is_win(score) && is_win(entry.score as i32) && score > entry.score as i32;
 
         if !force
             && key == entry.key


### PR DESCRIPTION
Improvement in best mates found with matetrack.

STC (Adjudication disabled)
Elo   | 1.04 +- 0.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 191118 W: 48300 L: 47730 D: 95088
Penta | [498, 20706, 52596, 21246, 513]
https://recklesschess.space/test/14315/

LTC (Adjudication disabled)
Elo   | 1.60 +- 1.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 58660 W: 14545 L: 14275 D: 29840
Penta | [23, 5860, 17290, 6138, 19]
https://recklesschess.space/test/14324/

main: 
Using ../Reckless/reckless on matetrack.epd with --nodes 1000000
Engine ID:     Reckless 0.10.0-dev-0675e0a8
Total FENs:    6554
Found mates:   3611
Best mates:    1989

replace-tt-decisive3: 
Using ../Reckless/reckless-replace-tt-decisive3 on matetrack.epd with --nodes 1000000
Engine ID:     Reckless 0.10.0-dev-3f43645b
Total FENs:    6554
Found mates:   3610
Best mates:    2002

