### PR TITLE
Make `parse_cpu_indices` more elegant

### DIFF
--- a/src/numa.rs
+++ b/src/numa.rs
@@ -263,7 +263,7 @@ fn parse_cpu_indices(cpu_ids: &str) -> Vec<usize> {
             let (a, b) = s.split_once('-').unwrap_or((s, s));
             let start = a.parse::<usize>().ok()?;
             let end = b.parse::<usize>().ok()?;
-            
+
             Some(start..=end)
         })
         .flatten()

--- a/src/numa.rs
+++ b/src/numa.rs
@@ -256,26 +256,18 @@ impl NumaConfig {
 }
 
 fn parse_cpu_indices(cpu_ids: &str) -> Vec<usize> {
-    if cpu_ids.is_empty() {
-        return Vec::new();
-    }
-
-    let mut indices = Vec::new();
-    for segment in cpu_ids.split(',').filter(|s| !s.is_empty()) {
-        let parts: Vec<_> = segment.split('-').collect();
-        match parts.len() {
-            1 => indices.push(parts[0].parse::<usize>().unwrap()),
-            2 => {
-                let first = parts[0].parse::<usize>().unwrap();
-                let last = parts[1].parse::<usize>().unwrap();
-                for cpu in first..=last {
-                    indices.push(cpu);
-                }
-            }
-            _ => {}
-        }
-    }
-    indices
+    cpu_ids
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| {
+            let (a, b) = s.split_once('-').unwrap_or((s, s));
+            let start = a.parse::<usize>().ok()?;
+            let end = b.parse::<usize>().ok()?;
+            
+            Some(start..=end)
+        })
+        .flatten()
+        .collect()
 }
 
 fn remove_whitespace(s: String) -> String {


### PR DESCRIPTION
Replaced the messy manual loops with a clean iterator chain that skips parsing errors instead of crashing.

Bench: 2669518