### PR TITLE
Simplify do-shallower margin

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -848,7 +848,7 @@ fn search<NODE: NodeType>(
             if score > alpha {
                 if !NODE::ROOT {
                     new_depth += (score > best_score + 61) as i32;
-                    new_depth -= (score < best_score + 5 + reduced_depth) as i32;
+                    new_depth -= (score < best_score + 8) as i32;
                 }
 
                 if new_depth > reduced_depth {


### PR DESCRIPTION
STC
Elo   | 1.73 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 25668 W: 6607 L: 6479 D: 12582
Penta | [92, 3073, 6382, 3189, 98]
https://recklesschess.space/test/14358/

LTC
Elo   | 1.17 +- 1.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 31696 W: 7850 L: 7743 D: 16103
Penta | [12, 3605, 8516, 3694, 21]
https://recklesschess.space/test/14359/

Bench: 2668676