### PR TITLE
Handle missing FEN castling field without panicking

### DIFF
--- a/src/board/parser.rs
+++ b/src/board/parser.rs
@@ -51,7 +51,7 @@ impl Board {
             _ => return Err(ParseFenError::InvalidActiveColor),
         };
 
-        board.set_castling(parts.next().unwrap());
+        board.set_castling(parts.next().unwrap_or_default());
 
         board.state.en_passant = parts.next().unwrap_or_default().try_into().unwrap_or_default();
         board.state.fiftymove_clock = parts.next().unwrap_or_default().parse().unwrap_or_default();

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -109,3 +109,14 @@ fn incremental_hash_matches_recomputation() {
         board.undo_null_move();
     }
 }
+
+#[test]
+fn from_fen_accepts_missing_optional_fields() {
+    prepare_lut();
+
+    assert!(Board::from_fen("4k3/8/8/8/8/8/8/4K3 w").is_ok());
+    assert!(Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w").is_ok());
+
+    assert!(Board::from_fen("").is_err());
+    assert!(Board::from_fen("4k3/8/8/8/8/8/8/4K3").is_err());
+}


### PR DESCRIPTION
Board::from_fen returns Err for missing placement data or an invalid active color, but unwrapped the castling field, so a FEN truncated after the active color (for example "4k3/8/8/8/8/8/8/4K3 w") panicked in the parser instead of parsing.

The trailing en passant / halfmove / fullmove fields already default via unwrap_or_default(); this makes the castling field consistent, so a missing or unrecognised castling field parses as no castling rights. Adds a regression test.

No functional change.

Bench: 2526370