### PR TITLE
This change introduces a branchless quality bonus for Exact scores, e…

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -233,7 +233,7 @@ impl TranspositionTable {
                     }
 
                     let is_exact = candidate.flags.bound() == Bound::Exact;
-                    let bound_bonus = (is_exact as i32) << 2;
+                    let bound_bonus = (is_exact as i32) * 4;
                     let quality = candidate.depth() - (4 * candidate.relative_age(tt_age)) + bound_bonus;
                     if quality < lowest_quality {
                         replacement_index = Some(index);

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -232,7 +232,9 @@ impl TranspositionTable {
                         break;
                     }
 
-                    let quality = candidate.depth() - 4 * candidate.relative_age(tt_age);
+                    let is_exact = candidate.flags.bound() == Bound::Exact;
+                    let bound_bonus = (is_exact as i32) << 2;
+                    let quality = candidate.depth() - (4 * candidate.relative_age(tt_age)) + bound_bonus;
                     if quality < lowest_quality {
                         replacement_index = Some(index);
                         lowest_quality = quality;


### PR DESCRIPTION
effectively treating definitive search results as 4 plies deeper during replacement decisions. By prioritizing these high-fidelity entries, the engine preserves its most certain information from being evicted by less informative upper or lower bounds

Elo   | 3.82 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19082 W: 4935 L: 4725 D: 9422
Penta | [48, 2040, 5181, 2198, 74]
https://recklesschess.space/test/14648/