### PR TITLE
add low depth singular extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -694,6 +694,10 @@ fn search<NODE: NodeType>(
             extension = -2;
         }
     }
+    // Low Depth Singular Extensions (LDSE)
+    else if depth <= 7 && !in_check && cut_node && estimated_score <= alpha - 25 {
+        extension = 1;
+    }
 
     let mut best_move = Move::NULL;
     let mut bound = Bound::Upper;


### PR DESCRIPTION
```
Elo   | -0.63 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34032 W: 8577 L: 8639 D: 16816
Penta | [114, 4101, 8649, 4037, 115]
```
https://recklesschess.space/test/14752/

```
Elo   | 1.09 +- 0.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 157644 W: 39292 L: 38799 D: 79553
Penta | [74, 17615, 42963, 18084, 86]
```
https://recklesschess.space/test/14755/


bench: 2717564