### PR TITLE
Simplify make_move and remove recapture_square

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -34,7 +34,6 @@ struct InternalState {
     plies_from_null: usize,
     repetition: i32,
     captured: Option<Piece>,
-    recapture_square: Square,
     piece_threats: [Bitboard; PieceType::NUM],
     all_threats: Bitboard,
     pinned: [Bitboard; Color::NUM],
@@ -126,10 +125,6 @@ impl Board {
 
     pub const fn captured_piece(&self) -> Option<Piece> {
         self.state.captured
-    }
-
-    pub const fn recapture_square(&self) -> Square {
-        self.state.recapture_square
     }
 
     pub const fn en_passant(&self) -> Square {

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -45,7 +45,7 @@ impl Board {
         }
 
         self.state.captured = None;
-        self.state.recapture_square = Square::None;
+        self.state.recapture_square = to;
 
         if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
             self.state.halfmove_clock = 0;
@@ -67,7 +67,6 @@ impl Board {
 
             self.state.material -= captured.value();
             self.state.captured = Some(captured);
-            self.state.recapture_square = to;
         } else if !mv.is_castling() {
             self.remove_piece(piece, from);
             self.add_piece(piece, to);

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -44,7 +44,8 @@ impl Board {
             self.state.en_passant = Square::None;
         }
 
-        self.state.captured = None;
+        let captured = self.piece_on(to);
+        self.state.captured = Some(captured);
         self.state.recapture_square = to;
 
         if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
@@ -54,7 +55,6 @@ impl Board {
         }
         self.state.plies_from_null += 1;
 
-        let captured = self.piece_on(to);
         if captured != Piece::None && !mv.is_castling() {
             self.remove_piece(piece, from);
             observer.on_piece_change(self, piece, from, false);

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -10,7 +10,6 @@ impl Board {
         self.state.plies_from_null = 0;
         self.state.repetition = 0;
         self.state.captured = None;
-        self.state.recapture_square = Square::None;
 
         self.update_threats();
 
@@ -46,7 +45,6 @@ impl Board {
 
         let captured = self.piece_on(to);
         self.state.captured = Some(captured);
-        self.state.recapture_square = to;
 
         if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
             self.state.halfmove_clock = 0;


### PR DESCRIPTION
STC
Elo   | 0.51 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 50874 W: 12700 L: 12626 D: 25548
Penta | [131, 5438, 14226, 5510, 132]
https://recklesschess.space/test/14757/