### PR TITLE
faster is special.

### DIFF
--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -83,7 +83,7 @@ impl Move {
     }
 
     pub const fn is_special(self) -> bool {
-        (self.kind() as u8 & 11) != 0
+        self.0 & (11 << 12) != 0
     }
 
     pub const fn is_capture(self) -> bool {


### PR DESCRIPTION
Not tested, since I don't trust the framework.

https://godbolt.org/z/nY33xEzhz

example::Move::is_special_main::hdc2dccdf0c7c1641:
        push    rax
        mov     ax, di
        mov     word ptr [rsp + 6], ax
        movzx   edi, ax
        call    qword ptr [rip + example::Move::kind::h22f490ca7fbf0414@GOTPCREL]
        movzx   eax, al
        and     al, 11
        cmp     al, 0
        setne   al
        and     al, 1
        pop     rcx
        ret

example::Move::is_special_patch::h2dece6e74f16f399:
        mov     ax, di
        mov     word ptr [rsp - 2], ax
        and     ax, -20480
        cmp     ax, 0
        setne   al
        and     al, 1
        ret

bench 2236102