### PR TITLE
Add history based pruning for quiet moves at low depth

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -762,6 +762,10 @@ fn search<NODE: NodeType>(
                 break;
             }
 
+            if !NODE::ROOT && !is_loss(best_score) && !in_check && is_quiet && depth < 5 && history < -1024 * depth {
+                continue;
+            }
+
             // Static Exchange Evaluation Pruning (SEE Pruning)
             let threshold = if is_quiet {
                 (-17 * depth * depth + 52 * depth - 21 * history / 1024 + 20).min(0)


### PR DESCRIPTION
STC:
Elo   | 5.49 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12726 W: 3364 L: 3163 D: 6199
Penta | [35, 1427, 3255, 1594, 52]
https://recklesschess.space/test/14502/

LTC:
Elo   | 4.49 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14920 W: 3797 L: 3604 D: 7519
Penta | [6, 1621, 4014, 1812, 7]
https://recklesschess.space/test/14503/

Bench: 2408185