### PR TITLE
simplify some stuff in moves.

### DIFF
--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -87,11 +87,11 @@ impl Move {
     }
 
     pub const fn is_capture(self) -> bool {
-        (self.0 >> 14) & 1 != 0
+        self.0 & (1 << 14) != 0
     }
 
     pub const fn is_promotion(self) -> bool {
-        (self.0 >> 15) != 0
+        self.0 & (1 << 15) != 0
     }
 
     pub const fn is_en_passant(self) -> bool {


### PR DESCRIPTION
This way, the compiler can do the shift which removes one operation:

STC
Elo   | 1.18 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 32970 W: 8472 L: 8360 D: 16138
Penta | [133, 3669, 8787, 3745, 151]
https://recklesschess.space/test/14479/

example::Move::is_capture_main::h6adeafeb483e2ecc:
        mov     ax, di
        mov     word ptr [rsp - 2], ax
        shr     ax, 14
        and     ax, 1
        cmp     ax, 0
        setne   al
        and     al, 1
        ret

example::Move::is_capture_patch::h519e92ab185aa2f1:
        mov     ax, di
        mov     word ptr [rsp - 2], ax
        and     ax, 16384
        cmp     ax, 0
        setne   al
        and     al, 1
        ret

bench 2540641