### PR TITLE
Simplify some movegen code.

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -54,9 +54,11 @@ impl super::Board {
 
     fn generate_moves<T: MoveGenerator>(&self, list: &mut MoveList) {
         let stm = self.side_to_move();
+        let occupancies = self.occupancies();
+        let kind_target = if T::KIND == Kind::Quiet { !occupancies } else { self.colors(!stm) };
         self.collect_unpinned::<T, _>(
             list,
-            !self.all_threats(),
+            kind_target & !self.all_threats(),
             self.colored_pieces(stm, PieceType::King),
             king_attacks,
         );
@@ -65,8 +67,7 @@ impl super::Board {
             return;
         }
 
-        let occupancies = self.occupancies();
-        let target = if self.in_check() {
+        let mut target = if self.in_check() {
             between(self.king_square(stm), self.checkers().lsb()) | self.checkers()
         } else {
             Bitboard::ALL
@@ -74,7 +75,9 @@ impl super::Board {
 
         let pinned = self.pinned(self.side_to_move());
 
-        self.collect_pawn_moves::<T>(list, target, pinned);
+        self.collect_pawn_moves::<T>(list, target, pinned); //bad noisy/quiet boundary
+
+        target &= kind_target;
 
         let knights = self.colored_pieces(stm, PieceType::Knight);
         let bishops = self.colored_pieces(stm, PieceType::Bishop);
@@ -98,14 +101,9 @@ impl super::Board {
     fn collect_unpinned<T: MoveGenerator, F: Fn(Square) -> Bitboard>(
         &self, list: &mut MoveList, target: Bitboard, bb: Bitboard, attacks: F,
     ) {
-        let stm = self.side_to_move();
         for from in bb {
-            if T::KIND == Kind::Noisy {
-                list.push_setwise(from, attacks(from) & target & self.colors(!stm), MoveKind::Capture);
-            }
-            if T::KIND == Kind::Quiet {
-                list.push_setwise(from, attacks(from) & target & !self.occupancies(), MoveKind::Normal);
-            }
+            let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal};
+            list.push_setwise(from, attacks(from) & target, kind);
         }
     }
 
@@ -113,15 +111,10 @@ impl super::Board {
         &self, list: &mut MoveList, target: Bitboard, bb: Bitboard, attacks: F,
     ) {
         let king = self.king_square(self.side_to_move());
-        let stm = self.side_to_move();
+        let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal};
         for from in bb {
             let pin_mask = ray_pass(king, from);
-            if T::KIND == Kind::Noisy {
-                list.push_setwise(from, attacks(from) & target & self.colors(!stm) & pin_mask, MoveKind::Capture);
-            }
-            if T::KIND == Kind::Quiet {
-                list.push_setwise(from, attacks(from) & target & !self.occupancies() & pin_mask, MoveKind::Normal);
-            }
+            list.push_setwise(from, attacks(from) & target & pin_mask, kind);
         }
     }
 

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -102,7 +102,7 @@ impl super::Board {
         &self, list: &mut MoveList, target: Bitboard, bb: Bitboard, attacks: F,
     ) {
         for from in bb {
-            let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal};
+            let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal };
             list.push_setwise(from, attacks(from) & target, kind);
         }
     }
@@ -111,7 +111,7 @@ impl super::Board {
         &self, list: &mut MoveList, target: Bitboard, bb: Bitboard, attacks: F,
     ) {
         let king = self.king_square(self.side_to_move());
-        let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal};
+        let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal };
         for from in bb {
             let pin_mask = ray_pass(king, from);
             list.push_setwise(from, attacks(from) & target & pin_mask, kind);

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -99,20 +99,20 @@ impl super::Board {
     }
 
     fn collect_unpinned<T: MoveGenerator, F: Fn(Square) -> Bitboard>(
-        &self, list: &mut MoveList, target: Bitboard, bb: Bitboard, attacks: F,
+        &self, list: &mut MoveList, target: Bitboard, pieces: Bitboard, attacks: F,
     ) {
-        for from in bb {
-            let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal };
+        let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal };
+        for from in pieces {
             list.push_setwise(from, attacks(from) & target, kind);
         }
     }
 
     fn collect_pinned<T: MoveGenerator, F: Fn(Square) -> Bitboard>(
-        &self, list: &mut MoveList, target: Bitboard, bb: Bitboard, attacks: F,
+        &self, list: &mut MoveList, target: Bitboard, pieces: Bitboard, attacks: F,
     ) {
         let king = self.king_square(self.side_to_move());
         let kind = if T::KIND == Kind::Noisy { MoveKind::Capture } else { MoveKind::Normal };
-        for from in bb {
+        for from in pieces {
             let pin_mask = ray_pass(king, from);
             list.push_setwise(from, attacks(from) & target & pin_mask, kind);
         }


### PR DESCRIPTION
If we precalculate some target into, it simplifies some stuff in the collect methods.

STC
Elo   | 2.14 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 21918 W: 5677 L: 5542 D: 10699
Penta | [103, 2481, 5666, 2596, 113]
https://recklesschess.space/test/14669/