### PR TITLE
Prevent SEE-pruning the quiet blockers when in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -781,7 +781,7 @@ fn search<NODE: NodeType>(
                 (-7 * depth * depth - 31 * depth - 32 * history / 1024 + 16).min(0)
             };
 
-            if !td.board.see(mv, threshold) {
+            if (!in_check || !is_quiet) && !td.board.see(mv, threshold) {
                 continue;
             }
         }


### PR DESCRIPTION
Elo   | 3.10 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26710 W: 6846 L: 6608 D: 13256
Penta | [87, 3112, 6732, 3324, 100]
https://recklesschess.space/test/14984/

Elo   | 1.61 +- 1.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63616 W: 15869 L: 15575 D: 32172
Penta | [27, 7047, 17377, 7319, 38]
https://recklesschess.space/test/14986/

Bench: 2756239