### PR TITLE
Fix eval stability tracking for MultiPV

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -185,7 +185,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             td.print_uci_info(depth);
         }
 
-        if (td.root_moves[0].score - average[td.pv_index]).abs() < 12 {
+        if (td.root_moves[0].score - average[0]).abs() < 12 {
             eval_stability += 1;
         } else {
             eval_stability = 0;


### PR DESCRIPTION
The eval stability metric was measuring against the worst PV average when using MultiPV. Now it compares the best move's score against the main line's history.

Ideally comparing against the main line's average prevents noisy resets when MultiPV rotates the active index, and thus giving better time management decisions.

STC
Elo   | 10.52 +- 4.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7930 W: 2636 L: 2396 D: 2898
Penta | [133, 851, 1820, 965, 196]
https://recklesschess.space/test/14691/

LTC
Elo   | 7.75 +- 3.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8786 W: 2627 L: 2431 D: 3728
Penta | [46, 869, 2371, 1057, 50]
https://recklesschess.space/test/14693/

Functional change for MultiPV > 1.

Bench: 2492078