### PR TITLE
Consider repetitions in tb probing

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -260,6 +260,10 @@ impl Board {
         self.state.repetition != 0 && self.state.repetition < ply
     }
 
+    pub const fn is_repetition(&self) -> bool {
+        self.state.repetition != 0
+    }
+
     pub fn draw_by_fifty_move_rule(&self) -> bool {
         self.halfmove_clock() >= 100 && (!self.in_check() || self.has_legal_moves())
     }

--- a/src/tb.rs
+++ b/src/tb.rs
@@ -117,7 +117,7 @@ pub fn rank_rootmoves(td: &mut ThreadData) {
             0,
             ep_square,
             td.board.side_to_move() == Color::White,
-            false,
+            td.board.is_repetition(),
             true,
             tb_ptr,
         );


### PR DESCRIPTION
has_repeated was hardcoded to false, so Fathom never knew if the root position had repeated before, and could rank a drawn position as a win.

Search usually catches this via upcoming_repetition and is_draw, but when DTZ succeeds we stop probing TB in search. The wrong score then gets written to TT and returned via TT cutoff before any repetition check can correct it, which might cause the engine to report an incorrect eval.

Bench: 2851948