### PR TITLE
simplify movegen.

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -67,7 +67,7 @@ impl super::Board {
 
         let occupancies = self.occupancies();
         let target = if self.in_check() {
-            between(self.king_square(self.side_to_move()), self.checkers().lsb()) | self.checkers().lsb().to_bb()
+            between(self.king_square(stm), self.checkers().lsb()) | self.checkers()
         } else {
             Bitboard::ALL
         };


### PR DESCRIPTION
bench 2442367

We know there is exactly one checker here, so just OR with checkers() is sufficient.

Not tested.