### PR TITLE
Remove move count from LMR

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -795,9 +795,8 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count >= 2 {
-            let mut reduction = 191 * (move_count.ilog2() * depth.ilog2()) as i32;
+            let mut reduction = 191 * depth.ilog2() as i32;
 
-            reduction -= 63 * move_count;
             reduction -= 3403 * correction_value.abs() / 1024;
             reduction += 1405 * (bound == Bound::Exact) as i32;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -795,7 +795,7 @@ fn search<NODE: NodeType>(
 
         // Late Move Reductions (LMR)
         if depth >= 2 && move_count >= 2 {
-            let mut reduction = 191 * depth.ilog2() as i32;
+            let mut reduction = 256 * depth.ilog2() as i32;
 
             reduction -= 3403 * correction_value.abs() / 1024;
             reduction += 1405 * (bound == Bound::Exact) as i32;


### PR DESCRIPTION
STC (accidentally summited with gainer bounds)
Elo   | 3.23 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 25152 W: 6582 L: 6348 D: 12222
Penta | [103, 2955, 6238, 3165, 115]
https://recklesschess.space/test/14586/

LTC
Elo   | 4.15 +- 3.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 11882 W: 3029 L: 2887 D: 5966
Penta | [8, 1264, 3254, 1408, 7]
https://recklesschess.space/test/14596/

Bench: 2479402