### PR TITLE
remove redundant code.

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -68,7 +68,6 @@ impl Board {
             observer.on_piece_mutate(self, captured, piece, to);
 
             self.state.material -= captured.value();
-            self.state.captured = Some(captured);
         } else {
             self.remove_piece(from);
             self.add_piece(piece, to);


### PR DESCRIPTION
bench 3634130

Captured is set earlier, so this line does nothing.  Not tested.