### PR TITLE
Scale back draw_by_material.

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -243,8 +243,11 @@ impl Board {
         }
 
         // Here on, there are exactly 2 non-king minors
+
+        // Here, each side has one minor
         if self.colored_pieces2(stm, PieceType::Bishop, PieceType::Knight).popcount() == 1 {
-            return true;
+            //If a king is in a corner, don't auto draw.
+            return (Bitboard::CORNERS & self.pieces(PieceType::King)).is_empty();
         }
 
         if self.pieces(PieceType::Knight) != Bitboard(0) {

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -15,6 +15,7 @@ impl Bitboard {
     pub const SEVENTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R7), Self::rank(Rank::R2)];
     pub const THIRD_RANK: [Bitboard; 2] = [Self::rank(Rank::R3), Self::rank(Rank::R6)];
     pub const HOME_ROWS: [Bitboard; 2] = [Self::rank(Rank::R1), Self::rank(Rank::R8)];
+    pub const CORNERS: Self = Self(0x8100000000000081);
 
     /// Creates a bitboard with all bits set in the specified rank.
     pub const fn rank(rank: Rank) -> Self {


### PR DESCRIPTION
Fixes rare cases where a king can be mated. 

bench 2511393
Elo   | 0.13 +- 1.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.18 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 85740 W: 21929 L: 21898 D: 41913
Penta | [430, 9964, 22047, 10003, 426]
https://recklesschess.space/test/14823/