### PR TITLE
Quantize the NNUE tail to integers

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -9,6 +9,7 @@ use std::{
 mod attacks;
 mod magics;
 mod maps;
+mod quantize;
 
 const BASE_URL: &str = "https://github.com/codedeliveryservice/RecklessNetworks/releases/download/networks";
 const NETWORK_NAME: &str = "v60-7f587dfb.nnue";
@@ -24,14 +25,9 @@ fn main() {
         generate_syzygy_binding();
     }
 
-    if !Path::new("networks").join(NETWORK_NAME).exists() && env::var("EVALFILE").is_err() {
-        download_network();
-    }
-
     println!("cargo:rerun-if-env-changed=EVALFILE");
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/logs/HEAD");
-    println!("cargo:rerun-if-changed=networks/{NETWORK_NAME}");
 }
 
 #[cfg(feature = "syzygy")]
@@ -62,7 +58,16 @@ fn generate_model_env() {
         path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
     }
 
-    println!("cargo:rustc-env=MODEL={}", path.display());
+    if !path.exists() && env::var("EVALFILE").is_err() {
+        download_network();
+    }
+
+    // The engine embeds the quantized image verbatim, so convert the f32 tail here.
+    let quantized = Path::new(&env::var("OUT_DIR").unwrap()).join("quantized.nnue");
+    quantize::quantize_model(&path, &quantized);
+
+    println!("cargo:rustc-env=MODEL={}", quantized.display());
+    println!("cargo:rerun-if-changed={}", path.display());
 }
 
 fn generate_attack_maps() {

--- a/build/quantize.rs
+++ b/build/quantize.rs
@@ -1,0 +1,138 @@
+//! Converts the f32 tail of the network into the engine's integer format,
+//! so the engine can embed the result verbatim. Scales must match src/nnue.
+//!
+//! All scales are powers of two, so the rounding is done on the raw f32
+//! bits. This keeps the build script free of float instructions, which
+//! matters when RUSTFLAGS carries a target-cpu the build host lacks.
+
+use std::path::Path;
+
+const L1_SIZE: usize = 768;
+const L2_SIZE: usize = 16;
+const L3_SIZE: usize = 32;
+const INPUT_BUCKETS: usize = 10;
+const OUTPUT_BUCKETS: usize = 8;
+const THREAT_ROWS: usize = 66864;
+
+const TAIL_SHIFT: i64 = 14;
+const TAIL_ACT_SHIFT: i64 = 12;
+const TAIL_ACT_QUANT: i64 = 1 << TAIL_ACT_SHIFT;
+const L1_SHIFT: i64 = 30;
+
+const HEAD_SIZE: usize =
+    THREAT_ROWS * L1_SIZE + INPUT_BUCKETS * 768 * L1_SIZE * 2 + L1_SIZE * 2 + OUTPUT_BUCKETS * L2_SIZE * L1_SIZE;
+
+const INPUT_SIZE: usize = HEAD_SIZE
+    + OUTPUT_BUCKETS * (L2_SIZE + L2_SIZE * L3_SIZE + L3_SIZE + L3_SIZE) * 4
+    + (OUTPUT_BUCKETS * 4).next_multiple_of(64);
+
+// round(value * 2^shift) with ties away from zero, straight from the f32 bits.
+fn quantize(bits: u32, shift: i64) -> i64 {
+    let exponent = (bits >> 23) as i64 & 0xFF;
+    let mantissa = (bits & 0x7F_FFFF) as i64;
+
+    assert!(exponent != 0xFF, "non-finite tail parameter");
+    let (mantissa, exponent) = if exponent == 0 { (mantissa, 1) } else { (mantissa | 0x80_0000, exponent) };
+
+    // value = sign * mantissa * 2^(exponent - 150)
+    let power = exponent - 150 + shift;
+    assert!(mantissa == 0 || power < 39, "tail parameter out of range");
+
+    let magnitude = if power >= 0 {
+        mantissa << power
+    } else if power >= -24 {
+        (mantissa + (1 << (-power - 1))) >> -power
+    } else {
+        0
+    };
+
+    if bits >> 31 != 0 { -magnitude } else { magnitude }
+}
+
+pub fn quantize_model(input: &Path, output: &Path) {
+    let data = std::fs::read(input).unwrap_or_else(|e| panic!("failed to read {}: {e}", input.display()));
+    assert!(data.len() == INPUT_SIZE, "unexpected network size {} (want {INPUT_SIZE})", data.len());
+
+    let mut floats = data[HEAD_SIZE..].chunks_exact(4).map(|c| u32::from_le_bytes(c.try_into().unwrap()));
+    let mut next = move || floats.next().unwrap();
+
+    let l1_biases: Vec<Vec<u32>> = (0..OUTPUT_BUCKETS).map(|_| (0..L2_SIZE).map(|_| next()).collect()).collect();
+    let l2_weights: Vec<Vec<Vec<u32>>> =
+        (0..OUTPUT_BUCKETS).map(|_| (0..L2_SIZE).map(|_| (0..L3_SIZE).map(|_| next()).collect()).collect()).collect();
+    let l2_biases: Vec<Vec<u32>> = (0..OUTPUT_BUCKETS).map(|_| (0..L3_SIZE).map(|_| next()).collect()).collect();
+    let l3_weights: Vec<Vec<u32>> = (0..OUTPUT_BUCKETS).map(|_| (0..L3_SIZE).map(|_| next()).collect()).collect();
+    let l3_biases: Vec<u32> = (0..OUTPUT_BUCKETS).map(|_| next()).collect();
+
+    let weight = |w: &u32| i16::try_from(quantize(*w, TAIL_SHIFT)).expect("tail weight does not fit i16 at TAIL_SHIFT");
+    let bias = |b: &u32| i32::try_from(quantize(*b, TAIL_SHIFT + TAIL_ACT_SHIFT)).expect("tail bias does not fit i32");
+
+    let quantized_l1_biases: Vec<Vec<i64>> = l1_biases
+        .iter()
+        .map(|bucket| bucket.iter().map(|b| quantize(*b, L1_SHIFT + TAIL_ACT_SHIFT)).collect())
+        .collect();
+
+    let mut quantized_l2 = vec![[[0i16; L3_SIZE * 2]; L2_SIZE / 2]; OUTPUT_BUCKETS];
+    for bucket in 0..OUTPUT_BUCKETS {
+        for i in 0..L2_SIZE {
+            for j in 0..L3_SIZE {
+                quantized_l2[bucket][i / 2][2 * j + i % 2] = weight(&l2_weights[bucket][i][j]);
+            }
+        }
+    }
+
+    let quantized_l2_biases: Vec<Vec<i32>> = l2_biases.iter().map(|bucket| bucket.iter().map(bias).collect()).collect();
+    let quantized_l3: Vec<Vec<i16>> = l3_weights.iter().map(|bucket| bucket.iter().map(weight).collect()).collect();
+    let quantized_l3_biases: Vec<i32> = l3_biases.iter().map(bias).collect();
+
+    // The i32 accumulators in the engine must fit the worst case of every activation
+    // saturated (plus the rounding half). Reject nets that break it.
+    let limit = i32::MAX as i64 - (1 << (TAIL_SHIFT - 1));
+
+    for bucket in 0..OUTPUT_BUCKETS {
+        for j in 0..L3_SIZE {
+            let mut bound = (quantized_l2_biases[bucket][j] as i64).abs();
+            for i in 0..L2_SIZE {
+                bound += quantized_l2[bucket][i / 2][2 * j + i % 2].unsigned_abs() as i64 * TAIL_ACT_QUANT;
+            }
+            assert!(bound <= limit, "l2 accumulator can overflow; lower TAIL_SHIFT");
+        }
+
+        let mut bound = (quantized_l3_biases[bucket] as i64).abs();
+        for w in &quantized_l3[bucket] {
+            bound += w.unsigned_abs() as i64 * TAIL_ACT_QUANT;
+        }
+        assert!(bound <= limit, "l3 accumulator can overflow; lower TAIL_SHIFT");
+    }
+
+    let mut image = Vec::with_capacity(INPUT_SIZE);
+    image.extend_from_slice(&data[..HEAD_SIZE]);
+
+    for bucket in &quantized_l1_biases {
+        for b in bucket {
+            image.extend_from_slice(&b.to_le_bytes());
+        }
+    }
+    for bucket in &quantized_l2 {
+        for row in bucket {
+            for w in row {
+                image.extend_from_slice(&w.to_le_bytes());
+            }
+        }
+    }
+    for bucket in &quantized_l2_biases {
+        for b in bucket {
+            image.extend_from_slice(&b.to_le_bytes());
+        }
+    }
+    for bucket in &quantized_l3 {
+        for w in bucket {
+            image.extend_from_slice(&w.to_le_bytes());
+        }
+    }
+    for b in &quantized_l3_biases {
+        image.extend_from_slice(&b.to_le_bytes());
+    }
+    image.resize(image.len().next_multiple_of(64), 0);
+
+    std::fs::write(output, image).unwrap_or_else(|e| panic!("failed to write {}: {e}", output.display()));
+}

--- a/src/nnue.rs
+++ b/src/nnue.rs
@@ -1,4 +1,5 @@
 mod accumulator;
+mod tail;
 
 pub use accumulator::threats::initialize;
 
@@ -96,7 +97,12 @@ const FT_SHIFT: u32 = 9;
 #[cfg(not(target_feature = "avx512f"))]
 const FT_SHIFT: i32 = 9;
 
-const DEQUANT_MULTIPLIER: f32 = (1 << FT_SHIFT) as f32 / (FT_QUANT * FT_QUANT * L1_QUANT) as f32;
+#[cfg(target_feature = "avx512f")]
+const TAIL_SHIFT: u32 = 14;
+#[cfg(not(target_feature = "avx512f"))]
+const TAIL_SHIFT: i32 = 14;
+
+const TAIL_ACT_QUANT: i32 = 1 << 12;
 
 #[rustfmt::skip]
 const INPUT_BUCKETS_LAYOUT: [u8; 64] = [
@@ -292,11 +298,12 @@ impl Network {
                 forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
 
-            let l1_out = forward::propagate_l1(&ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l1_pre = forward::propagate_l1(&ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l1_out = tail::activate_l1(&l1_pre, bucket, parameters);
             let l2_out = forward::propagate_l2(&l1_out, bucket, parameters);
             let l3_out = forward::propagate_l3(&l2_out, bucket, parameters);
 
-            (l3_out * NETWORK_SCALE as f32) as i32
+            tail::scale_output(l3_out)
         }
     }
 
@@ -310,10 +317,11 @@ impl Network {
             let ft_out =
                 forward::activate_ft(&self.pst_stack[self.index], &self.threat_stack[self.index], board.side_to_move());
             let (nnz_indexes, nnz_count) = forward::find_nnz(&ft_out, &self.nnz_table);
-            let l1_out = forward::propagate_l1(&ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l1_pre = forward::propagate_l1(&ft_out, &nnz_indexes[..nnz_count], bucket, parameters);
+            let l1_out = tail::activate_l1(&l1_pre, bucket, parameters);
             let l2_out = forward::propagate_l2(&l1_out, bucket, parameters);
             let l3_out = forward::propagate_l3(&l2_out, bucket, parameters);
-            (l3_out * NETWORK_SCALE as f32) as i32
+            tail::scale_output(l3_out)
         }
     }
 
@@ -353,17 +361,20 @@ impl BoardObserver for Network {
     }
 }
 
+// The tail is quantized by the build script; l2 weights come with the input
+// pairs (2p, 2p + 1) interleaved per output, so the scalar and madd paths
+// both walk them in memory order.
 #[repr(C)]
 pub struct Parameters {
     ft_threat_weights: Aligned<[[i8; L1_SIZE]; 66864]>,
     ft_piece_weights: Aligned<[[i16; L1_SIZE]; INPUT_BUCKETS * 768]>,
     ft_biases: Aligned<[i16; L1_SIZE]>,
     l1_weights: Aligned<[[i8; L2_SIZE * L1_SIZE]; OUTPUT_BUCKETS]>,
-    l1_biases: Aligned<[[f32; L2_SIZE]; OUTPUT_BUCKETS]>,
-    l2_weights: Aligned<[[[f32; L3_SIZE]; L2_SIZE]; OUTPUT_BUCKETS]>,
-    l2_biases: Aligned<[[f32; L3_SIZE]; OUTPUT_BUCKETS]>,
-    l3_weights: Aligned<[[f32; L3_SIZE]; OUTPUT_BUCKETS]>,
-    l3_biases: Aligned<[f32; OUTPUT_BUCKETS]>,
+    l1_biases: Aligned<[[i64; L2_SIZE]; OUTPUT_BUCKETS]>,
+    l2_weights: Aligned<[[[i16; L3_SIZE * 2]; L2_SIZE / 2]; OUTPUT_BUCKETS]>,
+    l2_biases: Aligned<[[i32; L3_SIZE]; OUTPUT_BUCKETS]>,
+    l3_weights: Aligned<[[i16; L3_SIZE]; OUTPUT_BUCKETS]>,
+    l3_biases: Aligned<[i32; OUTPUT_BUCKETS]>,
 }
 
 impl Parameters {

--- a/src/nnue/forward/scalar.rs
+++ b/src/nnue/forward/scalar.rs
@@ -1,6 +1,6 @@
 use crate::{
     nnue::{
-        Aligned, DEQUANT_MULTIPLIER, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, Parameters, SparseEntry,
+        Aligned, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, Parameters, SparseEntry, TAIL_ACT_QUANT, TAIL_SHIFT,
         accumulator::{PstAccumulator, ThreatAccumulator},
     },
     types::Color,
@@ -26,10 +26,10 @@ pub fn activate_ft(pst: &PstAccumulator, threat: &ThreatAccumulator, stm: Color)
 
 pub unsafe fn propagate_l1(
     ft_out: &Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
-) -> Aligned<[f32; L2_SIZE]> {
+) -> Aligned<[i32; L2_SIZE]> {
     const CHUNKS: usize = 4;
 
-    let mut pre_activations = [0i32; L2_SIZE];
+    let mut pre_activations = Aligned::new([0i32; L2_SIZE]);
 
     let packed = std::slice::from_raw_parts(ft_out.as_ptr() as *const i32, L1_SIZE / CHUNKS);
 
@@ -52,59 +52,42 @@ pub unsafe fn propagate_l1(
         }
     }
 
-    let mut output = Aligned::new([0.0; L2_SIZE]);
-
-    for i in 0..L2_SIZE {
-        // Starting from here, we move into float space, so order of operations is critical for staying semantically
-        // identical to the vectorized inference. In particular, using FMA instead of separate mul+add matters here and below.
-        output[i] =
-            (pre_activations[i] as f32).mul_add(DEQUANT_MULTIPLIER, parameters.l1_biases[bucket][i]).clamp(0.0, 1.0);
-    }
-
-    output
+    pre_activations
 }
 
 pub fn propagate_l2(
-    l1_out: &Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
-) -> Aligned<[f32; L3_SIZE]> {
-    // Note: It is important that we initialize the accumulator to the biases, and don't add the biases
-    // afterward, to preserve the same order of operations as the vector implementation.
-    let mut output = Aligned::new(parameters.l2_biases[bucket]);
+    l1_out: &Aligned<[i16; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+) -> Aligned<[i16; L3_SIZE]> {
+    let mut accumulators = parameters.l2_biases[bucket];
 
-    for i in 0..L2_SIZE {
+    for p in 0..L2_SIZE / 2 {
+        let a = l1_out[2 * p] as i32;
+        let b = l1_out[2 * p + 1] as i32;
+        let row = &parameters.l2_weights[bucket][p];
+
         for j in 0..L3_SIZE {
-            output[j] = parameters.l2_weights[bucket][i][j].mul_add(l1_out[i], output[j]);
+            accumulators[j] += a * row[2 * j] as i32 + b * row[2 * j + 1] as i32;
         }
     }
 
-    for i in 0..L3_SIZE {
-        output[i] = output[i].clamp(0.0, 1.0);
+    let mut output = Aligned::new([0; L3_SIZE]);
+
+    for j in 0..L3_SIZE {
+        let activation = (accumulators[j] + (1 << (TAIL_SHIFT - 1))) >> TAIL_SHIFT;
+        output[j] = activation.clamp(0, TAIL_ACT_QUANT) as i16;
     }
+
     output
 }
 
-pub fn propagate_l3(l2_out: &Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
-    // For cross platform compatibility, we always sum-reduce into a 16-element "vector", and then horizontally reduce that.
-    const LANES: usize = 16;
+pub fn propagate_l3(l2_out: &Aligned<[i16; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> i32 {
+    let mut accumulator = 0;
 
-    let mut sums = [0.0; LANES];
-    for i in (0..L3_SIZE).step_by(LANES) {
-        for j in 0..LANES {
-            sums[j] = parameters.l3_weights[bucket][i + j].mul_add(l2_out[i + j], sums[j]);
-        }
+    for i in 0..L3_SIZE {
+        accumulator += l2_out[i] as i32 * parameters.l3_weights[bucket][i] as i32;
     }
 
-    // We do the horizontal reduction via recursive halving, as that's what `_mm512_reduce_add_ps` does. Any other SIMD
-    // implementation (e.g. NEON) must ensure the same order of operations.
-    let mut stride = LANES / 2;
-    while stride > 0 {
-        for i in 0..stride {
-            sums[i] += sums[i + stride];
-        }
-        stride /= 2;
-    }
-
-    sums[0] + parameters.l3_biases[bucket]
+    accumulator + parameters.l3_biases[bucket]
 }
 
 pub unsafe fn find_nnz(ft_out: &Aligned<[u8; L1_SIZE]>, _: &[SparseEntry]) -> (Aligned<[u16; L1_SIZE / 4]>, usize) {

--- a/src/nnue/forward/vectorized.rs
+++ b/src/nnue/forward/vectorized.rs
@@ -1,6 +1,6 @@
 use crate::{
     nnue::{
-        Aligned, DEQUANT_MULTIPLIER, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, Parameters, SparseEntry,
+        Aligned, FT_QUANT, FT_SHIFT, L1_SIZE, L2_SIZE, L3_SIZE, Parameters, SparseEntry, TAIL_ACT_QUANT, TAIL_SHIFT,
         accumulator::{PstAccumulator, ThreatAccumulator},
         simd,
     },
@@ -54,10 +54,10 @@ pub unsafe fn activate_ft(pst: &PstAccumulator, threat: &ThreatAccumulator, stm:
 
 pub unsafe fn propagate_l1(
     ft_out: &Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
-) -> Aligned<[f32; L2_SIZE]> {
+) -> Aligned<[i32; L2_SIZE]> {
     const CHUNKS: usize = 4;
 
-    let mut pre_activations = Aligned::new([simd::zeroed(); L2_SIZE / simd::F32_LANES]);
+    let mut pre_activations = Aligned::new([simd::zeroed(); L2_SIZE / simd::I32_LANES]);
 
     let packed = std::slice::from_raw_parts(ft_out.as_ptr().cast::<i32>(), L1_SIZE / CHUNKS);
 
@@ -73,11 +73,11 @@ pub unsafe fn propagate_l1(
         let weights1 = parameters.l1_weights[bucket].as_ptr().add(index1 * L2_SIZE * CHUNKS);
         let weights2 = parameters.l1_weights[bucket].as_ptr().add(index2 * L2_SIZE * CHUNKS);
 
-        for j in (0..L2_SIZE).step_by(simd::F32_LANES) {
+        for j in (0..L2_SIZE).step_by(simd::I32_LANES) {
             let weights1 = *weights1.add(j * CHUNKS).cast();
             let weights2 = *weights2.add(j * CHUNKS).cast();
 
-            let vector = &mut pre_activations[j / simd::F32_LANES];
+            let vector = &mut pre_activations[j / simd::I32_LANES];
             *vector = simd::double_dpbusd(*vector, input1, weights1, input2, weights2);
         }
     }
@@ -87,73 +87,72 @@ pub unsafe fn propagate_l1(
         let input = simd::splat_i32(*packed.get_unchecked(index));
         let weights = parameters.l1_weights[bucket].as_ptr().add(index * L2_SIZE * CHUNKS);
 
-        for j in (0..L2_SIZE).step_by(simd::F32_LANES) {
+        for j in (0..L2_SIZE).step_by(simd::I32_LANES) {
             let weights = *weights.add(j * CHUNKS).cast();
-            let vector = &mut pre_activations[j / simd::F32_LANES];
+            let vector = &mut pre_activations[j / simd::I32_LANES];
             *vector = simd::dpbusd(*vector, input, weights);
         }
     }
 
-    let mut output = Aligned::new([0.0; L2_SIZE]);
+    let mut output = Aligned::new([0i32; L2_SIZE]);
 
-    let zero = simd::zero_f32();
-    let one = simd::splat_f32(1.0);
-    let dequant = simd::splat_f32(DEQUANT_MULTIPLIER);
-
-    for i in (0..L2_SIZE).step_by(simd::F32_LANES) {
-        let biases = *parameters.l1_biases[bucket].as_ptr().add(i).cast();
-        let vector = simd::mul_add_f32(simd::convert_to_f32(pre_activations[i / simd::F32_LANES]), dequant, biases);
-        *output.as_mut_ptr().add(i).cast() = simd::clamp_f32(vector, zero, one);
+    for i in (0..L2_SIZE).step_by(simd::I32_LANES) {
+        *output.as_mut_ptr().add(i).cast() = pre_activations[i / simd::I32_LANES];
     }
 
     output
 }
 
 pub unsafe fn propagate_l2(
-    l1_out: &Aligned<[f32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
-) -> Aligned<[f32; L3_SIZE]> {
-    let mut output = Aligned::new(parameters.l2_biases[bucket]);
+    l1_out: &Aligned<[i16; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+) -> Aligned<[i16; L3_SIZE]> {
+    const ACCUMULATORS: usize = L3_SIZE / simd::I32_LANES;
 
-    for i in 0..L2_SIZE {
-        let input = simd::splat_f32(l1_out[i]);
-        let weights = parameters.l2_weights[bucket][i].as_ptr();
+    let pairs = std::slice::from_raw_parts(l1_out.as_ptr().cast::<i32>(), L2_SIZE / 2);
 
-        for j in (0..L3_SIZE).step_by(simd::F32_LANES) {
-            let weights = *weights.add(j).cast();
-            let vector = output.as_mut_ptr().add(j).cast();
-            *vector = simd::mul_add_f32(weights, input, *vector);
+    let mut accumulators = [simd::zeroed(); ACCUMULATORS];
+    for (k, accumulator) in accumulators.iter_mut().enumerate() {
+        *accumulator = *parameters.l2_biases[bucket].as_ptr().add(k * simd::I32_LANES).cast();
+    }
+
+    for p in 0..L2_SIZE / 2 {
+        let input = simd::splat_i32(*pairs.get_unchecked(p));
+        let row = parameters.l2_weights[bucket][p].as_ptr();
+
+        for (k, accumulator) in accumulators.iter_mut().enumerate() {
+            let weights = *row.add(k * simd::I16_LANES).cast();
+            *accumulator = simd::add_i32(*accumulator, simd::madd_i16(input, weights));
         }
     }
 
-    let zero = simd::zero_f32();
-    let one = simd::splat_f32(1.0);
+    let mut output = Aligned::new([0; L3_SIZE]);
 
-    for i in (0..L3_SIZE).step_by(simd::F32_LANES) {
-        let vector = output.as_mut_ptr().add(i).cast();
-        *vector = simd::clamp_f32(*vector, zero, one);
+    let zero = simd::splat_i32(0);
+    let one = simd::splat_i32(TAIL_ACT_QUANT);
+    let half = simd::splat_i32(1 << (TAIL_SHIFT - 1));
+
+    for k in (0..ACCUMULATORS).step_by(2) {
+        let a = simd::shift_right_i32::<{ TAIL_SHIFT }>(simd::add_i32(accumulators[k], half));
+        let b = simd::shift_right_i32::<{ TAIL_SHIFT }>(simd::add_i32(accumulators[k + 1], half));
+
+        let packed = simd::pack_i32(simd::clamp_i32(a, zero, one), simd::clamp_i32(b, zero, one));
+        *output.as_mut_ptr().add(k * simd::I32_LANES).cast() = packed;
     }
 
     output
 }
 
-pub unsafe fn propagate_l3(l2_out: &Aligned<[f32; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> f32 {
-    const LANES: usize = 16 / simd::F32_LANES;
+pub unsafe fn propagate_l3(l2_out: &Aligned<[i16; L3_SIZE]>, bucket: usize, parameters: &Parameters) -> i32 {
+    let mut accumulator = simd::zeroed();
 
-    let input = l2_out.as_ptr();
-    let weights = parameters.l3_weights[bucket].as_ptr();
+    for i in (0..L3_SIZE).step_by(simd::I16_LANES) {
+        let input = *l2_out.as_ptr().add(i).cast();
+        let weights = *parameters.l3_weights[bucket].as_ptr().add(i).cast();
 
-    let mut output = [simd::zero_f32(); LANES];
-
-    for (lane, result) in output.iter_mut().enumerate() {
-        for i in (0..L3_SIZE).step_by(LANES * simd::F32_LANES) {
-            let a = *weights.add(i + lane * simd::F32_LANES).cast();
-            let b = *input.add(i + lane * simd::F32_LANES).cast();
-
-            *result = simd::mul_add_f32(a, b, *result);
-        }
+        accumulator = simd::add_i32(accumulator, simd::madd_i16(input, weights));
     }
 
-    simd::horizontal_sum(output) + parameters.l3_biases[bucket]
+    simd::horizontal_sum_i32(accumulator) + parameters.l3_biases[bucket]
 }
 
 #[cfg(all(not(target_arch = "wasm32"), not(target_feature = "neon"), not(target_feature = "avx512vbmi2")))]

--- a/src/nnue/simd/avx2.rs
+++ b/src/nnue/simd/avx2.rs
@@ -1,6 +1,5 @@
 use std::{arch::x86_64::*, mem::size_of};
 
-pub const F32_LANES: usize = size_of::<__m256>() / size_of::<f32>();
 pub const I32_LANES: usize = size_of::<__m256i>() / size_of::<i32>();
 pub const I16_LANES: usize = size_of::<__m256i>() / size_of::<i16>();
 pub const MUL_HI_SHIFT: i32 = 0;
@@ -53,24 +52,31 @@ pub unsafe fn splat_i32(a: i32) -> __m256i {
     _mm256_set1_epi32(a)
 }
 
-pub unsafe fn zero_f32() -> __m256 {
-    _mm256_setzero_ps()
+pub unsafe fn madd_i16(a: __m256i, b: __m256i) -> __m256i {
+    _mm256_madd_epi16(a, b)
 }
 
-pub unsafe fn splat_f32(a: f32) -> __m256 {
-    _mm256_set1_ps(a)
+pub unsafe fn add_i32(a: __m256i, b: __m256i) -> __m256i {
+    _mm256_add_epi32(a, b)
 }
 
-pub unsafe fn mul_add_f32(a: __m256, b: __m256, c: __m256) -> __m256 {
-    _mm256_fmadd_ps(a, b, c)
+pub unsafe fn shift_right_i32<const SHIFT: i32>(a: __m256i) -> __m256i {
+    _mm256_srai_epi32::<SHIFT>(a)
 }
 
-pub unsafe fn convert_to_f32(a: __m256i) -> __m256 {
-    _mm256_cvtepi32_ps(a)
+pub unsafe fn clamp_i32(x: __m256i, min: __m256i, max: __m256i) -> __m256i {
+    _mm256_max_epi32(_mm256_min_epi32(x, max), min)
 }
 
-pub unsafe fn clamp_f32(x: __m256, min: __m256, max: __m256) -> __m256 {
-    _mm256_max_ps(_mm256_min_ps(x, max), min)
+pub unsafe fn pack_i32(a: __m256i, b: __m256i) -> __m256i {
+    permute(_mm256_packs_epi32(a, b))
+}
+
+pub unsafe fn horizontal_sum_i32(x: __m256i) -> i32 {
+    let sum128 = _mm_add_epi32(_mm256_castsi256_si128(x), _mm256_extracti128_si256::<1>(x));
+    let sum64 = _mm_add_epi32(sum128, _mm_unpackhi_epi64(sum128, sum128));
+    let sum32 = _mm_add_epi32(sum64, _mm_shuffle_epi32::<1>(sum64));
+    _mm_cvtsi128_si32(sum32)
 }
 
 pub unsafe fn dpbusd(i32s: __m256i, u8s: __m256i, i8s: __m256i) -> __m256i {
@@ -84,22 +90,6 @@ pub unsafe fn double_dpbusd(i32s: __m256i, u8s1: __m256i, i8s1: __m256i, u8s2: _
     let pairwise2 = _mm256_maddubs_epi16(u8s2, i8s2);
     let widened = _mm256_madd_epi16(_mm256_add_epi16(pairwise1, pairwise2), _mm256_set1_epi16(1));
     _mm256_add_epi32(i32s, widened)
-}
-
-pub unsafe fn horizontal_sum(x: [__m256; 2]) -> f32 {
-    let vec = _mm256_add_ps(x[0], x[1]);
-
-    let hi128 = _mm256_extractf128_ps::<1>(vec);
-    let lo128 = _mm256_castps256_ps128(vec);
-    let sum128 = _mm_add_ps(lo128, hi128);
-
-    let hi64 = _mm_movehl_ps(sum128, sum128);
-    let sum64 = _mm_add_ps(sum128, hi64);
-
-    let hi32 = _mm_shuffle_ps::<1>(sum64, sum64);
-    let sum32 = _mm_add_ss(sum64, hi32);
-
-    _mm_cvtss_f32(sum32)
 }
 
 pub unsafe fn nnz_bitmask(x: __m256i) -> u16 {

--- a/src/nnue/simd/avx512.rs
+++ b/src/nnue/simd/avx512.rs
@@ -1,8 +1,6 @@
 use std::{arch::x86_64::*, mem::size_of};
 
-pub const F32_LANES: usize = size_of::<__m512>() / size_of::<f32>();
 pub const I16_LANES: usize = size_of::<__m512i>() / size_of::<i16>();
-#[allow(unused)]
 pub const I32_LANES: usize = size_of::<__m512i>() / size_of::<i32>();
 pub const MUL_HI_SHIFT: u32 = 0;
 
@@ -54,24 +52,28 @@ pub unsafe fn splat_i32(a: i32) -> __m512i {
     _mm512_set1_epi32(a)
 }
 
-pub unsafe fn zero_f32() -> __m512 {
-    _mm512_setzero_ps()
+pub unsafe fn madd_i16(a: __m512i, b: __m512i) -> __m512i {
+    _mm512_madd_epi16(a, b)
 }
 
-pub unsafe fn splat_f32(a: f32) -> __m512 {
-    _mm512_set1_ps(a)
+pub unsafe fn add_i32(a: __m512i, b: __m512i) -> __m512i {
+    _mm512_add_epi32(a, b)
 }
 
-pub unsafe fn mul_add_f32(a: __m512, b: __m512, c: __m512) -> __m512 {
-    _mm512_fmadd_ps(a, b, c)
+pub unsafe fn shift_right_i32<const SHIFT: u32>(a: __m512i) -> __m512i {
+    _mm512_srai_epi32::<SHIFT>(a)
 }
 
-pub unsafe fn convert_to_f32(a: __m512i) -> __m512 {
-    _mm512_cvtepi32_ps(a)
+pub unsafe fn clamp_i32(x: __m512i, min: __m512i, max: __m512i) -> __m512i {
+    _mm512_max_epi32(_mm512_min_epi32(x, max), min)
 }
 
-pub unsafe fn clamp_f32(x: __m512, min: __m512, max: __m512) -> __m512 {
-    _mm512_max_ps(_mm512_min_ps(x, max), min)
+pub unsafe fn pack_i32(a: __m512i, b: __m512i) -> __m512i {
+    permute(_mm512_packs_epi32(a, b))
+}
+
+pub unsafe fn horizontal_sum_i32(x: __m512i) -> i32 {
+    _mm512_reduce_add_epi32(x)
 }
 
 #[cfg(target_feature = "avx512vnni")]
@@ -97,10 +99,6 @@ pub unsafe fn double_dpbusd(i32s: __m512i, u8s1: __m512i, i8s1: __m512i, u8s2: _
     let pairwise2 = _mm512_maddubs_epi16(u8s2, i8s2);
     let widened = _mm512_madd_epi16(_mm512_add_epi16(pairwise1, pairwise2), _mm512_set1_epi16(1));
     _mm512_add_epi32(i32s, widened)
-}
-
-pub unsafe fn horizontal_sum(x: [__m512; 1]) -> f32 {
-    _mm512_reduce_add_ps(x[0])
 }
 
 pub unsafe fn nnz_bitmask(x: __m512i) -> u16 {

--- a/src/nnue/simd/neon.rs
+++ b/src/nnue/simd/neon.rs
@@ -1,6 +1,6 @@
 use std::{arch::aarch64::*, mem::size_of};
 
-pub const F32_LANES: usize = size_of::<float32x4_t>() / size_of::<f32>();
+pub const I32_LANES: usize = size_of::<int32x4_t>() / size_of::<i32>();
 pub const I16_LANES: usize = size_of::<int16x8_t>() / size_of::<i16>();
 pub const MUL_HI_SHIFT: i32 = 1;
 
@@ -55,24 +55,32 @@ pub unsafe fn splat_i32(a: i32) -> int32x4_t {
     vdupq_n_s32(a)
 }
 
-pub unsafe fn zero_f32() -> float32x4_t {
-    vdupq_n_f32(0.0)
+pub unsafe fn madd_i16(a: int32x4_t, b: int16x8_t) -> int32x4_t {
+    let a = vreinterpretq_s16_s32(a);
+
+    let low = vmull_s16(vget_low_s16(a), vget_low_s16(b));
+    let high = vmull_high_s16(a, b);
+    vpaddq_s32(low, high)
 }
 
-pub unsafe fn splat_f32(a: f32) -> float32x4_t {
-    vdupq_n_f32(a)
+pub unsafe fn add_i32(a: int32x4_t, b: int32x4_t) -> int32x4_t {
+    vaddq_s32(a, b)
 }
 
-pub unsafe fn mul_add_f32(a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
-    vfmaq_f32(c, a, b)
+pub unsafe fn shift_right_i32<const SHIFT: i32>(a: int32x4_t) -> int32x4_t {
+    vshrq_n_s32::<SHIFT>(a)
 }
 
-pub unsafe fn convert_to_f32(a: int32x4_t) -> float32x4_t {
-    vcvtq_f32_s32(a)
+pub unsafe fn clamp_i32(x: int32x4_t, min: int32x4_t, max: int32x4_t) -> int32x4_t {
+    vmaxq_s32(vminq_s32(x, max), min)
 }
 
-pub unsafe fn clamp_f32(x: float32x4_t, min: float32x4_t, max: float32x4_t) -> float32x4_t {
-    vmaxq_f32(vminq_f32(x, max), min)
+pub unsafe fn pack_i32(a: int32x4_t, b: int32x4_t) -> int16x8_t {
+    vcombine_s16(vqmovn_s32(a), vqmovn_s32(b))
+}
+
+pub unsafe fn horizontal_sum_i32(x: int32x4_t) -> i32 {
+    vaddvq_s32(x)
 }
 
 #[allow(unused)]
@@ -111,18 +119,6 @@ pub unsafe fn double_dpbusd(
     i32s: int32x4_t, u8s1: int32x4_t, i8s1: int8x16_t, u8s2: int32x4_t, i8s2: int8x16_t,
 ) -> int32x4_t {
     dpbusd(dpbusd(i32s, u8s1, i8s1), u8s2, i8s2)
-}
-
-pub unsafe fn horizontal_sum(x: [float32x4_t; 4]) -> f32 {
-    // The reduction order is important to prevent rounding differences
-    // with the AVX2/512 implementations
-    let sum02 = vaddq_f32(x[0], x[2]);
-    let sum13 = vaddq_f32(x[1], x[3]);
-    let sum = vaddq_f32(sum02, sum13);
-
-    let pair = vadd_f32(vget_low_f32(sum), vget_high_f32(sum));
-
-    vget_lane_f32::<0>(pair) + vget_lane_f32::<1>(pair)
 }
 
 pub unsafe fn nnz_bitmask(x: int32x4_t) -> u16 {

--- a/src/nnue/simd/wasm.rs
+++ b/src/nnue/simd/wasm.rs
@@ -1,6 +1,5 @@
 use std::{arch::wasm32::*, mem::size_of};
 
-pub const F32_LANES: usize = size_of::<v128>() / size_of::<f32>();
 pub const I32_LANES: usize = size_of::<v128>() / size_of::<i32>();
 pub const I16_LANES: usize = size_of::<v128>() / size_of::<i16>();
 pub const MUL_HI_SHIFT: i32 = 0;
@@ -55,30 +54,28 @@ pub unsafe fn splat_i32(a: i32) -> v128 {
     i32x4_splat(a)
 }
 
-pub unsafe fn zero_f32() -> v128 {
-    f32x4_splat(0.0)
+pub unsafe fn madd_i16(a: v128, b: v128) -> v128 {
+    i32x4_dot_i16x8(a, b)
 }
 
-pub unsafe fn splat_f32(a: f32) -> v128 {
-    f32x4_splat(a)
+pub unsafe fn add_i32(a: v128, b: v128) -> v128 {
+    i32x4_add(a, b)
 }
 
-pub unsafe fn mul_add_f32(a: v128, b: v128, c: v128) -> v128 {
-    #[cfg(target_feature = "relaxed-simd")]
-    return f32x4_relaxed_madd(a, b, c);
-    #[cfg(not(target_feature = "relaxed-simd"))]
-    return f32x4_add(f32x4_mul(a, b), c);
+pub unsafe fn shift_right_i32<const SHIFT: i32>(a: v128) -> v128 {
+    i32x4_shr(a, SHIFT as u32)
 }
 
-pub unsafe fn convert_to_f32(a: v128) -> v128 {
-    f32x4_convert_i32x4(a)
+pub unsafe fn clamp_i32(x: v128, min: v128, max: v128) -> v128 {
+    i32x4_max(i32x4_min(x, max), min)
 }
 
-pub unsafe fn clamp_f32(x: v128, min: v128, max: v128) -> v128 {
-    #[cfg(target_feature = "relaxed-simd")]
-    return f32x4_relaxed_max(f32x4_relaxed_min(x, max), min);
-    #[cfg(not(target_feature = "relaxed-simd"))]
-    return f32x4_max(f32x4_min(x, max), min);
+pub unsafe fn pack_i32(a: v128, b: v128) -> v128 {
+    i16x8_narrow_i32x4(a, b)
+}
+
+pub unsafe fn horizontal_sum_i32(x: v128) -> i32 {
+    i32x4_extract_lane::<0>(x) + i32x4_extract_lane::<1>(x) + i32x4_extract_lane::<2>(x) + i32x4_extract_lane::<3>(x)
 }
 
 pub unsafe fn dpbusd(i32s: v128, u8s: v128, i8s: v128) -> v128 {
@@ -109,15 +106,6 @@ pub unsafe fn double_dpbusd(i32s: v128, u8s1: v128, i8s1: v128, u8s2: v128, i8s2
         let odd = i8x16_shuffle::<4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31>(sum_lo, sum_hi);
         i32x4_add(i32s, i32x4_add(even, odd))
     }
-}
-
-pub unsafe fn horizontal_sum(x: [v128; 4]) -> f32 {
-    let sum02 = f32x4_add(x[0], x[2]);
-    let sum13 = f32x4_add(x[1], x[3]);
-    let sum = f32x4_add(sum02, sum13);
-    let rotated = i8x16_shuffle::<8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7>(sum, sum);
-    let sum2 = f32x4_add(sum, rotated);
-    f32x4_extract_lane::<0>(sum2) + f32x4_extract_lane::<1>(sum2)
 }
 
 pub unsafe fn nnz_bitmask(x: v128) -> u16 {

--- a/src/nnue/tail.rs
+++ b/src/nnue/tail.rs
@@ -1,0 +1,32 @@
+use crate::nnue::{
+    Aligned, FT_QUANT, FT_SHIFT, L1_QUANT, L2_SIZE, NETWORK_SCALE, Parameters, TAIL_ACT_QUANT, TAIL_SHIFT,
+};
+
+const DEQUANT_DIVISOR: i64 = (FT_QUANT * FT_QUANT * L1_QUANT) as i64;
+const OUTPUT_DIVISOR: i64 = (TAIL_ACT_QUANT as i64) << TAIL_SHIFT;
+
+const L1_SHIFT: i64 = 30;
+const L1_MULTIPLIER: i64 =
+    ((1 << (L1_SHIFT + FT_SHIFT as i64)) * TAIL_ACT_QUANT as i64 + DEQUANT_DIVISOR / 2) / DEQUANT_DIVISOR;
+
+#[inline]
+pub fn activate_l1(
+    pre_activations: &Aligned<[i32; L2_SIZE]>, bucket: usize, parameters: &Parameters,
+) -> Aligned<[i16; L2_SIZE]> {
+    let mut output = Aligned::new([0; L2_SIZE]);
+
+    for i in 0..L2_SIZE {
+        let raw = pre_activations[i] as i64 * L1_MULTIPLIER + parameters.l1_biases[bucket][i];
+        let activation = (raw + (1 << (L1_SHIFT - 1))) >> L1_SHIFT;
+
+        output[i] = activation.clamp(0, TAIL_ACT_QUANT as i64) as i16;
+    }
+
+    output
+}
+
+#[inline]
+pub fn scale_output(l3_out: i32) -> i32 {
+    // Truncates toward zero, like the `as i32` cast the f32 tail used.
+    (l3_out as i64 * NETWORK_SCALE as i64 / OUTPUT_DIVISOR) as i32
+}


### PR DESCRIPTION
Quantizes the f32 L2/L3 tail to integers when the net is embedded at build time (i16 weights, i32 accumulation), so the engine consumes the converted image verbatim and all backends produce the same eval by construction, wasm included. Evals move by at most 1 unit (~0.3 cp) on the bench positions, so this needs a non-regression run.