### PR TITLE
Missing guard on nmp

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -547,6 +547,7 @@ fn search<NODE: NodeType>(
         && ply as i32 >= td.nmp_min_ply
         && td.board.material() > 624
         && !is_loss(beta)
+        && !is_win(estimated_score)
         && !(tt_bound == Bound::Lower
             && tt_move.is_capture()
             && td.board.piece_on(tt_move.to()).value() >= PieceType::Knight.value())


### PR DESCRIPTION
Avoids wasting time searching with null move and polluting TT with zugzwang cases when a win is already present

Elo   | 1.80 +- 2.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.08 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 25712 W: 6561 L: 6428 D: 12723
Penta | [80, 2852, 6874, 2955, 95]
https://recklesschess.space/test/14343/

Elo   | 0.67 +- 1.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 45352 W: 11158 L: 11071 D: 23123
Penta | [18, 4952, 12653, 5031, 22]
https://recklesschess.space/test/14491/

Bench: 2454173