### PR TITLE
Simplify away quiet history factorizer

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -11,51 +11,23 @@ fn apply_bonus<const MAX: i32>(entry: &mut i16, bonus: i32) {
     *entry += (bonus - bonus.abs() * (*entry) as i32 / MAX) as i16;
 }
 
-struct QuietHistoryEntry {
-    factorizer: i16,
-    buckets: [[i16; 2]; 2],
-}
-
-impl QuietHistoryEntry {
-    const MAX_FACTORIZER: i32 = 1833;
-    const MAX_BUCKET: i32 = 6441;
-
-    pub const fn bucket(&self, threats: Bitboard, mv: Move) -> i16 {
-        let from_threatened = threats.contains(mv.from()) as usize;
-        let to_threatened = threats.contains(mv.to()) as usize;
-
-        self.buckets[from_threatened][to_threatened]
-    }
-
-    pub fn update_factorizer(&mut self, bonus: i32) {
-        let entry = &mut self.factorizer;
-        apply_bonus::<{ Self::MAX_FACTORIZER }>(entry, bonus);
-    }
-
-    pub fn update_bucket(&mut self, threats: Bitboard, mv: Move, bonus: i32) {
-        let from_threatened = threats.contains(mv.from()) as usize;
-        let to_threatened = threats.contains(mv.to()) as usize;
-
-        let entry = &mut self.buckets[from_threatened][to_threatened];
-        apply_bonus::<{ Self::MAX_BUCKET }>(entry, bonus);
-    }
-}
-
 pub struct QuietHistory {
-    entries: Box<[FromToHistory<QuietHistoryEntry>; 2]>,
+    // [side_to_move][from_threatened][to_threatened][from][to]
+    entries: Box<[[[FromToHistory<i16>; 2]; 2]; 2]>,
 }
 
 impl QuietHistory {
+    const MAX_HISTORY: i32 = 8192;
+
     pub fn get(&self, threats: Bitboard, stm: Color, mv: Move) -> i32 {
-        let entry = &self.entries[stm][mv.from()][mv.to()];
-        (entry.factorizer + entry.bucket(threats, mv)) as i32
+        self.entries[stm][threats.contains(mv.from()) as usize][threats.contains(mv.to()) as usize][mv.from()][mv.to()]
+            as i32
     }
 
     pub fn update(&mut self, threats: Bitboard, stm: Color, mv: Move, bonus: i32) {
-        let entry = &mut self.entries[stm][mv.from()][mv.to()];
-
-        entry.update_factorizer(bonus);
-        entry.update_bucket(threats, mv, bonus);
+        let entry = &mut self.entries[stm][threats.contains(mv.from()) as usize][threats.contains(mv.to()) as usize]
+            [mv.from()][mv.to()];
+        apply_bonus::<{ Self::MAX_HISTORY }>(entry, bonus);
     }
 }
 


### PR DESCRIPTION
STC
Elo   | -2.31 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.97 (-2.94, 2.94) [-2.75, 0.25]
Games | N: 36876 W: 9275 L: 9520 D: 18081
Penta | [154, 4421, 9488, 4266, 109]
https://recklesschess.space/test/14827/

LTC
Elo   | -0.01 +- 1.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 94916 W: 23415 L: 23418 D: 48083
Penta | [60, 10778, 25774, 10797, 49]
https://recklesschess.space/test/14753/

Bench: 2720496
