### PR TITLE
Limit eval-based history updates

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -453,7 +453,13 @@ fn search<NODE: NodeType>(
     td.cutoff_count[ply + 2] = 0;
 
     // Quiet move ordering using eval difference
-    if !NODE::ROOT && !in_check && !excluded && td.stack[ply - 1].mv.is_quiet() && is_valid(td.stack[ply - 1].eval) {
+    if !NODE::ROOT
+        && !in_check
+        && !excluded
+        && td.stack[ply - 1].mv.is_quiet()
+        && is_valid(td.stack[ply - 1].eval)
+        && (depth < 7 || entry.is_none())
+    {
         let value = 880 * (-(eval + td.stack[ply - 1].eval)) / 128;
         let bonus = value.clamp(-133, 361);
 


### PR DESCRIPTION
If we encounter the same position again at high depth, we skip the eval-difference update and let the depth-based history handle it later, this should minimize the uncertain bias introduced by the feedback loop of doing it again.

Elo   | 2.34 +- 1.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39490 W: 10256 L: 9990 D: 19244
Penta | [173, 4613, 9905, 4883, 171]
https://recklesschess.space/test/15083/

Elo   | 2.35 +- 1.73 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36296 W: 8949 L: 8704 D: 18643
Penta | [21, 4062, 9742, 4297, 26]
https://recklesschess.space/test/15086/

Bench: 4014185