### PR TITLE
Check the generic and Apple Silicon benches in CI

### DIFF
--- a/.github/workflows/check_bench.yml
+++ b/.github/workflows/check_bench.yml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The x86-64 baseline takes the scalar NNUE path, which the other
-          # rows don't cover. Nehalem also confirms it needs nothing past SSE4.2.
           - name: Generic (x86-64)
             sde_flag: -nhm
             rustflags: "-C target-cpu=x86-64"

--- a/.github/workflows/check_bench.yml
+++ b/.github/workflows/check_bench.yml
@@ -18,6 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The x86-64 baseline takes the scalar NNUE path, which the other
+          # rows don't cover. Nehalem also confirms it needs nothing past SSE4.2.
+          - name: Generic (x86-64)
+            sde_flag: -nhm
+            rustflags: "-C target-cpu=x86-64"
+
           - name: Haswell
             sde_flag: -hsw
             rustflags: "-C target-cpu=haswell"
@@ -70,6 +76,50 @@ jobs:
         env:
           CARGO_TARGET_APPLIES_TO_HOST: false
           RUSTFLAGS: ${{ matrix.rustflags }}
+
+      - name: Check bench
+        shell: bash
+        run: |
+          if [ "$expected_bench" != "$measured_bench" ]; then
+            echo "Bench mismatch"
+            exit 1
+          fi
+
+  # macos runs natively on Apple Silicon, so this covers the neon path that
+  # SDE can't and that release.yml ships. No SDE, no cross-cpu rustflags.
+  check-bench-arm:
+    runs-on: macos-latest
+    name: Check bench on Apple Silicon (neon)
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 10
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Confirm the build targets neon
+        shell: bash
+        run: rustc --print cfg | grep -q 'target_feature="neon"'
+
+      - name: Get expected bench
+        shell: bash
+        run: |
+          messages=$(git log -10 --format=%B)
+          expected_bench=$(grep -m1 -E "^[[:space:]]*[Bb]ench[ :]" <<< "$messages" | grep -Eo "[[:digit:]]+")
+          [[ -n "$expected_bench" ]] || (echo "No Bench Found" && exit 1)
+          echo "expected_bench=$expected_bench" >> $GITHUB_ENV
+          echo "Expected Bench: $expected_bench"
+
+      - name: Get measured bench
+        shell: bash
+        run: |
+          cargo build --release --bin reckless
+          measured_bench=$(./target/release/reckless bench | tail -1 | cut -d " " -f 2)
+          echo "measured_bench=$measured_bench" >> $GITHUB_ENV
+          echo "Measured Bench: $measured_bench"
 
       - name: Check bench
         shell: bash


### PR DESCRIPTION
release.yml ships -generic (target-cpu=x86-64, scalar NNUE path) and macos binaries, but check_bench only ran the avx2 and avx512 cpus under SDE. A scalar or neon regression like the one #1102 fixed would ship in those binaries unnoticed.

Add a generic x86-64 row to the SDE matrix (Nehalem also confirms it needs nothing past SSE4.2), and a macos job for the neon path, which SDE can't emulate. Both benches already match the committed one (the macos value against the existing rust.yml runs) since #1102 made the scalar and simd inference bit-identical. The macos job asserts it's really a neon build first, so it can't quietly turn into a second x86 check if the runner image changes.

No functional change.

Bench: 2931707