### PR TITLE
Reduce probcut depth when improving

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -651,7 +651,7 @@ fn search<NODE: NodeType>(
 
             let mut score = -qsearch::<NonPV>(td, -probcut_beta, -probcut_beta + 1, ply + 1);
 
-            let base_depth = (depth - 4).max(0);
+            let base_depth = (depth - 4 - improving as i32).max(0);
             let mut probcut_depth = (base_depth - (score - probcut_beta) / 319).clamp(0, base_depth);
 
             if score >= probcut_beta && probcut_depth > 0 {


### PR DESCRIPTION
STC
Elo   | 2.47 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 35530 W: 9008 L: 8755 D: 17767
Penta | [132, 4108, 9026, 4373, 126]
https://recklesschess.space/test/15316/

LTC
Elo   | 2.61 +- 1.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29372 W: 7402 L: 7181 D: 14789
Penta | [8, 3201, 8058, 3400, 19]
https://recklesschess.space/test/15317/

Thanks to @Vizvezdenec for the idea.

Bench: 2764394