### PR TITLE
In movepicker, limit to 3 good captures if the tt_move was quiet.

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -22,7 +22,7 @@ pub struct MovePicker {
     stage: Stage,
     bad_noisy: ArrayVec<Move, MAX_MOVES>,
     bad_noisy_idx: usize,
-    capture_count: usize,
+    noisy_count: usize,
 }
 
 impl MovePicker {
@@ -34,7 +34,7 @@ impl MovePicker {
             stage: if tt_move.is_present() { Stage::HashMove } else { Stage::GenerateNoisy },
             bad_noisy: ArrayVec::new(),
             bad_noisy_idx: 0,
-            capture_count: 0,
+            noisy_count: 0,
         }
     }
 
@@ -62,7 +62,7 @@ impl MovePicker {
             while !self.list.is_empty() {
                 let entry = self.get_best_entry();
                 let threshold = self.threshold.unwrap_or_else(|| -entry.score / 39 + 107);
-                if (self.tt_move.is_quiet() && self.capture_count > 2) || !td.board.see(entry.mv, threshold) {
+                if (self.tt_move.is_quiet() && self.noisy_count > 2) || !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;
                 }
@@ -71,7 +71,7 @@ impl MovePicker {
                     self.score_noisy(td);
                 }
 
-                self.capture_count += 1;
+                self.noisy_count += 1;
                 return Some(entry.mv);
             }
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -22,6 +22,7 @@ pub struct MovePicker {
     stage: Stage,
     bad_noisy: ArrayVec<Move, MAX_MOVES>,
     bad_noisy_idx: usize,
+    capture_count: usize,
 }
 
 impl MovePicker {
@@ -33,6 +34,7 @@ impl MovePicker {
             stage: if tt_move.is_present() { Stage::HashMove } else { Stage::GenerateNoisy },
             bad_noisy: ArrayVec::new(),
             bad_noisy_idx: 0,
+            capture_count: 0,
         }
     }
 
@@ -60,7 +62,7 @@ impl MovePicker {
             while !self.list.is_empty() {
                 let entry = self.get_best_entry();
                 let threshold = self.threshold.unwrap_or_else(|| -entry.score / 39 + 107);
-                if self.tt_move.is_quiet() || !td.board.see(entry.mv, threshold) {
+                if (self.tt_move.is_quiet() && self.capture_count > 2) || !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;
                 }
@@ -69,6 +71,7 @@ impl MovePicker {
                     self.score_noisy(td);
                 }
 
+                self.capture_count += 1;
                 return Some(entry.mv);
             }
 

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -60,7 +60,7 @@ impl MovePicker {
             while !self.list.is_empty() {
                 let entry = self.get_best_entry();
                 let threshold = self.threshold.unwrap_or_else(|| -entry.score / 39 + 107);
-                if !td.board.see(entry.mv, threshold) {
+                if self.tt_move.is_quiet() || !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;
                 }


### PR DESCRIPTION
STC
Elo   | 1.05 +- 0.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 203550 W: 51915 L: 51300 D: 100335
Penta | [632, 23206, 53521, 23747, 669]
https://recklesschess.space/test/14535/

LTC (unfinished)
Elo   | 0.85 +- 0.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 1.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 273648 W: 67506 L: 66837 D: 139305
Penta | [107, 30355, 75263, 30960, 139]
https://recklesschess.space/test/14541/

bench 2572587