### PR TITLE
Fix excluded search overriding parent's TTPV flag

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -663,6 +663,7 @@ fn search<NODE: NodeType>(
         td.stack[ply].mv = Move::NULL;
         singular_score = search::<NonPV>(td, singular_beta - 1, singular_beta, singular_depth, cut_node, ply);
         td.stack[ply].excluded = Move::NULL;
+        td.stack[ply].tt_pv = tt_pv;
 
         if td.shared.status.get() == Status::STOPPED {
             return Score::ZERO;


### PR DESCRIPTION
STC
Elo   | 1.96 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 23886 W: 6172 L: 6037 D: 11677
Penta | [94, 2709, 6201, 2846, 93]
https://recklesschess.space/test/14636/

LTC
Elo   | 1.82 +- 2.15 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 23112 W: 5844 L: 5723 D: 11545
Penta | [16, 2526, 6351, 2647, 16]
https://recklesschess.space/test/14654/

Bench: 2492078