### PR TITLE
Simplify condition for LMR reduction

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -839,7 +839,7 @@ fn search<NODE: NodeType>(
                 reduction += 2113 * tt_move.is_null() as i32;
             }
 
-            if is_quiet && !is_decisive(alpha) && move_count > 1 {
+            if is_quiet {
                 reduction += 3 * ((alpha - estimated_score).clamp(-64, 96));
             }
 


### PR DESCRIPTION
STC
Elo   | 0.97 +- 1.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 36742 W: 9484 L: 9381 D: 17877
Penta | [119, 3999, 10062, 4042, 149]
https://recklesschess.space/test/15113/

LTC
Elo   | 0.96 +- 1.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 35472 W: 8811 L: 8713 D: 17948
Penta | [28, 3679, 10217, 3791, 21]
https://recklesschess.space/test/15117/

Bench: 2738963