### PR TITLE
Apply decay to quiet move malus

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1055,9 +1055,11 @@ fn search<NODE: NodeType>(
             td.quiet_history.update(td.board.all_threats(), stm, best_move, quiet_bonus);
             update_continuation_histories(td, ply, td.board.moved_piece(best_move), best_move.to(), cont_bonus);
 
-            for &mv in quiet_moves.iter() {
-                td.quiet_history.update(td.board.all_threats(), stm, mv, -quiet_malus);
-                update_continuation_histories(td, ply, td.board.moved_piece(mv), mv.to(), -cont_malus);
+            for (i, &mv) in quiet_moves.iter().enumerate() {
+                let denom = 1024 + 45 * i as i32;
+                let scale = 1024_i32 * 1024 / (denom * denom / 1024);
+                td.quiet_history.update(td.board.all_threats(), stm, mv, -quiet_malus * scale / 1024);
+                update_continuation_histories(td, ply, td.board.moved_piece(mv), mv.to(), -cont_malus * scale / 1024);
             }
         }
 


### PR DESCRIPTION
STC
Elo   | 4.67 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15778 W: 4085 L: 3873 D: 7820
Penta | [49, 1759, 4072, 1949, 60]
https://recklesschess.space/test/14855/

LTC
Elo   | 5.18 +- 2.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12682 W: 3185 L: 2996 D: 6501
Penta | [1, 1329, 3500, 1502, 9]
https://recklesschess.space/test/14857/

Bench: 3123830