### PR TITLE
Consolidate news in MovePicker

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -25,6 +25,17 @@ pub struct MovePicker {
 }
 
 impl MovePicker {
+    pub const fn new_all(tt_move: Move, threshold: i32) -> Self {
+        Self {
+            list: MoveList::new(),
+            tt_move,
+            threshold: Some(threshold),
+            stage: if tt_move.is_present() { Stage::HashMove } else { Stage::GenerateNoisy },
+            bad_noisy: ArrayVec::new(),
+            bad_noisy_idx: 0,
+        }
+    }
+
     pub const fn new(tt_move: Move) -> Self {
         Self {
             list: MoveList::new(),

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -25,7 +25,7 @@ pub struct MovePicker {
 }
 
 impl MovePicker {
-    pub const fn new_all(tt_move: Move, threshold: Option<i32>) -> Self {
+    pub const fn new(tt_move: Move, threshold: Option<i32>) -> Self {
         Self {
             list: MoveList::new(),
             tt_move,

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -36,17 +36,6 @@ impl MovePicker {
         }
     }
 
-    pub const fn new_qsearch() -> Self {
-        Self {
-            list: MoveList::new(),
-            tt_move: Move::NULL,
-            threshold: None,
-            stage: Stage::GenerateNoisy,
-            bad_noisy: ArrayVec::new(),
-            bad_noisy_idx: 0,
-        }
-    }
-
     pub const fn stage(&self) -> Stage {
         self.stage
     }

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -36,17 +36,6 @@ impl MovePicker {
         }
     }
 
-    pub const fn new(tt_move: Move) -> Self {
-        Self {
-            list: MoveList::new(),
-            tt_move,
-            threshold: None,
-            stage: if tt_move.is_present() { Stage::HashMove } else { Stage::GenerateNoisy },
-            bad_noisy: ArrayVec::new(),
-            bad_noisy_idx: 0,
-        }
-    }
-
     pub const fn new_qsearch() -> Self {
         Self {
             list: MoveList::new(),

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -25,11 +25,11 @@ pub struct MovePicker {
 }
 
 impl MovePicker {
-    pub const fn new_all(tt_move: Move, threshold: i32) -> Self {
+    pub const fn new_all(tt_move: Move, threshold: Option<i32>) -> Self {
         Self {
             list: MoveList::new(),
             tt_move,
-            threshold: Some(threshold),
+            threshold,
             stage: if tt_move.is_present() { Stage::HashMove } else { Stage::GenerateNoisy },
             bad_noisy: ArrayVec::new(),
             bad_noisy_idx: 0,
@@ -42,17 +42,6 @@ impl MovePicker {
             tt_move,
             threshold: None,
             stage: if tt_move.is_present() { Stage::HashMove } else { Stage::GenerateNoisy },
-            bad_noisy: ArrayVec::new(),
-            bad_noisy_idx: 0,
-        }
-    }
-
-    pub const fn new_probcut(threshold: i32) -> Self {
-        Self {
-            list: MoveList::new(),
-            tt_move: Move::NULL,
-            threshold: Some(threshold),
-            stage: Stage::GenerateNoisy,
             bad_noisy: ArrayVec::new(),
             bad_noisy_idx: 0,
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -692,7 +692,7 @@ fn search<NODE: NodeType>(
     let mut noisy_moves = ArrayVec::<Move, 32>::new();
 
     let mut move_count = 0;
-    let mut move_picker = MovePicker::new(tt_move);
+    let mut move_picker = MovePicker::new_all(tt_move, None);
     let mut skip_quiets = false;
     let mut current_search_count = 0;
     let mut tt_move_score = Score::NONE;

--- a/src/search.rs
+++ b/src/search.rs
@@ -591,7 +591,7 @@ fn search<NODE: NodeType>(
         && if is_valid(tt_score) { tt_score >= probcut_beta && !is_decisive(tt_score) } else { eval >= beta }
         && !tt_move.is_quiet()
     {
-        let mut move_picker = MovePicker::new_all(Move::NULL, Some(probcut_beta - eval));
+        let mut move_picker = MovePicker::new(Move::NULL, Some(probcut_beta - eval));
 
         while let Some(mv) = move_picker.next::<NODE>(td, true, ply) {
             if move_picker.stage() == Stage::BadNoisy {
@@ -692,7 +692,7 @@ fn search<NODE: NodeType>(
     let mut noisy_moves = ArrayVec::<Move, 32>::new();
 
     let mut move_count = 0;
-    let mut move_picker = MovePicker::new_all(tt_move, None);
+    let mut move_picker = MovePicker::new(tt_move, None);
     let mut skip_quiets = false;
     let mut current_search_count = 0;
     let mut tt_move_score = Score::NONE;
@@ -1222,7 +1222,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut best_move = Move::NULL;
 
     let mut move_count = 0;
-    let mut move_picker = MovePicker::new_all(Move::NULL, None);
+    let mut move_picker = MovePicker::new(Move::NULL, None);
 
     let skip_quiets = |best_score| !in_check || !is_loss(best_score);
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1222,7 +1222,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     let mut best_move = Move::NULL;
 
     let mut move_count = 0;
-    let mut move_picker = MovePicker::new_qsearch();
+    let mut move_picker = MovePicker::new_all(Move::NULL, None);
 
     let skip_quiets = |best_score| !in_check || !is_loss(best_score);
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -591,7 +591,7 @@ fn search<NODE: NodeType>(
         && if is_valid(tt_score) { tt_score >= probcut_beta && !is_decisive(tt_score) } else { eval >= beta }
         && !tt_move.is_quiet()
     {
-        let mut move_picker = MovePicker::new_probcut(probcut_beta - eval);
+        let mut move_picker = MovePicker::new_all(Move::NULL, probcut_beta - eval);
 
         while let Some(mv) = move_picker.next::<NODE>(td, true, ply) {
             if move_picker.stage() == Stage::BadNoisy {

--- a/src/search.rs
+++ b/src/search.rs
@@ -591,7 +591,7 @@ fn search<NODE: NodeType>(
         && if is_valid(tt_score) { tt_score >= probcut_beta && !is_decisive(tt_score) } else { eval >= beta }
         && !tt_move.is_quiet()
     {
-        let mut move_picker = MovePicker::new_all(Move::NULL, probcut_beta - eval);
+        let mut move_picker = MovePicker::new_all(Move::NULL, Some(probcut_beta - eval));
 
         while let Some(mv) = move_picker.next::<NODE>(td, true, ply) {
             if move_picker.stage() == Stage::BadNoisy {


### PR DESCRIPTION
STC
Elo   | 0.14 +- 1.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 80014 W: 20202 L: 20170 D: 39642
Penta | [204, 8733, 22112, 8743, 215]
https://recklesschess.space/test/14385/