### PR TITLE
Reduce depth reduction if not improving

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -546,7 +546,8 @@ fn search<NODE: NodeType>(
     {
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
-        let r = (5335 + 260 * depth + 493 * (estimated_score - beta).clamp(0, 1003) / 128) / 1024;
+        let r =
+            (5335 + 260 * depth + 493 * (estimated_score - beta).clamp(0, 1003) / 128) / 1024 + improving as i32 - 1;
 
         td.stack[ply].conthist = td.stack.sentinel().conthist;
         td.stack[ply].contcorrhist = td.stack.sentinel().contcorrhist;

--- a/src/search.rs
+++ b/src/search.rs
@@ -547,7 +547,7 @@ fn search<NODE: NodeType>(
         debug_assert_ne!(td.stack[ply - 1].mv, Move::NULL);
 
         let r =
-            (5335 + 260 * depth + 493 * (estimated_score - beta).clamp(0, 1003) / 128) / 1024 + improving as i32 - 1;
+            (4311 + 1024 * improving as i32 + 260 * depth + 493 * (estimated_score - beta).clamp(0, 1003) / 128) / 1024;
 
         td.stack[ply].conthist = td.stack.sentinel().conthist;
         td.stack[ply].contcorrhist = td.stack.sentinel().contcorrhist;


### PR DESCRIPTION
STC
Elo   | 1.80 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.11 (-2.25, 2.89) [0.00, 3.00]
Games | N: 64248 W: 16600 L: 16268 D: 31380
Penta | [246, 7534, 16262, 7806, 276]
https://recklesschess.space/test/14409/

LTC
Elo   | 1.71 +- 1.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 59106 W: 14619 L: 14328 D: 30159
Penta | [42, 6638, 15901, 6931, 41]
https://recklesschess.space/test/14411/

Bench: 2287208