### PR TITLE
Saturate the halfmove clock instead of overflowing

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -98,7 +98,7 @@ impl Board {
         let fiftymove_clock = if captured != Piece::None || piece.piece_type() == PieceType::Pawn {
             0
         } else {
-            self.fiftymove_clock() + 1
+            self.fiftymove_clock().saturating_add(1)
         };
         let bucket = (fiftymove_clock.saturating_sub(8) as usize / 8).min(15);
 

--- a/src/board/makemove.rs
+++ b/src/board/makemove.rs
@@ -44,7 +44,7 @@ impl Board {
         if mv.kind() == MoveKind::Capture || piece.piece_type() == PieceType::Pawn {
             self.state.fiftymove_clock = 0;
         } else {
-            self.state.fiftymove_clock += 1;
+            self.state.fiftymove_clock = self.state.fiftymove_clock.saturating_add(1);
         }
 
         if mv.is_castling() {

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -120,3 +120,21 @@ fn from_fen_accepts_missing_optional_fields() {
     assert!(Board::from_fen("").is_err());
     assert!(Board::from_fen("4k3/8/8/8/8/8/8/4K3").is_err());
 }
+
+#[test]
+fn halfmove_clock_saturates_instead_of_overflowing() {
+    prepare_lut();
+
+    let board = Board::from_fen("4k3/8/8/8/8/8/8/4K3 w - - 200 1").unwrap();
+    assert_eq!(board.fiftymove_clock(), 200);
+    let _ = board.hash();
+
+    let mut board = Board::from_fen("4k3/8/8/8/8/8/8/4K3 w - - 255 1").unwrap();
+    assert_eq!(board.fiftymove_clock(), 255);
+
+    let mv = board.generate_all_moves().iter().next().unwrap().mv;
+    let _ = board.key_after(mv);
+    board.make_move(mv, &mut NullBoardObserver);
+    assert_eq!(board.fiftymove_clock(), 255);
+    let _ = board.hash();
+}


### PR DESCRIPTION
from_fen reads the halfmove clock into a u8 with no validation, so a FEN can put 255 on the board, and the next quiet move overflows the counter in make_move and inside key_after (panic in debug, wrap in release). A long enough moves list gets there without any FEN help.

Saturate both increments and leave the parsed value alone. The bucket .min(15) already keeps any clock safe for the hash, the draw logic only compares against 100, and rewriting the clock at the parser turned out to be wrong anyway: analysis positions legitimately carry 100-150 and TB probing wants the real value. Adds a regression test.

No functional change.

Bench: 2931707