### PR TITLE
Fix output convention of eval command

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -334,7 +334,7 @@ fn eval(td: &mut ThreadData, board: &Board) {
 
     let side = board.side_to_move();
 
-    println!("NNUE derived piece values");
+    println!("NNUE derived piece values:");
     println!("+-------+-------+-------+-------+-------+-------+-------+-------+");
     for rank in (0..8).rev() {
         print!("|");
@@ -352,7 +352,8 @@ fn eval(td: &mut ThreadData, board: &Board) {
             match td.nnue.piece_contribution(board, sq) {
                 None => print!("       |"),
                 Some(v) => {
-                    let val = v as f32 / 100.0;
+                    let white_relative = if side == Color::White { v } else { -v };
+                    let val = white_relative as f32 / 100.0;
                     print!("{val:+6.2} |");
                 }
             }
@@ -363,10 +364,10 @@ fn eval(td: &mut ThreadData, board: &Board) {
 
     let used_bucket = crate::nnue::OUTPUT_BUCKETS_LAYOUT[board.occupancies().popcount()];
 
-    println!("\nNNUE output buckets (White side)");
-    println!("+------------+------------+");
-    println!("|   Bucket   |   Total    |");
-    println!("+------------+------------+");
+    println!("\nNNUE output buckets (White's POV):");
+    println!("+-------------+------------+");
+    println!("|   Buckets   |   Total    |");
+    println!("+-------------+------------+");
 
     for bucket in 0..8 {
         let raw_score = td.nnue.eval_with_bucket(board, bucket);
@@ -374,16 +375,16 @@ fn eval(td: &mut ThreadData, board: &Board) {
         let total = white_score as f32 / 100.0;
 
         if bucket == used_bucket {
-            println!("|  {bucket:<2}        | {total:+7.2}    | <-- this bucket is used");
+            println!("|  >   {bucket:<7}| {total:+7.2}    |");
         } else {
-            println!("|  {bucket:<2}        | {total:+7.2}    |");
+            println!("|{bucket:^13}| {total:+7.2}    |");
         }
     }
-    println!("+------------+------------+");
+    println!("+-------------+------------+");
 
     let final_eval = td.nnue.evaluate(board);
     let final_total = (if side == Color::White { final_eval } else { -final_eval }) as f32 / 100.0;
-    println!("\nNNUE evaluation        {final_total:+.2} (White side)");
+    println!("\nNNUE evaluation        {final_total:+.2} (White's POV)");
 }
 
 fn parse_limits(color: Color, tokens: &[&str]) -> Limits {


### PR DESCRIPTION
Previously on black's turn the evaluation table would invert signs. This pr fixes that behavior + cleans up the general output of the eval command. For example:

Previous output
```
NNUE derived piece values
+-------+-------+-------+-------+-------+-------+-------+-------+
|   r   |       |   b   |   q   |   k   |       |       |   r   |
|+11.74 |       | +8.66 |+14.51 |       |       |       |+11.79 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   p   |   p   |   p   |       |       |   p   |   p   |   p   |
| +2.11 | +4.49 | +2.99 |       |       | +3.41 | +4.58 | +1.91 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   n   |       |       |   n   |       |       |
|       |       | +8.30 |       |       | +8.24 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   b   |   p   |   p   |       |       |       |
|       |       | +7.79 | +6.76 | +3.77 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   B   |       |   P   |       |       |       |
|       |       |-12.15 |       | -8.97 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   N   |   P   |       |   N   |       |       |
|       |       |-13.70 | -5.28 |       |-13.17 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   P   |   P   |   P   |       |       |   P   |   P   |   P   |
| -2.23 | -5.78 | -3.64 |       |       | -5.65 | -6.37 | -2.64 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   R   |       |   B   |   Q   |   K   |       |       |   R   |
|-13.67 |       |-13.30 |-14.54 |       |       |       |-14.03 |
+-------+-------+-------+-------+-------+-------+-------+-------+

NNUE output buckets (White side)
+------------+------------+
|   Bucket   |   Total    |
+------------+------------+
|  0         |  -10.91    |
|  1         |   -4.49    |
|  2         |   -3.45    |
|  3         |   -2.37    |
|  4         |   -1.83    |
|  5         |   -1.88    |
|  6         |   -1.82    |
|  7         |   -1.66    | <-- this bucket is used
+------------+------------+

NNUE evaluation        -1.66 (White side)
```

Current output
```
NNUE derived piece values:
+-------+-------+-------+-------+-------+-------+-------+-------+
|   r   |       |   b   |   q   |   k   |       |       |   r   |
|-11.74 |       | -8.66 |-14.51 |       |       |       |-11.79 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   p   |   p   |   p   |       |       |   p   |   p   |   p   |
| -2.11 | -4.49 | -2.99 |       |       | -3.41 | -4.58 | -1.91 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   n   |       |       |   n   |       |       |
|       |       | -8.30 |       |       | -8.24 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   b   |   p   |   p   |       |       |       |
|       |       | -7.79 | -6.76 | -3.77 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   B   |       |   P   |       |       |       |
|       |       |+12.15 |       | +8.97 |       |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|       |       |   N   |   P   |       |   N   |       |       |
|       |       |+13.70 | +5.28 |       |+13.17 |       |       |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   P   |   P   |   P   |       |       |   P   |   P   |   P   |
| +2.23 | +5.78 | +3.64 |       |       | +5.65 | +6.37 | +2.64 |
+-------+-------+-------+-------+-------+-------+-------+-------+
|   R   |       |   B   |   Q   |   K   |       |       |   R   |
|+13.67 |       |+13.30 |+14.54 |       |       |       |+14.03 |
+-------+-------+-------+-------+-------+-------+-------+-------+

NNUE output buckets (White's POV):
+-------------+------------+
|   Buckets   |   Total    |
+-------------+------------+
|      0      |  -10.91    |
|      1      |   -4.49    |
|      2      |   -3.45    |
|      3      |   -2.37    |
|      4      |   -1.83    |
|      5      |   -1.88    |
|      6      |   -1.82    |
|  >   7      |   -1.66    |
+-------------+------------+

NNUE evaluation        -1.66 (White's POV)
```