### PR TITLE
MP bonus for advanced pawn attacks

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -166,8 +166,8 @@ impl MovePicker {
 
             let mut p = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
 
-            // Add advanced attacks on anything
-            p |= Bitboard::HOME_ROWS[!side] | Bitboard::SEVENTH_RANK[side];
+            // Add advanced pawn attacks to pawn offense
+            p |= pawn_threats & Bitboard::SIXTH_RANK[side];
 
             let n = knight_attacks_setwise(knight_vulnerable) & !threats;
             let b = bishop_attacks_setwise(bishop_vulnerable, occupancies) & !threats;

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -164,7 +164,11 @@ impl MovePicker {
             let queen_orth_vulnerable = td.board.colored_pieces(!side, PieceType::Bishop) & !threats;
             let queen_diag_vulnerable = td.board.colored_pieces(!side, PieceType::Rook) & !threats;
 
-            let p = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
+            let mut p = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
+
+            // Add advanced attacks on anything
+            p |= Bitboard::HOME_ROWS[!side] | Bitboard::SEVENTH_RANK[side];
+
             let n = knight_attacks_setwise(knight_vulnerable) & !threats;
             let b = bishop_attacks_setwise(bishop_vulnerable, occupancies) & !threats;
             let r = Bitboard::file(td.board.king_square(!side).file()) & !threats;

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -146,6 +146,12 @@ impl MovePicker {
         let occupancies = td.board.occupancies();
         let pawn_threats = td.board.piece_threats(PieceType::Pawn);
 
+        let non_pawn_threats = td.board.piece_threats(PieceType::Knight)
+            | td.board.piece_threats(PieceType::Bishop)
+            | td.board.piece_threats(PieceType::Rook)
+            | td.board.piece_threats(PieceType::Queen)
+            | td.board.piece_threats(PieceType::King);
+
         let threatened = {
             let minor_threats =
                 pawn_threats | td.board.piece_threats(PieceType::Knight) | td.board.piece_threats(PieceType::Bishop);
@@ -167,7 +173,7 @@ impl MovePicker {
             let mut p = pawn_attacks_setwise(td.board.colors(!side), !side) & !threats;
 
             // Add advanced pawn attacks to pawn offense
-            p |= pawn_threats & Bitboard::SIXTH_RANK[side];
+            p |= pawn_threats & Bitboard::LEVER_RANKS[side] & !non_pawn_threats;
 
             let n = knight_attacks_setwise(knight_vulnerable) & !threats;
             let b = bishop_attacks_setwise(bishop_vulnerable, occupancies) & !threats;

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -15,6 +15,7 @@ impl Bitboard {
     pub const SEVENTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R7), Self::rank(Rank::R2)];
     pub const THIRD_RANK: [Bitboard; 2] = [Self::rank(Rank::R3), Self::rank(Rank::R6)];
     pub const HOME_ROWS: [Bitboard; 2] = [Self::rank(Rank::R1), Self::rank(Rank::R8)];
+    pub const LEVER_RANKS: [Bitboard; 2] = [Self(0x0000FFFF00000000), Self(0x00000000FFFF0000)];
 
     /// Creates a bitboard with all bits set in the specified rank.
     pub const fn rank(rank: Rank) -> Self {

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -13,6 +13,7 @@ impl Bitboard {
     pub const ALL: Self = Self(0xFFFFFFFFFFFFFFFF);
     pub const LIGHT_SQUARES: Self = Self(0x55AA55AA55AA55AA);
     pub const SEVENTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R7), Self::rank(Rank::R2)];
+    pub const SIXTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R6), Self::rank(Rank::R3)];
     pub const THIRD_RANK: [Bitboard; 2] = [Self::rank(Rank::R3), Self::rank(Rank::R6)];
     pub const HOME_ROWS: [Bitboard; 2] = [Self::rank(Rank::R1), Self::rank(Rank::R8)];
     pub const LEVER_RANKS: [Bitboard; 2] = [Self(0x0000FFFF00000000), Self(0x00000000FFFF0000)];


### PR DESCRIPTION
STC
Elo   | 2.20 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 42260 W: 10887 L: 10619 D: 20754
Penta | [136, 4879, 10842, 5127, 146]
https://recklesschess.space/test/14796/

LTC
Elo   | 2.04 +- 1.54 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.06 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44726 W: 11146 L: 10884 D: 22696
Penta | [21, 4908, 12243, 5170, 21]
https://recklesschess.space/test/14801/