### PR TITLE
Simplify away root depth condition

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -924,7 +924,7 @@ fn search<NODE: NodeType>(
 
         // Principal Variation Search (PVS)
         if NODE::PV && (move_count == 1 || score > alpha) {
-            if mv == tt_move && tt_depth > 1 && td.root_depth > 8 {
+            if mv == tt_move && tt_depth > 1 {
                 new_depth = new_depth.max(1);
             }
 


### PR DESCRIPTION
STC
Elo   | -0.03 +- 1.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 97964 W: 24954 L: 24962 D: 48048
Penta | [319, 11734, 24923, 11648, 358]
https://recklesschess.space/test/14633/

LTC
Elo   | 3.20 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 15000 W: 3811 L: 3673 D: 7516
Penta | [7, 1660, 4030, 1794, 9]
https://recklesschess.space/test/14694/

Bench: 2304807