### PR TITLE
Simplify pawn captures

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -195,15 +195,16 @@ impl super::Board {
         let left_pin_mask = relative_anti_diagonal(stm, self.king_square(stm));
         let right_pawns = Self::movable_pawns(pinned, pawns, right_pin_mask) & !Bitboard::file(File::H);
         let left_pawns = Self::movable_pawns(pinned, pawns, left_pin_mask) & !Bitboard::file(File::A);
+        let target = target & self.colors(!stm);
 
-        let right = (right_pawns & seventh_rank).shift(up_right) & self.colors(!stm);
-        let left = (left_pawns & seventh_rank).shift(up_left) & self.colors(!stm);
+        let right = (right_pawns & seventh_rank).shift(up_right);
+        let left = (left_pawns & seventh_rank).shift(up_left);
 
         list.push_promotion_capture_setwise(up_right, right & target);
         list.push_promotion_capture_setwise(up_left, left & target);
 
-        let right_captures = (right_pawns & !seventh_rank).shift(up_right) & self.colors(!stm);
-        let left_captures = (left_pawns & !seventh_rank).shift(up_left) & self.colors(!stm);
+        let right_captures = (right_pawns & !seventh_rank).shift(up_right);
+        let left_captures = (left_pawns & !seventh_rank).shift(up_left);
 
         list.push_pawns_setwise(up_right, right_captures & target, MoveKind::Capture);
         list.push_pawns_setwise(up_left, left_captures & target, MoveKind::Capture);

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -193,26 +193,26 @@ impl super::Board {
         let up_left = Square::UP[stm] + Square::LEFT;
         let right_pin_mask = relative_diagonal(stm, self.king_square(stm));
         let left_pin_mask = relative_anti_diagonal(stm, self.king_square(stm));
-        let right_pawns = Self::movable_pawns(pinned, pawns, right_pin_mask);
-        let left_pawns = Self::movable_pawns(pinned, pawns, left_pin_mask);
+        let right_pawns = Self::movable_pawns(pinned, pawns, right_pin_mask) & !Bitboard::file(File::H);
+        let left_pawns = Self::movable_pawns(pinned, pawns, left_pin_mask) & !Bitboard::file(File::A);
 
-        let right = (right_pawns & seventh_rank & !Bitboard::file(File::H)).shift(up_right) & self.colors(!stm);
-        let left = (left_pawns & seventh_rank & !Bitboard::file(File::A)).shift(up_left) & self.colors(!stm);
+        let right = (right_pawns & seventh_rank).shift(up_right) & self.colors(!stm);
+        let left = (left_pawns & seventh_rank).shift(up_left) & self.colors(!stm);
 
         list.push_promotion_capture_setwise(up_right, right & target);
         list.push_promotion_capture_setwise(up_left, left & target);
 
         let right_captures =
-            (right_pawns & !seventh_rank & !Bitboard::file(File::H)).shift(up_right) & self.colors(!stm);
-        let left_captures = (left_pawns & !seventh_rank & !Bitboard::file(File::A)).shift(up_left) & self.colors(!stm);
+            (right_pawns & !seventh_rank).shift(up_right) & self.colors(!stm);
+        let left_captures = (left_pawns & !seventh_rank).shift(up_left) & self.colors(!stm);
 
         list.push_pawns_setwise(up_right, right_captures & target, MoveKind::Capture);
         list.push_pawns_setwise(up_left, left_captures & target, MoveKind::Capture);
 
         if self.en_passant() != Square::None {
             let ep = self.en_passant().to_bb();
-            let right_attacker = right_pawns & !Bitboard::file(File::H) & ep.shift(-up_right);
-            let left_attacker = left_pawns & !Bitboard::file(File::A) & ep.shift(-up_left);
+            let right_attacker = right_pawns & ep.shift(-up_right);
+            let left_attacker = left_pawns & ep.shift(-up_left);
             for pawn in right_attacker | left_attacker {
                 list.push(pawn, self.en_passant(), MoveKind::EnPassant);
             }

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -202,8 +202,7 @@ impl super::Board {
         list.push_promotion_capture_setwise(up_right, right & target);
         list.push_promotion_capture_setwise(up_left, left & target);
 
-        let right_captures =
-            (right_pawns & !seventh_rank).shift(up_right) & self.colors(!stm);
+        let right_captures = (right_pawns & !seventh_rank).shift(up_right) & self.colors(!stm);
         let left_captures = (left_pawns & !seventh_rank).shift(up_left) & self.colors(!stm);
 
         list.push_pawns_setwise(up_right, right_captures & target, MoveKind::Capture);


### PR DESCRIPTION
This is a bit easier to read and probably saves a few ops.

STC
Elo   | -0.04 +- 1.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 99084 W: 25011 L: 25021 D: 49052
Penta | [299, 10655, 27626, 10681, 281]
https://recklesschess.space/test/14613/