### PR TITLE
Simplify away move_count in LMR reduced depth

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -849,8 +849,7 @@ fn search<NODE: NodeType>(
 
             reduction += ((td.nodes() + td.id as u64 * 25) & 127) as i32 - 63;
 
-            let reduced_depth =
-                (new_depth - reduction / 1024).clamp(1, new_depth + (move_count <= 3) as i32 + 1) + 2 * NODE::PV as i32;
+            let reduced_depth = (new_depth - reduction / 1024).clamp(1, new_depth + 2) + 2 * NODE::PV as i32;
 
             td.stack[ply].reduction = reduction;
             score = -search::<NonPV>(td, -alpha - 1, -alpha, reduced_depth, true, ply + 1);


### PR DESCRIPTION
STC
Elo   | 1.10 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 34310 W: 8691 L: 8582 D: 17037
Penta | [100, 4002, 8860, 4075, 118]
https://recklesschess.space/test/14595/

LTC
Elo   | 0.77 +- 1.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 40840 W: 10046 L: 9956 D: 20838
Penta | [19, 4553, 11183, 4649, 16]
https://recklesschess.space/test/14600/

Bench: 2516458