### PR TITLE
faster en passant.

### DIFF
--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -95,7 +95,7 @@ impl Move {
     }
 
     pub const fn is_en_passant(self) -> bool {
-        matches!(self.kind(), MoveKind::EnPassant)
+        self.0 & (15 << 12) == 0b0101_0000_0000_0000
     }
 
     pub fn capture_sq(self) -> Square {


### PR DESCRIPTION
bench 2236102

https://godbolt.org/z/r79a6v7zP

example::Move::is_en_passant_main::he86b55cc60c5af74:
        push    rax
        mov     ax, di
        mov     word ptr [rsp + 6], ax
        movzx   edi, ax
        call    qword ptr [rip + example::Move::kind::h22f490ca7fbf0414@GOTPCREL]
        movzx   eax, al
        cmp     rax, 5
        jne     .LBB2_2
        mov     byte ptr [rsp + 5], 1
        jmp     .LBB2_3
.LBB2_2:
        mov     byte ptr [rsp + 5], 0
.LBB2_3:
        mov     al, byte ptr [rsp + 5]
        and     al, 1
        pop     rcx
        ret

example::Move::is_en_passant_patch::h8f8e053ef7318c78:
        mov     ax, di
        mov     word ptr [rsp - 2], ax
        and     ax, -4096
        cmp     ax, 20480
        sete    al
        and     al, 1
        ret
