### PR TITLE
Increase reduction based on correct expectation

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -837,8 +837,8 @@ fn search<NODE: NodeType>(
             }
 
             if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1504;
-                reduction += 256 * (!NODE::PV && !cut_node) as i32;
+                reduction += 992;
+                reduction += 384 * (!NODE::PV && !cut_node) as i32;
             }
 
             if is_valid(tt_move_score) && is_valid(singular_score) {

--- a/src/search.rs
+++ b/src/search.rs
@@ -837,7 +837,8 @@ fn search<NODE: NodeType>(
             }
 
             if td.stack[ply + 1].cutoff_count > 2 {
-                reduction += 1568;
+                reduction += 1504;
+                reduction += 256 * (!NODE::PV && !cut_node) as i32;
             }
 
             if is_valid(tt_move_score) && is_valid(singular_score) {
@@ -900,6 +901,7 @@ fn search<NODE: NodeType>(
 
             if td.stack[ply + 1].cutoff_count > 2 {
                 reduction += 1454;
+                reduction += 256 * (!NODE::PV && !cut_node) as i32;
             }
 
             if is_valid(tt_move_score) && is_valid(singular_score) {


### PR DESCRIPTION
STC
Elo   | 3.08 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.12 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27784 W: 7158 L: 6912 D: 13714
Penta | [80, 3181, 7131, 3413, 87]
https://recklesschess.space/test/14743/

LTC
Elo   | 4.13 +- 2.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16406 W: 4154 L: 3959 D: 8293
Penta | [5, 1747, 4508, 1934, 9]
https://recklesschess.space/test/14746/

Bench: 2740416