### PR TITLE
simplify movable pawns.

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -155,7 +155,7 @@ impl super::Board {
     }
 
     fn movable_pawns(pinned: Bitboard, pawns: Bitboard, pin_mask: Bitboard) -> Bitboard {
-        (pawns & !pinned) | (pawns & pinned & pin_mask)
+        pawns & (!pinned | pin_mask)
     }
 
     fn collect_pawn_pushes<T: MoveGenerator>(


### PR DESCRIPTION
bench 2668676

non-functional.

sanity check:
STC
Elo   | -0.00 +- 0.00 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 10424 W: 2945 L: 2945 D: 4534
Penta | [0, 0, 5212, 0, 0]
https://recklesschess.space/test/14387/