### PR TITLE
Captures that win material are always considered good

### DIFF
--- a/src/movepick.rs
+++ b/src/movepick.rs
@@ -61,8 +61,10 @@ impl MovePicker {
         if self.stage == Stage::GoodNoisy {
             while !self.list.is_empty() {
                 let entry = self.get_best_entry();
-                let threshold = self.threshold.unwrap_or_else(|| -entry.score / 47 + 116);
-                if (self.tt_move.is_quiet() && self.noisy_count > 2) || !td.board.see(entry.mv, threshold) {
+                let threshold = self.threshold.unwrap_or_else(|| {
+                    if self.tt_move.is_quiet() && self.noisy_count > 2 { 1 } else { -entry.score / 47 + 116 }
+                });
+                if !td.board.see(entry.mv, threshold) {
                     self.bad_noisy.push(entry.mv);
                     continue;
                 }


### PR DESCRIPTION
Elo   | 1.46 +- 1.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 84552 W: 21432 L: 21077 D: 42043
Penta | [264, 9592, 22249, 9867, 304]
https://recklesschess.space/test/15441/

Elo   | 1.92 +- 1.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 3.00]
Games | N: 47808 W: 11843 L: 11579 D: 24386
Penta | [18, 5211, 13183, 5473, 19]
https://recklesschess.space/test/15448/

Bench 2338009