### PR TITLE
Adjust qsearch SEE margin using quiet/noisy history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1191,6 +1191,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         }
     }
 
+    let stm = td.board.side_to_move();
     let in_check = td.board.in_check();
 
     if NODE::PV {
@@ -1294,6 +1295,12 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
         move_count += 1;
 
+        let history = if mv.is_quiet() {
+            td.quiet_history.get(td.board.all_threats(), stm, mv) + td.conthist(ply, 1, mv) + td.conthist(ply, 2, mv)
+        } else {
+            td.noisy_history.get(td.board.all_threats(), td.board.moved_piece(mv), mv.to(), td.board.type_on(mv.to()))
+        };
+
         if !is_loss(best_score) {
             // Late Move Pruning (LMP)
             if move_count >= 3 && !td.board.is_direct_check(mv) {
@@ -1301,7 +1308,9 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
 
             // Static Exchange Evaluation Pruning (SEE Pruning)
-            if is_valid(eval) && !td.board.see(mv, (alpha - eval) / 8 - correction_value.abs().min(68) - 74) {
+            if is_valid(eval)
+                && !td.board.see(mv, (alpha - eval) / 8 - correction_value.abs().min(68) - 74 - history / 48)
+            {
                 continue;
             }
         }


### PR DESCRIPTION
STC
Elo   | 4.53 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16626 W: 4310 L: 4093 D: 8223
Penta | [65, 1842, 4281, 2061, 64]
https://recklesschess.space/test/15573/

LTC
Elo   | 3.61 +- 2.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20184 W: 5095 L: 4885 D: 10204
Penta | [13, 2199, 5465, 2395, 20]
https://recklesschess.space/test/15575/

Bench: 2569707