### PR TITLE
Add a strict wasm build target and run it in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,15 +16,6 @@ rustflags = ["-C", "target-cpu=native"]
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-cpu=native"]
 
-[target.wasm32-unknown-unknown]
-rustflags = [
-    "-C", "target-feature=+atomics,+bulk-memory,+simd128,+relaxed-simd",
-    "-C", "link-arg=--shared-memory",
-    "-C", "link-arg=--max-memory=1073741824",
-    "-C", "link-arg=--import-memory",
-    "-C", "link-arg=--export=__wasm_init_tls",
-    "-C", "link-arg=--export=__tls_size",
-    "-C", "link-arg=--export=__tls_align",
-    "-C", "link-arg=--export=__tls_base",
-    "-C", "link-arg=--export=__heap_base",
-]
+# wasm32 rustflags live in the Makefile (wasm / wasm-strict targets). RUSTFLAGS
+# overrides this file completely, so a second variant here would mean keeping
+# two copies of the link-args in sync.

--- a/.github/wasm-check/check.mjs
+++ b/.github/wasm-check/check.mjs
@@ -1,0 +1,68 @@
+// Compares the strict wasm build's NNUE evals against the native binary.
+//
+// Usage: node check.mjs PKG_DIR NATIVE_BIN POSITIONS_TXT [TOLERANCE_CP]
+//
+// The strict wasm and native builds sit in different f32 rounding families
+// (non-fused vs fused madd), at most 1cp apart in practice, hence the
+// default tolerance. Real breakage shows up as hundreds of cp.
+//
+// Exit codes: 0 ok, 1 eval mismatch beyond tolerance, 2 usage/load failure.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const [pkgDir, nativeBin, positionsPath, tolArg] = process.argv.slice(2);
+if (!pkgDir || !nativeBin || !positionsPath) {
+  console.error('usage: node check.mjs PKG_DIR NATIVE_BIN POSITIONS_TXT [TOLERANCE_CP]');
+  process.exit(2);
+}
+const tolerance = tolArg === undefined ? 1 : Number(tolArg);
+
+const fens = readFileSync(positionsPath, 'utf8')
+  .split('\n').map(s => s.trim()).filter(s => s && !s.startsWith('#'));
+
+// Native evals: one process, "position fen X" + "eval" per position. The
+// final line of each eval block is "NNUE evaluation  +0.80 (White side)".
+const input = fens.map(f => `position fen ${f}\neval\n`).join('') + 'quit\n';
+const native = spawnSync(nativeBin, [], { input, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+if (native.status !== 0) {
+  console.error(`native binary failed: status ${native.status}\n${native.stderr}`);
+  process.exit(2);
+}
+const nativeEvals = [...native.stdout.matchAll(/NNUE evaluation\s+([+-]?\d+\.\d+)/g)]
+  .map(m => Math.round(parseFloat(m[1]) * 100));
+if (nativeEvals.length !== fens.length) {
+  console.error(`expected ${fens.length} native evals, parsed ${nativeEvals.length}`);
+  process.exit(2);
+}
+
+let glue, engine;
+try {
+  glue = await import(pathToFileURL(resolve(pkgDir, 'reckless.js')).href);
+  glue.initSync({ module: readFileSync(resolve(pkgDir, 'reckless_bg.wasm')) });
+  engine = new glue.Engine();
+  engine.set_threads(1);
+} catch (e) {
+  console.error(`failed to load wasm package from ${pkgDir}: ${e}`);
+  process.exit(2);
+}
+
+let failures = 0;
+fens.forEach((fen, i) => {
+  engine.set_position(fen);
+  const stm = fen.split(/\s+/)[1];
+  const wasmWhite = stm === 'b' ? -engine.evaluate() : engine.evaluate();
+  const delta = Math.abs(wasmWhite - nativeEvals[i]);
+  if (delta > tolerance) {
+    failures++;
+    console.error(`MISMATCH  native ${nativeEvals[i]}  wasm ${wasmWhite}  (delta ${delta})  ${fen}`);
+  }
+});
+
+if (failures > 0) {
+  console.error(`${failures}/${fens.length} positions beyond ${tolerance}cp of native`);
+  process.exit(1);
+}
+console.log(`${fens.length}/${fens.length} positions within ${tolerance}cp of native`);

--- a/.github/wasm-check/positions.txt
+++ b/.github/wasm-check/positions.txt
@@ -1,0 +1,14 @@
+# Positions for the wasm-vs-native eval comparison. Mixed openings, tactics
+# and endgames; with the current network a few of these sit right on the
+# rounding boundary between the fused and non-fused madd families, which is
+# what the 1cp tolerance covers.
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
+2b1kb1r/rp2pp1p/p2p3n/2qPP1pP/2B5/P1P5/1B1KQPn1/RN4NR b k - 0 17
+1rb1kb1r/2p1n2p/p3ppp1/1p1q2N1/PP1n4/8/R1PPNPPP/2BQKB1R w Kk - 0 12
+rnb1k1nr/pp1p1p1p/3b3R/2p1p1P1/P7/1PNq1PK1/1B2P1P1/2RQ1BN1 b kq - 2 12
+r1bqkbnr/pppppppp/n7/8/8/P1P3PB/1P1PPP1P/RNBQK1NR b KQkq - 0 4
+rn1qkb1r/pb1ppppp/1pp2n2/5Q2/8/N7/PPPP1PPP/R1B1KBNR w KQkq - 2 7
+rnb2b1r/1B3k1n/p2p4/2p2p1P/P1pP2p1/R1Q4N/1PP2P1P/3K3R w - - 2 22
+2bqk2r/r1p1ppb1/2n3pn/p2p3p/pP2PB2/2KP1PPN/2P4P/RN2QB1R w k - 2 14
+r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1
+rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8

--- a/.github/workflows/wasm_check.yml
+++ b/.github/workflows/wasm_check.yml
@@ -1,0 +1,52 @@
+name: Wasm Eval Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  wasm-eval:
+    runs-on: ubuntu-latest
+    name: wasm strict eval vs native
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: wasm32-unknown-unknown
+          components: rust-src
+
+      - name: Install wasm tools
+        run: |
+          curl -sSL https://github.com/WebAssembly/binaryen/releases/download/version_130/binaryen-version_130-x86_64-linux.tar.gz | tar xz
+          echo "$PWD/binaryen-version_130/bin" >> $GITHUB_PATH
+          cargo install wasm-bindgen-cli --version 0.2.123
+
+      - name: Build strict wasm
+        run: make wasm-strict
+
+      - name: Build native reference
+        run: cargo build --release --no-default-features
+
+      # The strict build and native sit in different f32 rounding families
+      # (non-fused vs fused madd), measured at most 1cp apart. Comparing
+      # against a native binary built in the same job means nothing is
+      # pinned, so network updates need no fixture regeneration.
+      - name: Compare wasm evals against native
+        run: node .github/wasm-check/check.mjs pkg-strict target/release/reckless .github/wasm-check/positions.txt
+
+      # A relaxed-simd leak into the strict build would fuse madd and match
+      # native exactly, so the eval comparison alone cannot catch it. The
+      # instruction scan does. wasm-opt runs on its own line so a failure
+      # there fails the step instead of counting as zero matches.
+      - name: Check the strict build has no relaxed opcodes
+        run: |
+          wasm-opt --print pkg-strict/reckless_bg.wasm > strict.wat
+          count=$(grep -c 'relaxed_' strict.wat || true)
+          echo "relaxed instructions: $count"
+          test "$count" -eq 0

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,20 @@ else
 	PGO_MOVE := move /Y "target\$(TARGET)\release\$(EXE).exe" "$(NAME)"
 endif
 
-.PHONY: all no-syzygy pgo wasm x64-check checkdeps clean help
+# Wasm build flags. The two targets below differ only in relaxed-simd:
+# some engines fuse relaxed_madd (matches native avx2) and some don't,
+# so the relaxed build is engine-dependent while the strict one isn't.
+WASM_FEATURES  := +atomics,+bulk-memory,+simd128
+WASM_LINK_ARGS := -C link-arg=--shared-memory \
+	-C link-arg=--max-memory=1073741824 \
+	-C link-arg=--import-memory \
+	-C link-arg=--export=__wasm_init_tls \
+	-C link-arg=--export=__tls_size \
+	-C link-arg=--export=__tls_align \
+	-C link-arg=--export=__tls_base \
+	-C link-arg=--export=__heap_base
+
+.PHONY: all no-syzygy pgo wasm wasm-strict x64-check checkdeps clean help
 
 all: ## Build the engine
 	cargo rustc --release --bin reckless -- --emit link=$(NAME)
@@ -35,13 +48,23 @@ pgo: ## Build with profile-guided optimization
 	cargo pgo optimize
 	$(PGO_MOVE)
 
-wasm: ## Build the WebAssembly target
-	RUSTFLAGS= rustup run nightly \
+wasm: ## Build the WebAssembly target (relaxed-simd)
+	RUSTFLAGS="-C target-feature=$(WASM_FEATURES),+relaxed-simd $(WASM_LINK_ARGS)" \
+		rustup run nightly \
 		cargo build -Z build-std=panic_abort,std \
 		--lib --target wasm32-unknown-unknown --release --no-default-features
 	wasm-bindgen target/wasm32-unknown-unknown/release/reckless.wasm --target web --out-dir pkg
 	wasm-opt -O3 --enable-simd --enable-threads --enable-relaxed-simd \
 		pkg/reckless_bg.wasm -o pkg/reckless_bg.wasm
+
+wasm-strict: ## Build the WebAssembly target (no relaxed-simd, same output on every engine)
+	RUSTFLAGS="-C target-feature=$(WASM_FEATURES) $(WASM_LINK_ARGS)" \
+		rustup run nightly \
+		cargo build -Z build-std=panic_abort,std \
+		--lib --target wasm32-unknown-unknown --release --no-default-features
+	wasm-bindgen target/wasm32-unknown-unknown/release/reckless.wasm --target web --out-dir pkg-strict
+	wasm-opt -O3 --enable-simd --enable-threads \
+		pkg-strict/reckless_bg.wasm -o pkg-strict/reckless_bg.wasm
 
 x64-check: ## Check compilation for x86-64 v1-v4
 	RUSTFLAGS="-C target-cpu=x86-64" cargo check --target x86_64-unknown-linux-gnu --no-default-features


### PR DESCRIPTION
The wasm build is relaxed-simd only and CI never executes it, so a numerical regression in the wasm NNUE path (or an engine changing how it lowers relaxed_madd) would not be caught.

Move the wasm rustflags into the Makefile (RUSTFLAGS overrides the config.toml flags completely, so a second variant there would mean duplicating the link-args) and add a wasm-strict target without relaxed-simd.

The new CI job builds it next to the native binary and compares NNUE evals between the two with a 1cp tolerance. The builds sit in different f32 rounding families (non-fused vs fused madd), measured at most 1cp apart, while real breakage shows up as hundreds of cp. Nothing is pinned, so network updates need no fixture maintenance. The job also scans the strict artifact for relaxed opcodes, since a relaxed-simd leak would fuse madd and match native exactly, which the eval comparison alone cannot catch. The shipped relaxed package is unchanged.

Context: #1094.

No functional change.

Bench: 2931707