### PR TITLE
Prefetch TTable entry on move generation

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -83,6 +83,28 @@ impl Board {
         self.state.keys.full() ^ ZOBRIST.fiftymove_clock[self.fiftymove_clock_bucket()]
     }
 
+    pub fn key_after(&self, mv: Move) -> u64 {
+        let from = mv.from();
+        let to = mv.to();
+        let piece = self.piece_on(from);
+        let captured = self.piece_on(to);
+
+        let mut key = self.state.keys.full() ^ ZOBRIST.side ^ ZOBRIST.pieces[piece][from] ^ ZOBRIST.pieces[piece][to];
+
+        if captured != Piece::None {
+            key ^= ZOBRIST.pieces[captured][to];
+        }
+
+        let fiftymove_clock = if captured != Piece::None || piece.piece_type() == PieceType::Pawn {
+            0
+        } else {
+            self.fiftymove_clock() + 1
+        };
+        let bucket = (fiftymove_clock.saturating_sub(8) as usize / 8).min(15);
+
+        key ^ ZOBRIST.fiftymove_clock[bucket]
+    }
+
     pub const fn pawn_key(&self) -> u64 {
         self.state.keys.pawn()
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1414,6 +1414,7 @@ fn update_continuation_histories(td: &mut ThreadData, ply: isize, piece: Piece, 
 }
 
 fn make_move(td: &mut ThreadData, ply: isize, mv: Move) {
+    td.shared.tt.prefetch(td.board.key_after(mv));
     td.stack[ply].mv = mv;
     td.stack[ply].piece = td.board.moved_piece(mv);
     td.stack[ply].conthist =


### PR DESCRIPTION
VSTC
Elo   | 6.20 +- 3.23 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11032 W: 2919 L: 2722 D: 5391
Penta | [42, 1086, 3085, 1239, 64]
https://recklesschess.space/test/15314/

Thanks to @dhanaway for the idea.

No functional change.

Bench: 3204302