### PR TITLE
Fix adjusting NMP bound with TT score

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -610,19 +610,19 @@ fn search<NODE: NodeType>(
         }
 
         if score >= bound && !is_win(score) {
-            if td.nmp_min_ply > 0 || depth < 16 {
+            if (td.nmp_min_ply > 0 || depth < 16) && score >= beta {
                 return score;
             }
 
             td.nmp_min_ply = ply as i32 + 3 * (depth - r) / 4;
-            let verified_score = search::<NonPV>(td, bound - 1, bound, depth - r, false, ply);
+            let verified_score = search::<NonPV>(td, beta - 1, beta, depth - r, false, ply);
             td.nmp_min_ply = 0;
 
             if td.shared.status.get() == Status::STOPPED {
                 return Score::ZERO;
             }
 
-            if verified_score >= bound {
+            if verified_score >= beta {
                 return score;
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -595,7 +595,7 @@ fn search<NODE: NodeType>(
         td.board.make_null_move();
         td.shared.tt.prefetch(td.board.hash());
 
-        let bound = if is_valid(tt_score) && beta > tt_score && tt_bound == Bound::Upper && depth - 2 <= tt_depth {
+        let bound = if is_valid(tt_score) && beta > tt_score && tt_bound == Bound::Lower && depth - 2 <= tt_depth {
             tt_score
         } else {
             beta

--- a/src/search.rs
+++ b/src/search.rs
@@ -595,7 +595,7 @@ fn search<NODE: NodeType>(
         td.board.make_null_move();
         td.shared.tt.prefetch(td.board.hash());
 
-        let bound = if is_valid(tt_score) && beta > tt_score && tt_bound == Bound::Lower && depth - 2 <= tt_depth {
+        let bound = if is_valid(tt_score) && beta > tt_score && tt_bound == Bound::Upper && depth - 2 <= tt_depth {
             tt_score
         } else {
             beta
@@ -614,8 +614,10 @@ fn search<NODE: NodeType>(
                 return score;
             }
 
-            td.nmp_min_ply = ply as i32 + 3 * (depth - r) / 4;
-            let verified_score = search::<NonPV>(td, beta - 1, beta, depth - r, false, ply);
+            let reduced_depth = if score < beta { depth / 2 } else { depth - r };
+
+            td.nmp_min_ply = ply as i32 + 3 * reduced_depth / 4;
+            let verified_score = search::<NonPV>(td, beta - 1, beta, reduced_depth, false, ply);
             td.nmp_min_ply = 0;
 
             if td.shared.status.get() == Status::STOPPED {


### PR DESCRIPTION
Fix a correctness issue in #1031 where lower bound scores were being returned like upper bound scores, noted by @cj5716.

We fix this by doing an unconditional reduced verification search when `tt_score <= score < beta`. This is instead of just returning score; we avoid returning scores that are in this range to ensure correctness.

STC non-reg
Elo   | 0.36 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 58926 W: 14777 L: 14716 D: 29433
Penta | [164, 6346, 16382, 6407, 164]
https://recklesschess.space/test/15439/

LTC non-reg
Elo   | 2.47 +- 2.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.93 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 17986 W: 4471 L: 4343 D: 9172
Penta | [8, 1866, 5115, 1998, 6]
https://recklesschess.space/test/15440/

Bench: 2691895