### PR TITLE
Increase LMR reduction for winning beta

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -850,6 +850,7 @@ fn search<NODE: NodeType>(
 
             reduction += 464 * (is_valid(tt_score) && tt_score <= alpha) as i32;
             reduction += 326 * (is_valid(tt_score) && tt_depth < depth) as i32;
+            reduction += 1024 * is_win(beta) as i32;
 
             if is_quiet {
                 reduction += 2171;


### PR DESCRIPTION
Matetrack:

1,000,000 nodes
Main: Found 3668, Best 2098
Patch: Found 3696, Best 2102
Net (branch): Found +28, Best +4

STC
Elo   | 1.48 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 29640 W: 7581 L: 7455 D: 14604
Penta | [130, 3186, 8024, 3388, 92]
https://recklesschess.space/test/15321/

Bench: 2764394