### PR TITLE
Fix fullmove counter handling in move application

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -199,6 +199,10 @@ impl Board {
         self.fullmove_number += self.side_to_move() as usize;
     }
 
+    pub const fn retreat_fullmove_counter(&mut self) {
+        self.fullmove_number -= self.side_to_move() as usize;
+    }
+
     pub const fn set_frc(&mut self, frc: bool) {
         self.frc = frc;
     }

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -116,6 +116,7 @@ impl Board {
             _ => (),
         }
 
+        self.advance_fullmove_counter();
         self.side_to_move = !self.side_to_move;
 
         self.state.castling.raw &= self.castling_rights[from] & self.castling_rights[to];
@@ -149,6 +150,7 @@ impl Board {
 
     pub fn undo_move(&mut self, mv: Move) {
         self.side_to_move = !self.side_to_move;
+        self.retreat_fullmove_counter();
 
         let from = mv.from();
         let to = mv.to();

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -277,7 +277,6 @@ fn make_uci_move(board: &mut Board, uci_move: &str) {
     let moves = board.generate_all_moves();
     if let Some(mv) = moves.iter().map(|entry| entry.mv).find(|mv| mv.to_uci(board) == uci_move) {
         board.make_move(mv, &mut NullBoardObserver);
-        board.advance_fullmove_counter();
     }
 }
 


### PR DESCRIPTION
The move counter previously was being increased on the wrong moves.

Before:
Fen  1: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Move 1: position startpos moves e2e4
Fen  2: rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2
(Wrong)

After:
Fen  1: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
Move 1: position startpos moves e2e4
Fen  2: rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1
(Correct)

Bench: 2482674