### PR TITLE
correct EP captured.

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -45,13 +45,13 @@ impl Board {
 
         let captured = self.piece_on(to);
         self.state.captured = Some(captured);
+        self.state.plies_from_null += 1;
 
         if mv.kind() == MoveKind::Capture || pt == PieceType::Pawn {
             self.state.halfmove_clock = 0;
         } else {
             self.state.halfmove_clock += 1;
         }
-        self.state.plies_from_null += 1;
 
         if captured != Piece::None && !mv.is_castling() {
             self.remove_piece(piece, from);
@@ -88,6 +88,7 @@ impl Board {
                 self.update_hash(captured, to ^ 8);
 
                 self.state.material -= captured.value();
+                self.state.captured = Some(captured);
             }
             MoveKind::Castling => {
                 let (rook_from, rook_to) = self.get_castling_rook(to);
@@ -174,9 +175,7 @@ impl Board {
             self.add_piece(new_mover, from);
 
             if mv.is_capture() {
-                let captured =
-                    if mv.is_en_passant() { Some(Piece::new(!stm, PieceType::Pawn)) } else { self.state.captured };
-                self.add_piece(captured.expect("REASON"), mv.capture_sq());
+                self.add_piece(self.captured_piece().expect("REASON"), mv.capture_sq());
             }
         }
 


### PR DESCRIPTION
bench 2632917

Treat EP captures like all other captures setting the capture type, which simplifies undo_move.

STC
Elo   | 0.64 +- 1.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 46998 W: 12113 L: 12027 D: 22858
Penta | [154, 5533, 12072, 5553, 187]
https://recklesschess.space/test/14767/

Since the bench changes, do I need to do LTC?