### PR TITLE
Fix tbprobe output for cursed positions

### DIFF
--- a/src/tb.rs
+++ b/src/tb.rs
@@ -125,8 +125,11 @@ pub fn rank_rootmoves(td: &mut ThreadData) {
         if dtz_success != 0 {
             let c_rootmoves: &TbRootMoves = &*tb_ptr;
             update_rootmoves(&mut td.root_moves, c_rootmoves);
-            td.shared.stop_probing_tb.store(true, Ordering::Relaxed);
             td.shared.root_in_tb.store(true, Ordering::Relaxed);
+
+            let best_rank = td.root_moves[0].tb_rank;
+            let is_decisive = best_rank >= 99900 || best_rank <= -99900;
+            td.shared.stop_probing_tb.store(is_decisive, Ordering::Relaxed);
             return;
         }
 
@@ -153,8 +156,9 @@ pub fn rank_rootmoves(td: &mut ThreadData) {
             update_rootmoves(&mut td.root_moves, c_rootmoves);
             td.shared.root_in_tb.store(true, Ordering::Relaxed);
 
-            // Keep probing in search if DTZ is not available and we are winning
-            td.shared.stop_probing_tb.store(td.root_moves[0].tb_score <= Score::ZERO, Ordering::Relaxed);
+            let best_rank = td.root_moves[0].tb_rank;
+            let is_decisive = best_rank >= 99900 || best_rank <= -99900;
+            td.shared.stop_probing_tb.store(is_decisive && td.root_moves[0].tb_score > Score::ZERO, Ordering::Relaxed);
         }
     }
 }

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -106,7 +106,11 @@ impl ThreadPool {
                 t1.board.generate_all_moves().iter().map(|v| RootMove { mv: v.mv, ..Default::default() }).collect();
 
             #[cfg(feature = "syzygy")]
-            if t1.board.castling().raw() == 0 && t1.board.occupancies().popcount() <= tb::size() {
+            if t1.board.castling().raw() == 0
+                && t1.board.occupancies().popcount() <= tb::size()
+                && !t1.board.draw_by_fifty_move_rule()
+                && !t1.board.draw_by_material()
+            {
                 tb::rank_rootmoves(t1);
             }
 


### PR DESCRIPTION
Testing on a 50 move rule position with 7 piece syzygy tb: 6R1/1R6/8/3N2k1/3K4/8/8/r6r b - - 100 103

Before:
info depth 1 seldepth 1 multipv 1 score cp -20000 nodes 4 time 9 nps 428 hashfull 0 tbhits 0 pv g5h6
info depth 2 seldepth 1 multipv 1 score cp -20000 nodes 8 time 9 nps 848 hashfull 0 tbhits 0 pv g5h6
...

After:
info depth 1 seldepth 1 multipv 1 score cp 0 nodes 4 time 0 nps 7920 hashfull 0 tbhits 0 pv g5h6
info depth 2 seldepth 1 multipv 1 score cp 1 nodes 8 time 9 nps 13931 hashfull 0 tbhits 0 pv g5h6
...

Bench: 2482674