### PR TITLE
Refactor and idiomize ArrayVec

### DIFF
--- a/src/types/arrayvec.rs
+++ b/src/types/arrayvec.rs
@@ -10,8 +10,7 @@ pub struct ArrayVec<T: Copy, const N: usize> {
 
 impl<T: Copy, const N: usize> ArrayVec<T, N> {
     pub const fn new() -> Self {
-        let data: [MaybeUninit<T>; N] = unsafe { MaybeUninit::uninit().assume_init() };
-        Self { data, len: 0 }
+        Self { data: [const { MaybeUninit::uninit() }; N], len: 0 }
     }
 
     pub const fn len(&self) -> usize {
@@ -25,20 +24,20 @@ impl<T: Copy, const N: usize> ArrayVec<T, N> {
     pub fn get(&self, index: usize) -> &T {
         debug_assert!(index < self.len);
 
-        unsafe { &*self.data.get_unchecked(index).as_ptr() }
+        unsafe { self.data.get_unchecked(index).assume_init_ref() }
     }
 
     pub fn push(&mut self, value: T) {
         debug_assert!(self.len < N);
 
-        unsafe { self.data[self.len].as_mut_ptr().write(value) };
+        unsafe { self.data.get_unchecked_mut(self.len).write(value) };
         self.len += 1;
     }
 
     pub fn maybe_push(&mut self, mask: bool, value: T) {
         debug_assert!(self.len < N);
 
-        unsafe { self.data[self.len].as_mut_ptr().write(value) };
+        unsafe { self.data.get_unchecked_mut(self.len).write(value) };
         self.len += mask as usize;
     }
 
@@ -46,22 +45,28 @@ impl<T: Copy, const N: usize> ArrayVec<T, N> {
         self.len = 0;
     }
 
-    pub const fn swap_remove(&mut self, index: usize) -> T {
+    pub fn swap_remove(&mut self, index: usize) -> T {
+        // SAFETY: index < len is assumed by the caller, len - 1 < N always holds.
         unsafe {
-            let value = std::ptr::read(self.data[index].as_ptr());
-
+            let value = self.data.get_unchecked(index).assume_init();
             self.len -= 1;
-            std::ptr::copy(self.data[self.len].as_ptr(), self.data[index].as_mut_ptr(), 1);
+            std::ptr::copy(
+                self.data.get_unchecked(self.len).as_ptr(),
+                self.data.get_unchecked_mut(index).as_mut_ptr(),
+                1,
+            );
 
             value
         }
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        // SAFETY: data[..len] is fully initialized
         unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast(), self.len) }.iter()
     }
 
     pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        // SAFETY: data[..len] is fully initialized
         unsafe { std::slice::from_raw_parts_mut(self.data.as_mut_ptr().cast(), self.len) }.iter_mut()
     }
 

--- a/src/types/movelist.rs
+++ b/src/types/movelist.rs
@@ -122,7 +122,7 @@ impl MoveList {
         self.inner.iter_mut()
     }
 
-    pub const fn remove(&mut self, index: usize) -> MoveEntry {
+    pub fn remove(&mut self, index: usize) -> MoveEntry {
         self.inner.swap_remove(index)
     }
 }


### PR DESCRIPTION
1. Remove unsafe from new() using 1.36 stable const initializer
2. Remove bounds checks
3. Add SAFETY comments to all relevant blocks

A side effect of 2 and 3 is that the asm for this code blocks are
smaller, local speedtest gives the following:
Before:
Total nodes:       116447182
Total time (sec):  119.31
Nodes/second:      975990

After:
Total nodes:       116983758
Total time (sec):  119.31
Nodes/second:      980461

No functional change.

Bench: 2479402