### PR TITLE
Consolidate some code in move making.

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -2,7 +2,6 @@ use super::{Board, BoardObserver};
 use crate::types::{Move, MoveKind, Piece, PieceType, Square};
 
 impl Board {
-
     fn increment_stack(&mut self) {
         self.halfmove_number += 1;
         self.state_stack.push(self.state);
@@ -16,13 +15,10 @@ impl Board {
     }
 
     pub fn make_null_move(&mut self) {
-
         self.increment_stack();
-
         self.state.plies_from_null = 0;
         self.state.repetition = 0;
         self.state.captured = None;
-
         self.update_threats();
     }
 

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -7,14 +7,14 @@ impl Board {
 
         self.halfmove_number += 1;
         self.state_stack.push(self.state);
+        self.state.keys.toggle_side();
+        self.state.keys.toggle_castling(self.state.castling);
     }
 
     pub fn make_null_move(&mut self) {
 
         self.increment_stack();
 
-        self.state.keys.toggle_side();
-        self.state.keys.toggle_castling(self.state.castling);
         self.state.plies_from_null = 0;
         self.state.repetition = 0;
         self.state.captured = None;
@@ -42,9 +42,6 @@ impl Board {
         let stm = self.side_to_move();
 
         self.increment_stack();
-
-        self.state.keys.toggle_side();
-        self.state.keys.toggle_castling(self.state.castling);
 
         if self.en_passant() != Square::None {
             self.state.keys.toggle_en_passant(self.en_passant());

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -5,11 +5,11 @@ impl Board {
 
     fn increment_stack(&mut self) {
 
+        self.halfmove_number += 1;
         self.state_stack.push(self.state);
     }
 
     pub fn make_null_move(&mut self) {
-        self.halfmove_number += 1;
 
         self.increment_stack();
 
@@ -119,8 +119,6 @@ impl Board {
 
             self.state.material += promotion.value() - PieceType::Pawn.value();
         }
-
-        self.halfmove_number += 1;
 
         self.state.castling.raw &= self.castling_rights[from] & self.castling_rights[to];
         self.state.keys.toggle_castling(self.state.castling);

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -4,11 +4,15 @@ use crate::types::{Move, MoveKind, Piece, PieceType, Square};
 impl Board {
 
     fn increment_stack(&mut self) {
-
         self.halfmove_number += 1;
         self.state_stack.push(self.state);
         self.state.keys.toggle_side();
         self.state.keys.toggle_castling(self.state.castling);
+
+        if self.en_passant() != Square::None {
+            self.state.keys.toggle_en_passant(self.en_passant());
+            self.state.en_passant = Square::None;
+        }
     }
 
     pub fn make_null_move(&mut self) {
@@ -20,11 +24,6 @@ impl Board {
         self.state.captured = None;
 
         self.update_threats();
-
-        if self.en_passant() != Square::None {
-            self.state.keys.toggle_en_passant(self.en_passant());
-            self.state.en_passant = Square::None;
-        }
     }
 
     pub fn undo_null_move(&mut self) {
@@ -42,11 +41,6 @@ impl Board {
         let stm = self.side_to_move();
 
         self.increment_stack();
-
-        if self.en_passant() != Square::None {
-            self.state.keys.toggle_en_passant(self.en_passant());
-            self.state.en_passant = Square::None;
-        }
 
         let captured = self.piece_on(to);
         self.state.captured = Some(captured);

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -2,9 +2,16 @@ use super::{Board, BoardObserver};
 use crate::types::{Move, MoveKind, Piece, PieceType, Square};
 
 impl Board {
+
+    fn increment_stack(&mut self) {
+
+        self.state_stack.push(self.state);
+    }
+
     pub fn make_null_move(&mut self) {
         self.halfmove_number += 1;
-        self.state_stack.push(self.state);
+
+        self.increment_stack();
 
         self.state.keys.toggle_side();
         self.state.keys.toggle_castling(self.state.castling);
@@ -34,7 +41,7 @@ impl Board {
         let piece = self.piece_on(from);
         let stm = self.side_to_move();
 
-        self.state_stack.push(self.state);
+        self.increment_stack();
 
         self.state.keys.toggle_side();
         self.state.keys.toggle_castling(self.state.castling);


### PR DESCRIPTION
No performance difference expected.  Just removes some redundant code.

STC
Elo   | 1.57 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 26940 W: 6808 L: 6686 D: 13446
Penta | [80, 2889, 7440, 2951, 110]
https://recklesschess.space/test/15099/