### PR TITLE
Faster is_noisy.

### DIFF
--- a/src/types/moves.rs
+++ b/src/types/moves.rs
@@ -65,17 +65,10 @@ impl Move {
         self.is_present() && !self.is_noisy()
     }
 
+    // Sneaky bit-twidling.  If we just look at the last 3 bits (& 7), anything
+    // greater than Castling is a queen push promotion or a capture.
     pub const fn is_noisy(self) -> bool {
-        matches!(
-            self.kind(),
-            MoveKind::Capture
-                | MoveKind::EnPassant
-                | MoveKind::PromotionQ
-                | MoveKind::PromotionCaptureN
-                | MoveKind::PromotionCaptureB
-                | MoveKind::PromotionCaptureR
-                | MoveKind::PromotionCaptureQ
-        )
+        (self.kind() as u8 & 7) > MoveKind::Castling as u8
     }
 
     pub const fn is_special(self) -> bool {


### PR DESCRIPTION
bench 3634130

Trying again with a little cleaner version and added some comments for clarity.  Not tested, but this demonstrably faster.

```
is_noisy_main:
        movzx   eax, di
        shr     eax, 12
        mov     ecx, 63536
        bt      ecx, eax
        setb    al
        ret

is_noisy_patch:
        and     edi, 28672
        cmp     edi, 8193
        setae   al
        ret
```