### PR TITLE
Deduplicate .cargo/config.toml flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,22 +1,9 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native"]
-
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-cpu=native"]
-
-[target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native"]
-
-[target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-cpu=native"]
-
-[target.x86_64-pc-windows-gnu]
-rustflags = ["-C", "target-cpu=native"]
-
-[target.x86_64-pc-windows-msvc]
+[build]
 rustflags = ["-C", "target-cpu=native"]
 
 [target.wasm32-unknown-unknown]
+# Note that `target.<...>.rustflags` takes precedence over `build.rustflags`.
+# This happens to work out well, as `-Ctarget-cpu=native` breaks wasm builds.
 rustflags = [
     "-C", "target-feature=+atomics,+bulk-memory,+simd128,+relaxed-simd",
     "-C", "link-arg=--shared-memory",


### PR DESCRIPTION
Unsure why these were previously duplicated. No functional change.

Bench: 2669518