### PR TITLE
Internal Iterative Deepening

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -735,6 +735,15 @@ fn search<NODE: NodeType>(
         extension = 1;
     }
 
+    // Internal Iterative Deepening (IID)
+    if !NODE::ROOT && NODE::PV && depth >= 8 && !in_check && !excluded && tt_move.is_null() {
+        let _ = search::<NonPV>(td, alpha, alpha + 1, (3 * depth - 7) / 4, true, ply);
+
+        if let Some(entry) = td.shared.tt.read(hash, td.board.fiftymove_clock(), ply) {
+            tt_move = entry.mv;
+        }
+    }
+
     let mut best_move = Move::NULL;
     let mut bound = Bound::Upper;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -737,7 +737,7 @@ fn search<NODE: NodeType>(
 
     // Internal Iterative Deepening (IID)
     if !NODE::ROOT && NODE::PV && depth >= 8 && !in_check && !excluded && tt_move.is_null() {
-        let _ = search::<NonPV>(td, alpha, alpha + 1, (3 * depth - 7) / 4, true, ply);
+        let _ = search::<PV>(td, alpha, beta, (3 * depth - 7) / 4, cut_node, ply);
 
         if let Some(entry) = td.shared.tt.read(hash, td.board.fiftymove_clock(), ply) {
             tt_move = entry.mv;

--- a/src/search.rs
+++ b/src/search.rs
@@ -737,7 +737,7 @@ fn search<NODE: NodeType>(
 
     // Internal Iterative Deepening (IID)
     if !NODE::ROOT && NODE::PV && depth >= 8 && !in_check && !excluded && tt_move.is_null() {
-        let _ = search::<PV>(td, alpha, beta, (3 * depth - 7) / 4, cut_node, ply);
+        let _ = search::<PV>(td, alpha, beta, (768 * depth - 1792) / 1024, cut_node, ply);
 
         if let Some(entry) = td.shared.tt.read(hash, td.board.fiftymove_clock(), ply) {
             tt_move = entry.mv;


### PR DESCRIPTION
STC
Elo   | 4.42 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16444 W: 4196 L: 3987 D: 8261
Penta | [50, 1822, 4295, 1979, 76]

LTC
Elo   | 5.56 +- 3.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11626 W: 2960 L: 2774 D: 5892
Penta | [5, 1231, 3156, 1415, 6]

Bench: 2862950