### PR TITLE
Faster moves.is_noisy

### DIFF
--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -70,16 +70,7 @@ impl Move {
     }
 
     pub const fn is_noisy(self) -> bool {
-        matches!(
-            self.kind(),
-            MoveKind::Capture
-                | MoveKind::EnPassant
-                | MoveKind::PromotionQ
-                | MoveKind::PromotionCaptureN
-                | MoveKind::PromotionCaptureB
-                | MoveKind::PromotionCaptureR
-                | MoveKind::PromotionCaptureQ
-        )
+        self.0 & 0b0111_0000_0000_0000 > 0b0010_0000_0000_0000
     }
 
     pub const fn is_special(self) -> bool {

--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -69,17 +69,9 @@ impl Move {
         self.is_present() && !self.is_noisy()
     }
 
+    //only Queen promotions are noisy unders are not
     pub const fn is_noisy(self) -> bool {
-        matches!(
-            self.kind(),
-            MoveKind::Capture
-                | MoveKind::EnPassant
-                | MoveKind::PromotionQ
-                | MoveKind::PromotionCaptureN
-                | MoveKind::PromotionCaptureB
-                | MoveKind::PromotionCaptureR
-                | MoveKind::PromotionCaptureQ
-        )
+        (self.kind() as u8 & 7) > 2
     }
 
     pub const fn is_special(self) -> bool {


### PR DESCRIPTION
https://godbolt.org/z/M3ajaTWcj

example::Move::is_noisy_main::h9c7e176d8389c99b:
        sub     rsp, 24
        mov     ax, di
        mov     word ptr [rsp + 22], ax
        mov     di, ax
        mov     rax, qword ptr [rip + example::Move::kind::h22f490ca7fbf0414@GOTPCREL]
        call    rax
        movzx   eax, al
        mov     ecx, eax
        mov     qword ptr [rsp + 8], rcx
        add     eax, -4
        sub     eax, 2
        jb      .LBB2_2
        jmp     .LBB2_4
.LBB2_4:
        mov     rax, qword ptr [rsp + 8]
        add     rax, -11
        sub     rax, 5
        jb      .LBB2_2
        jmp     .LBB2_1
.LBB2_1:
        mov     byte ptr [rsp + 21], 0
        jmp     .LBB2_3
.LBB2_2:
        mov     byte ptr [rsp + 21], 1
.LBB2_3:
        mov     al, byte ptr [rsp + 21]
        and     al, 1
        add     rsp, 24
        ret

example::Move::is_noisy_patch::hf1716113e9a5933f:
        mov     ax, di
        mov     word ptr [rsp - 2], ax
        and     ax, 28672
        cmp     ax, 8192
        seta    al
        and     al, 1
        ret

bench 2236102