### PR TITLE
Fix non-canonical hash after null moves

### DIFF
--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -6,7 +6,6 @@ impl Board {
         self.halfmove_number += 1;
         self.state_stack.push(self.state);
         self.state.keys.toggle_side();
-        self.state.keys.toggle_castling(self.state.castling);
         self.state.repetition = 0;
 
         if self.en_passant() != Square::None {
@@ -94,6 +93,7 @@ impl Board {
             self.state.material += promotion.value() - PieceType::Pawn.value();
         }
 
+        self.state.keys.toggle_castling(self.state.castling);
         self.state.castling.raw &= self.castling_rights[from] & self.castling_rights[to];
         self.state.keys.toggle_castling(self.state.castling);
 


### PR DESCRIPTION
increment_stack toggles the castling key out on every ply, which is the remove-old-rights half of the pair that make_move completes when it updates castling rights. make_null_move goes through increment_stack but never toggles it back, so the hash after a null move is left off by the castling term: a position reached via a null move hashes differently from the same position parsed from FEN.

Move the castling toggle out of the shared increment_stack into make_move, which owns both halves. Null moves now leave castling untouched, matching the standard convention (Stockfish, Viridithas).

STC
Elo   | 3.45 +- 2.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 14716 W: 3733 L: 3587 D: 7396
Penta | [43, 1679, 3779, 1803, 54]
https://recklesschess.space/test/15402/

LTC
Elo   | 2.57 +- 2.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 17832 W: 4442 L: 4310 D: 9080
Penta | [7, 2002, 4764, 2138, 5]
https://recklesschess.space/test/15403/

Bench: 2931707