### PR TITLE
Tweak negative extensions

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -692,7 +692,7 @@ fn search<NODE: NodeType>(
         }
         // Negative Extensions
         else if tt_score >= beta || cut_node {
-            extension = -2;
+            extension = -3;
         }
     }
     // Low Depth Singular Extensions (LDSE)


### PR DESCRIPTION
My reasoning to increase it now is that with the introduction of resetting tt-move in the previous else, we can probably afford aggressive  reduction

Elo   | 1.20 +- 0.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 141028 W: 35911 L: 35422 D: 69695
Penta | [425, 16497, 36253, 16842, 497]
https://recklesschess.space/test/15167/

Elo   | 3.08 +- 2.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23914 W: 6095 L: 5883 D: 11936
Penta | [8, 2626, 6493, 2806, 24]
https://recklesschess.space/test/15168/

Bench: 3634130