### PR TITLE
Simplify away checking for quiet moves in SEE pruning

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -827,7 +827,7 @@ fn search<NODE: NodeType>(
                 (-7 * depth * depth - 36 * depth - 39 * history / 1024 + 14).min(0)
             };
 
-            if (!in_check || !is_quiet) && !td.board.see(mv, threshold) {
+            if !in_check && !td.board.see(mv, threshold) {
                 continue;
             }
         }


### PR DESCRIPTION
STC
Elo   | 6.68 +- 3.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 8326 W: 2158 L: 1998 D: 4170
Penta | [31, 933, 2071, 1101, 27]
https://recklesschess.space/test/15421/

LTC
Elo   | 0.79 +- 1.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 41224 W: 10148 L: 10054 D: 21022
Penta | [18, 4605, 11268, 4707, 14]
https://recklesschess.space/test/15422/

Bench: 2929550