### PR TITLE
Shrink initial aspiration window if our search has been stable

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -95,7 +95,7 @@ pub fn start(td: &mut ThreadData, report: Report, thread_count: usize) {
             rm.previous_score = rm.score;
         }
 
-        let mut delta = 23;
+        let mut delta = 23 - eval_stability.min(pv_stability).min(7);
         let mut reduction = 0;
 
         for index in 0..td.multi_pv {


### PR DESCRIPTION
Elo   | 4.58 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16856 W: 4371 L: 4149 D: 8336
Penta | [70, 1947, 4206, 2101, 104]
https://recklesschess.space/test/15456/

Elo   | 2.08 +- 1.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 42662 W: 10627 L: 10372 D: 21663
Penta | [23, 4740, 11556, 4983, 29]
https://recklesschess.space/test/15457/

Bench 2669518