### PR TITLE
Use flat array for root move pv storage

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1005,7 +1005,7 @@ fn search<NODE: NodeType>(
 
                 root_move.score = score;
                 root_move.sel_depth = td.sel_depth;
-                root_move.pv.commit_full_root_pv(&td.pv_table, 1);
+                root_move.pv.commit_from_pv(&td.pv_table, 1);
 
                 if move_count > 1 && td.pv_index == 0 {
                     td.best_move_changes += 1;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -393,7 +393,7 @@ pub struct RootMove {
     pub lowerbound: bool,
     pub sel_depth: i32,
     pub nodes: u64,
-    pub pv: PrincipalVariationTable,
+    pub pv: RootPV,
     pub tb_rank: i32,
     pub tb_score: i32,
 }
@@ -409,7 +409,7 @@ impl Default for RootMove {
             lowerbound: false,
             sel_depth: 0,
             nodes: 0,
-            pv: PrincipalVariationTable::default(),
+            pv: RootPV::default(),
             tb_rank: 0,
             tb_score: 0,
         }
@@ -423,10 +423,6 @@ pub struct PrincipalVariationTable {
 }
 
 impl PrincipalVariationTable {
-    pub fn line(&self) -> &[Move] {
-        &self.table[0][..self.len[0]]
-    }
-
     pub const fn clear(&mut self, ply: usize) {
         self.len[ply] = 0;
     }
@@ -439,12 +435,6 @@ impl PrincipalVariationTable {
             self.table[ply][i + 1] = self.table[ply + 1][i];
         }
     }
-
-    pub fn commit_full_root_pv(&mut self, src: &Self, start_ply: usize) {
-        let len = src.len[start_ply].min(MAX_PLY + 1);
-        self.len[0] = len;
-        self.table[0][..len].copy_from_slice(&src.table[start_ply][..len]);
-    }
 }
 
 impl Default for PrincipalVariationTable {
@@ -453,5 +443,29 @@ impl Default for PrincipalVariationTable {
             table: vec![[Move::NULL; MAX_PLY + 1]; MAX_PLY + 1].into_boxed_slice(),
             len: [0; MAX_PLY + 1],
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct RootPV {
+    table: Box<[Move; MAX_PLY + 1]>,
+    len: usize,
+}
+
+impl RootPV {
+    pub fn line(&self) -> &[Move] {
+        &self.table[..self.len]
+    }
+
+    pub fn commit_from_pv(&mut self, src: &PrincipalVariationTable, ply: usize) {
+        let len = src.len[ply].min(MAX_PLY + 1);
+        self.len = len;
+        self.table[..len].copy_from_slice(&src.table[ply][..len]);
+    }
+}
+
+impl Default for RootPV {
+    fn default() -> Self {
+        Self { table: Box::new([Move::NULL; MAX_PLY + 1]), len: 0 }
     }
 }


### PR DESCRIPTION
VSTC
Elo   | 4.00 +- 2.56 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19212 W: 5094 L: 4873 D: 9245
Penta | [123, 2017, 5090, 2268, 108]
https://recklesschess.space/test/15476/

No functional change.

Bench: 2669518