### PR TITLE
Fix is_legal accepting non-canonical castling encodings

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -363,7 +363,8 @@ impl Board {
             if mv.is_castling() {
                 let kind = CastlingKind::KINDS[stm][(to.file() == File::G) as usize];
 
-                return self.castling().is_allowed(kind)
+                return to == kind.landing_square()
+                    && self.castling().is_allowed(kind)
                     && (self.castling_path[kind] & self.occupancies()).is_empty()
                     && (self.castling_threat[kind] & self.all_threats()).is_empty()
                     && !self.pinned(stm).contains(self.castling_rooks[kind]);


### PR DESCRIPTION
is_legal derives the castling kind from to.file() == File::G alone and never checks that to is the actual landing square, so with castling rights and a clear path it accepts (king_from, arbitrary to, Castling) for 63 bogus encodings per position. Playing one hits the unreachable in get_castling_rook. Search is unaffected (UCI and the TT path only see canonical encodings), but islegalperft feeds every accepted encoding to make_move and currently panics on any position with castling rights:

    position fen r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1
    islegalperft 1  ->  panicked: entered unreachable code

Require to == kind.landing_square(), making is_legal an exact mirror of generate_all_moves and restoring the diagnostic (kiwipete islegalperft 1 now completes: 48). Matches the convention in Stockfish, where special-move validity is generated-set membership.

No functional change.

Bench: 2526370