### PR TITLE
simplify make_move

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -53,7 +53,23 @@ impl Board {
             self.state.halfmove_clock += 1;
         }
 
-        if captured != Piece::None && !mv.is_castling() {
+        if mv.is_castling() {
+            let (rook_from, rook_to) = self.get_castling_rook(to);
+            let rook = Piece::new(stm, PieceType::Rook);
+
+            self.remove_piece(rook, rook_from);
+            observer.on_piece_change(self, rook, rook_from, false);
+
+            self.remove_piece(piece, from);
+            self.add_piece(piece, to);
+            observer.on_piece_move(self, piece, from, to);
+
+            self.add_piece(rook, rook_to);
+            observer.on_piece_change(self, rook, rook_to, true);
+
+            self.update_hash(rook, rook_from);
+            self.update_hash(rook, rook_to);
+        } else if captured != Piece::None {
             self.remove_piece(piece, from);
             observer.on_piece_change(self, piece, from, false);
 
@@ -65,7 +81,7 @@ impl Board {
 
             self.state.material -= captured.value();
             self.state.captured = Some(captured);
-        } else if !mv.is_castling() {
+        } else {
             self.remove_piece(piece, from);
             self.add_piece(piece, to);
             observer.on_piece_move(self, piece, from, to);
@@ -89,23 +105,6 @@ impl Board {
 
                 self.state.material -= captured.value();
                 self.state.captured = Some(captured);
-            }
-            MoveKind::Castling => {
-                let (rook_from, rook_to) = self.get_castling_rook(to);
-                let rook = Piece::new(stm, PieceType::Rook);
-
-                self.remove_piece(rook, rook_from);
-                observer.on_piece_change(self, rook, rook_from, false);
-
-                self.remove_piece(piece, from);
-                self.add_piece(piece, to);
-                observer.on_piece_move(self, piece, from, to);
-
-                self.add_piece(rook, rook_to);
-                observer.on_piece_change(self, rook, rook_to, true);
-
-                self.update_hash(rook, rook_from);
-                self.update_hash(rook, rook_to);
             }
             _ if mv.is_promotion() => {
                 let promotion = Piece::new(stm, mv.promo_piece_type());


### PR DESCRIPTION
Not much of a line count difference but simplifies some checks.

STC#1
Elo   | 6.83 +- 3.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 7738 W: 1993 L: 1841 D: 3904
Penta | [14, 762, 2174, 896, 23]
https://recklesschess.space/test/14768/

STC#2
Elo   | -0.17 +- 0.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 134056 W: 33984 L: 34048 D: 66024
Penta | [362, 14625, 37118, 14561, 362]
https://recklesschess.space/test/14769/

bench 2851948