### PR TITLE
Avoid incrementing aspiration reduction on decisive fail highs

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -147,7 +147,11 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
                     s if s >= beta => {
                         alpha = (beta - delta).max(alpha);
                         beta = (score + delta).min(Score::INFINITE);
-                        reduction += 1;
+                        if !is_decisive(score) {
+                            reduction += 1;
+                        } else {
+                            reduction = reduction.min(1)
+                        }
                         delta += 60 * delta / 128;
                     }
                     _ => {


### PR DESCRIPTION
Matetrack:

1,000,000 nodes
Main: Found 3607, Best 2072
Patch: Found 3647, Best 2106
Net (branch): Found +40, Best +34

STC
Elo   | -0.09 +- 0.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 112018 W: 28367 L: 28395 D: 55256
Penta | [315, 11821, 31760, 11803, 310]
https://recklesschess.space/test/15193/

Bench: 3634130