### PR TITLE
Adjust NMP bound with TT score

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -565,7 +565,13 @@ fn search<NODE: NodeType>(
         td.board.make_null_move();
         td.shared.tt.prefetch(td.board.hash());
 
-        let score = -search::<NonPV>(td, -beta, -beta + 1, depth - r, false, ply + 1);
+        let bound = if is_valid(tt_score) && beta > tt_score && tt_bound == Bound::Lower && depth - 2 <= tt_depth {
+            tt_score
+        } else {
+            beta
+        };
+
+        let score = -search::<NonPV>(td, -bound, -bound + 1, depth - r, false, ply + 1);
 
         td.board.undo_null_move();
 
@@ -573,23 +579,20 @@ fn search<NODE: NodeType>(
             return Score::ZERO;
         }
 
-        if !is_win(score)
-            && (score >= beta
-                || (is_valid(tt_score) && score >= tt_score && tt_bound == Bound::Lower && depth - 2 <= tt_depth))
-        {
+        if score >= bound && !is_win(score) {
             if td.nmp_min_ply > 0 || depth < 16 {
                 return score;
             }
 
             td.nmp_min_ply = ply as i32 + 3 * (depth - r) / 4;
-            let verified_score = search::<NonPV>(td, beta - 1, beta, depth - r, false, ply);
+            let verified_score = search::<NonPV>(td, bound - 1, bound, depth - r, false, ply);
             td.nmp_min_ply = 0;
 
             if td.shared.status.get() == Status::STOPPED {
                 return Score::ZERO;
             }
 
-            if verified_score >= beta {
+            if verified_score >= bound {
                 return score;
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -573,7 +573,10 @@ fn search<NODE: NodeType>(
             return Score::ZERO;
         }
 
-        if !is_win(score) && (score >= beta || (is_valid(tt_score) && score >= tt_score && tt_bound == Bound::Lower)) {
+        if !is_win(score)
+            && (score >= beta
+                || (is_valid(tt_score) && score >= tt_score && tt_bound == Bound::Lower && depth - 2 <= tt_depth))
+        {
             if td.nmp_min_ply > 0 || depth < 16 {
                 return score;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -573,7 +573,7 @@ fn search<NODE: NodeType>(
             return Score::ZERO;
         }
 
-        if score >= beta && !is_win(score) {
+        if !is_win(score) && (score >= beta || (is_valid(tt_score) && score >= tt_score && tt_bound == Bound::Lower)) {
             if td.nmp_min_ply > 0 || depth < 16 {
                 return score;
             }


### PR DESCRIPTION
Idea inspired by Beal's paper "A generalised quiescence search algorithm" where he mentions the concept of touching bounds when considering null-move searches.

If we have a null move search score that touches the TT score, we have an adequate estimate of the value of the position. Therefore, return.

STC
Elo   | 2.35 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36348 W: 9282 L: 9036 D: 18030
Penta | [104, 3990, 9753, 4210, 117]
https://recklesschess.space/test/14804/

LTC
Elo   | 1.66 +- 1.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 58740 W: 14662 L: 14381 D: 29697
Penta | [37, 6263, 16482, 6558, 30]
https://recklesschess.space/test/14805/