### PR TITLE
Implement pawn history for quiet move ordering

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -105,6 +105,33 @@ impl Default for QuietHistory {
     }
 }
 
+pub struct PawnHistory {
+    // [pawn_key_bucket][piece][to]
+    entries: Box<[PieceToHistory<i16>; Self::SIZE]>,
+}
+
+impl PawnHistory {
+    const MAX_HISTORY: i32 = 8192;
+
+    const SIZE: usize = 512;
+    const MASK: usize = Self::SIZE - 1;
+
+    pub fn get(&self, pawn_key: u64, piece: Piece, to: Square) -> i32 {
+        self.entries[pawn_key as usize & Self::MASK][piece][to] as i32
+    }
+
+    pub fn update(&mut self, pawn_key: u64, piece: Piece, to: Square, bonus: i32) {
+        let entry = &mut self.entries[pawn_key as usize & Self::MASK][piece][to];
+        apply_bonus::<{ Self::MAX_HISTORY }>(entry, bonus);
+    }
+}
+
+impl Default for PawnHistory {
+    fn default() -> Self {
+        Self { entries: zeroed_box() }
+    }
+}
+
 pub struct NoisyHistory {
     // [piece][to][captured_piece_type][to_threatened]
     entries: Box<PieceToHistory<[[i16; 2]; 7]>>,

--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -143,6 +143,7 @@ impl MovePicker {
     fn score_quiet(&mut self, td: &ThreadData, ply: isize) {
         let threats = td.board.all_threats();
         let side = td.board.side_to_move();
+        let pawn_key = td.board.pawn_key();
         let occupancies = td.board.occupancies();
         let pawn_threats = td.board.piece_threats(PieceType::Pawn);
 
@@ -198,6 +199,7 @@ impl MovePicker {
             let pt = td.board.type_on(mv.from());
 
             entry.score = 1763 * td.quiet_history.get(threats, side, mv) / 1024
+                + 1024 * td.pawn_history.get(pawn_key, td.board.moved_piece(mv), mv.to()) / 1024
                 + 1614 * td.conthist(ply, 1, mv) / 1024
                 + 1066 * td.conthist(ply, 2, mv) / 1024
                 + 1086 * td.conthist(ply, 4, mv) / 1024

--- a/src/search.rs
+++ b/src/search.rs
@@ -1079,12 +1079,19 @@ fn search<NODE: NodeType>(
             );
         } else {
             td.quiet_history.update(td.board.all_threats(), stm, best_move, quiet_bonus);
+            td.pawn_history.update(td.board.pawn_key(), td.board.moved_piece(best_move), best_move.to(), quiet_bonus);
             update_continuation_histories(td, ply, td.board.moved_piece(best_move), best_move.to(), cont_bonus);
 
             for (i, &mv) in quiet_moves.iter().enumerate() {
                 let denom = 1024 + 45 * i as i32;
                 let scale = 1024_i32 * 1024 / (denom * denom / 1024);
                 td.quiet_history.update(td.board.all_threats(), stm, mv, -quiet_malus * scale / 1024);
+                td.pawn_history.update(
+                    td.board.pawn_key(),
+                    td.board.moved_piece(mv),
+                    mv.to(),
+                    -quiet_malus * scale / 1024,
+                );
                 update_continuation_histories(td, ply, td.board.moved_piece(mv), mv.to(), -cont_malus * scale / 1024);
             }
         }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -19,7 +19,9 @@ pub static WORKERS_REMAINING: AtomicUsize = AtomicUsize::new(0);
 
 use crate::{
     board::Board,
-    history::{ContinuationCorrectionHistory, ContinuationHistory, CorrectionHistory, NoisyHistory, QuietHistory},
+    history::{
+        ContinuationCorrectionHistory, ContinuationHistory, CorrectionHistory, NoisyHistory, PawnHistory, QuietHistory,
+    },
     nnue::{Network, ParametersHandle},
     numa::{NumaConfig, NumaReplicable, NumaReplicated, NumaReplicatedAccessToken, NumaReplicationContext},
     stack::Stack,
@@ -220,6 +222,7 @@ pub struct ThreadData {
     pub pv_table: PrincipalVariationTable,
     pub noisy_history: NoisyHistory,
     pub quiet_history: QuietHistory,
+    pub pawn_history: PawnHistory,
     pub continuation_history: ContinuationHistory,
     pub continuation_corrhist: ContinuationCorrectionHistory,
     pub best_move_changes: usize,
@@ -256,6 +259,7 @@ impl ThreadData {
             pv_table: PrincipalVariationTable::default(),
             noisy_history: NoisyHistory::default(),
             quiet_history: QuietHistory::default(),
+            pawn_history: PawnHistory::default(),
             continuation_history: ContinuationHistory::default(),
             continuation_corrhist: ContinuationCorrectionHistory::default(),
             best_move_changes: 0,


### PR DESCRIPTION
STC
Elo   | 4.43 +- 2.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17334 W: 4519 L: 4298 D: 8517
Penta | [73, 2023, 4276, 2200, 95]
https://recklesschess.space/test/15342/

LTC
Elo   | 2.13 +- 1.65 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40472 W: 10127 L: 9879 D: 20466
Penta | [36, 4531, 10844, 4799, 26]
https://recklesschess.space/test/15346/

Bench: 2526370