### PR TITLE
Simplify FDS reduction formula

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -859,9 +859,8 @@ fn search<NODE: NodeType>(
         }
         // Full Depth Search (FDS)
         else if !NODE::PV || move_count >= 2 {
-            let mut reduction = 232 * (move_count.ilog2() * depth.ilog2()) as i32;
+            let mut reduction = 232 * depth.ilog2() as i32;
 
-            reduction -= 48 * move_count;
             reduction -= 2408 * correction_value.abs() / 1024;
 
             if is_quiet {


### PR DESCRIPTION
STC
Elo   | 1.40 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 29044 W: 7368 L: 7251 D: 14425
Penta | [68, 3409, 7456, 3516, 73]
https://recklesschess.space/test/14322/

LTC
Elo   | 0.94 +- 1.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 37038 W: 9233 L: 9133 D: 18672
Penta | [17, 4249, 9884, 4355, 14]
https://recklesschess.space/test/14412/