### PR TITLE
Simplify away using bounded tt score for evaluation when in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -409,7 +409,7 @@ fn search<NODE: NodeType>(
     let correction_value = eval_correction(td, ply);
 
     let raw_eval;
-    let mut eval;
+    let eval;
 
     // Evaluation
     if in_check {
@@ -442,19 +442,6 @@ fn search<NODE: NodeType>(
     } else {
         eval
     };
-
-    // Use the bounded TT entry score for evaluation when in check
-    if in_check
-        && !is_decisive(tt_score)
-        && is_valid(tt_score)
-        && match tt_bound {
-            Bound::Upper => tt_score <= alpha,
-            Bound::Lower => tt_score >= beta,
-            _ => true,
-        }
-    {
-        eval = tt_score;
-    }
 
     td.stack[ply].eval = eval;
     td.stack[ply].tt_move = tt_move;


### PR DESCRIPTION
STC
Elo   | -0.18 +- 0.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 134776 W: 34057 L: 34128 D: 66591
Penta | [466, 16075, 34340, 16078, 429]
https://recklesschess.space/test/14902/

LTC
Elo   | 0.59 +- 1.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 47028 W: 11750 L: 11670 D: 23608
Penta | [28, 5324, 12731, 5402, 29]
https://recklesschess.space/test/14912/

Bench: 3466720