### PR TITLE
Update default network to v60-7f587dfb.nnue

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -11,7 +11,7 @@ mod magics;
 mod maps;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
-const NETWORK_NAME: &str = "v59-f6f160f4.nnue";
+const NETWORK_NAME: &str = "v60-7f587dfb.nnue";
 
 fn main() {
     generate_model_env();


### PR DESCRIPTION
Fixed nodes
Elo   | 1.22 +- 2.04 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 40526 W: 11675 L: 11533 D: 17318
Penta | [637, 4760, 9331, 4894, 641]
https://recklesschess.space/test/14363/

STC
Elo   | 3.61 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21294 W: 5576 L: 5355 D: 10363
Penta | [71, 2437, 5411, 2656, 72]
https://recklesschess.space/test/14364/

LTC
Elo   | 1.23 +- 0.98 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 114258 W: 28659 L: 28256 D: 57343
Penta | [71, 13024, 30556, 13387, 91]
https://recklesschess.space/test/14365/

Bench: 2540641