### PR TITLE
Use improvement value in RFP

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -520,11 +520,11 @@ fn search<NODE: NodeType>(
         && !excluded
         && estimated_score
             >= beta
-                + (1189 * depth * depth / 128 - (83 * improving as i32)
+                + (1189 * depth * depth / 128 - 96 * improvement / 1024
                     + 23 * depth
                     + 600 * correction_value.abs() / 1024
                     - 60 * (td.board.all_threats() & td.board.colors(stm)).is_empty() as i32
-                    + 29)
+                    - 19)
                     .max(1)
         && !is_loss(beta)
         && !is_win(estimated_score)


### PR DESCRIPTION
STC
Elo   | 3.02 +- 2.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27030 W: 7016 L: 6781 D: 13233
Penta | [86, 3110, 6893, 3335, 91]
https://recklesschess.space/test/14589/

LTC
Elo   | 1.84 +- 1.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50562 W: 12543 L: 12275 D: 25744
Penta | [26, 5587, 13782, 5865, 21]
https://recklesschess.space/test/14597/
