### PR TITLE
Simplify pawn captures

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -104,12 +104,12 @@ impl super::Board {
     }
 
     fn collect_pawn_captures(
-        &self, list: &mut MoveList, pawns: Bitboard, dir: i8, target: Bitboard, seventh_rank: Bitboard,
+        &self, list: &mut MoveList, pawns: Bitboard, dir: i8, target: Bitboard,
     ) {
-        let promos = (pawns & seventh_rank).shift(dir);
-        list.push_promotion_capture_setwise(dir, promos & target);
-        let captures = (pawns & !seventh_rank).shift(dir);
-        list.push_pawns_setwise(dir, captures & target, MoveKind::Capture);
+        let captures = pawns.shift(dir) & target;
+        let promos = captures & Bitboard::BOTH_HOME_ROWS;
+        list.push_promotion_capture_setwise(dir, promos);
+        list.push_pawns_setwise(dir, captures ^ promos, MoveKind::Capture);
 
         let ep = self.en_passant();
         if ep != Square::None && pawns.contains(ep.shift(-dir)) {
@@ -152,7 +152,7 @@ impl super::Board {
 
             for i in 0..2 {
                 let the_pawns = pawns & (!pinned | pin_masks[i]) & shift_masks[i];
-                self.collect_pawn_captures(list, the_pawns, dirs[i], target, seventh_rank);
+                self.collect_pawn_captures(list, the_pawns, dirs[i], target);
             }
         }
     }

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -127,7 +127,8 @@ impl super::Board {
         let king_sq = self.king_square(stm);
 
         let pushable_pawns = pawns & (!pinned | Bitboard::file(king_sq.file()));
-        let promotions = (pushable_pawns & seventh_rank).shift(up) & empty;
+        //let promotions = (pushable_pawns & seventh_rank).shift(up) & empty;
+        let promotions = (pawns & (!pinned | Bitboard::file(king_sq.file()))).shift(up) & empty & Bitboard::BOTH_HOME_ROWS;
 
         if mgkind == MovegenKind::Quiet {
             let non_promotions = pushable_pawns & !seventh_rank;

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -103,9 +103,7 @@ impl super::Board {
         }
     }
 
-    fn collect_pawn_captures(
-        &self, list: &mut MoveList, pawns: Bitboard, dir: i8, target: Bitboard,
-    ) {
+    fn collect_pawn_captures(&self, list: &mut MoveList, pawns: Bitboard, dir: i8, target: Bitboard) {
         let captures = pawns.shift(dir) & target;
         let promos = captures & Bitboard::BOTH_HOME_ROWS;
         list.push_promotion_capture_setwise(dir, promos);

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -121,18 +121,15 @@ impl super::Board {
         let stm = self.side_to_move();
         let up = Square::UP[stm];
         let pawns = self.colored_pieces(stm, PieceType::Pawn);
-        let seventh_rank = Bitboard::SEVENTH_RANK[stm];
         let third_rank = Bitboard::THIRD_RANK[stm];
         let empty = !self.occupancies();
         let king_sq = self.king_square(stm);
 
-        let pushable_pawns = pawns & (!pinned | Bitboard::file(king_sq.file()));
-        //let promotions = (pushable_pawns & seventh_rank).shift(up) & empty;
-        let promotions = (pawns & (!pinned | Bitboard::file(king_sq.file()))).shift(up) & empty & Bitboard::BOTH_HOME_ROWS;
+        let pushed_pawns = (pawns & (!pinned | Bitboard::file(king_sq.file()))).shift(up) & empty;
+        let promotions = pushed_pawns & Bitboard::BOTH_HOME_ROWS;
 
         if mgkind == MovegenKind::Quiet {
-            let non_promotions = pushable_pawns & !seventh_rank;
-            let single_pushes = non_promotions.shift(up) & empty;
+            let single_pushes = pushed_pawns ^ promotions;
             let double_pushes = (single_pushes & third_rank).shift(up) & empty;
 
             list.push_pawns_setwise(up, single_pushes & target, MoveKind::Normal);

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -126,7 +126,7 @@ impl super::Board {
         let king_sq = self.king_square(stm);
 
         let pushed_pawns = (pawns & (!pinned | Bitboard::file(king_sq.file()))).shift(up) & empty;
-        let promotions = pushed_pawns & Bitboard::BOTH_HOME_ROWS;
+        let promotions = pushed_pawns & Bitboard::BOTH_HOME_ROWS & target;
 
         if mgkind == MovegenKind::Quiet {
             let single_pushes = pushed_pawns ^ promotions;
@@ -134,9 +134,9 @@ impl super::Board {
 
             list.push_pawns_setwise(up, single_pushes & target, MoveKind::Normal);
             list.push_pawns_setwise(up * 2, double_pushes & target, MoveKind::DoublePush);
-            list.push_pawns_setwise(up, promotions & target, MoveKind::PromotionR);
-            list.push_pawns_setwise(up, promotions & target, MoveKind::PromotionB);
-            list.push_pawns_setwise(up, promotions & target, MoveKind::PromotionN);
+            list.push_pawns_setwise(up, promotions, MoveKind::PromotionR);
+            list.push_pawns_setwise(up, promotions, MoveKind::PromotionB);
+            list.push_pawns_setwise(up, promotions, MoveKind::PromotionN);
         }
 
         if mgkind == MovegenKind::Noisy {

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -13,7 +13,6 @@ impl Bitboard {
     pub const ALL: Self = Self(0xFFFFFFFFFFFFFFFF);
     pub const LIGHT_SQUARES: Self = Self(0x55AA55AA55AA55AA);
     pub const BOTH_HOME_ROWS: Self = Self(0xFF000000000000FF);
-    pub const SEVENTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R7), Self::rank(Rank::R2)];
     pub const SIXTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R6), Self::rank(Rank::R3)];
     pub const THIRD_RANK: [Bitboard; 2] = [Self::rank(Rank::R3), Self::rank(Rank::R6)];
     pub const HOME_ROWS: [Bitboard; 2] = [Self::rank(Rank::R1), Self::rank(Rank::R8)];

--- a/src/types/bitboard.rs
+++ b/src/types/bitboard.rs
@@ -12,6 +12,7 @@ pub struct Bitboard(pub u64);
 impl Bitboard {
     pub const ALL: Self = Self(0xFFFFFFFFFFFFFFFF);
     pub const LIGHT_SQUARES: Self = Self(0x55AA55AA55AA55AA);
+    pub const BOTH_HOME_ROWS: Self = Self(0xFF000000000000FF);
     pub const SEVENTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R7), Self::rank(Rank::R2)];
     pub const SIXTH_RANK: [Bitboard; 2] = [Self::rank(Rank::R6), Self::rank(Rank::R3)];
     pub const THIRD_RANK: [Bitboard; 2] = [Self::rank(Rank::R3), Self::rank(Rank::R6)];


### PR DESCRIPTION
If we shift first, it saves a few operations and we don't have to pass around a seventh_rank but can use a compile time constant.

STC
Elo   | 2.12 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 21170 W: 5472 L: 5343 D: 10355
Penta | [49, 2285, 5812, 2366, 73]
https://recklesschess.space/test/15010/