### PR TITLE
Reduce LMR less aggressively in loose alpha windows

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -830,6 +830,10 @@ fn search<NODE: NodeType>(
                 reduction += (414 - 238 * improvement / 128).min(1014);
             }
 
+            if is_quiet && !is_decisive(alpha) && move_count > 1 {
+                reduction += 3 * ((alpha - estimated_score).clamp(-64, 96));
+            }
+
             if td.board.in_check() {
                 reduction -= 939;
             }


### PR DESCRIPTION
STC
Elo   | 2.19 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 42200 W: 10704 L: 10438 D: 21058
Penta | [110, 4940, 10779, 5116, 155]
https://recklesschess.space/test/14981/

LTC
Elo   | 4.27 +- 2.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15716 W: 3968 L: 3775 D: 7973
Penta | [5, 1683, 4295, 1864, 11]
https://recklesschess.space/test/14987/

Bench: 3479389