### PR TITLE
Avoid LMP when in a forced win

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -734,6 +734,7 @@ fn search<NODE: NodeType>(
             if !in_check
                 && !td.board.is_direct_check(mv)
                 && is_quiet
+                && !is_win(beta)
                 && move_count >= (2697 + 77 * improvement / 16 + 1510 * depth * depth + 70 * history / 1024) / 1024
             {
                 skip_quiets = true;


### PR DESCRIPTION
Matetrack:
| Nodes\Branch | Main          | Patch         | Net (branch) |
|--------------|---------------|---------------|--------------|
| 100,000      | Found:  1793  | Found:  1804  | Found:  +11  |
|              | Best:   1027  | Best:   1042  | Best:   +15  |
|--------------|---------------|---------------|--------------|
| 1,000,000    | Found:  3678  | Found:  3685  | Found:   +7  |
|              | Best:   2059  | Best:   2080  | Best:   +21  |
|--------------|---------------|---------------|--------------|
| Net (nodes)  | Found: +1885  | Found: +1881  |              |
|              | Best:  +1032  | Best:  +1038  |              |

STC
Elo   | 2.42 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 18938 W: 4889 L: 4757 D: 9292
Penta | [54, 1974, 5267, 2134, 40]
https://recklesschess.space/test/14779/

Bench: 2851948