### PR TITLE
Scale singular extension margin by tt_move history

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -693,8 +693,9 @@ fn search<NODE: NodeType>(
     if !NODE::ROOT && !excluded && potential_singularity {
         debug_assert!(is_valid(tt_score));
 
-        let singular_margin = if tt_bound == Bound::Exact { (depth as u32).div_ceil(4) as i32 } else { depth }
-            + depth * (tt_pv && !NODE::PV) as i32;
+        let singular_margin = (if tt_bound == Bound::Exact { (depth as u32).div_ceil(4) as i32 } else { depth }
+            + depth * (tt_pv && !NODE::PV) as i32)
+            + (td.move_history(ply, tt_move) / 1024).clamp(-depth / 4, depth / 4);
         let singular_beta = tt_score - singular_margin;
         let singular_depth = (depth - 1) / 2;
 
@@ -766,12 +767,7 @@ fn search<NODE: NodeType>(
         let is_quiet = mv.is_quiet();
         let is_direct_check = td.board.is_direct_check(mv);
 
-        let history = if is_quiet {
-            td.quiet_history.get(td.board.all_threats(), stm, mv) + td.conthist(ply, 1, mv) + td.conthist(ply, 2, mv)
-        } else {
-            let captured_type = td.board.type_on(mv.to());
-            td.noisy_history.get(td.board.all_threats(), td.board.moved_piece(mv), mv.to(), captured_type)
-        };
+        let history = td.move_history(ply, mv);
 
         if !NODE::ROOT && !is_loss(best_score) {
             // Late Move Pruning (LMP)
@@ -1191,7 +1187,6 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
         }
     }
 
-    let stm = td.board.side_to_move();
     let in_check = td.board.in_check();
 
     if NODE::PV {
@@ -1295,11 +1290,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
     while let Some(mv) = move_picker.next::<NODE>(td, skip_quiets(best_score), ply) {
         move_count += 1;
 
-        let history = if mv.is_quiet() {
-            td.quiet_history.get(td.board.all_threats(), stm, mv) + td.conthist(ply, 1, mv) + td.conthist(ply, 2, mv)
-        } else {
-            td.noisy_history.get(td.board.all_threats(), td.board.moved_piece(mv), mv.to(), td.board.type_on(mv.to()))
-        };
+        let history = td.move_history(ply, mv);
 
         if !is_loss(best_score) {
             // Late Move Pruning (LMP)

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -295,6 +295,21 @@ impl ThreadData {
         self.continuation_history.get(self.stack[ply - index].conthist, self.board.piece_on(mv.from()), mv.to())
     }
 
+    pub fn move_history(&self, ply: isize, mv: Move) -> i32 {
+        if mv.is_quiet() {
+            self.quiet_history.get(self.board.all_threats(), self.board.side_to_move(), mv)
+                + self.conthist(ply, 1, mv)
+                + self.conthist(ply, 2, mv)
+        } else {
+            self.noisy_history.get(
+                self.board.all_threats(),
+                self.board.moved_piece(mv),
+                mv.to(),
+                self.board.type_on(mv.to()),
+            )
+        }
+    }
+
     pub fn print_uci_info(&mut self, depth: i32) {
         if self.root_moves.is_empty() {
             self.print_uci_no_move();


### PR DESCRIPTION
STC
Elo   | 2.45 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36158 W: 9255 L: 9000 D: 17903
Penta | [140, 4163, 9215, 4424, 137]
https://recklesschess.space/test/15580/

LTC
Elo   | 2.08 +- 1.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 41650 W: 10423 L: 10174 D: 21053
Penta | [17, 4621, 11311, 4848, 28]
https://recklesschess.space/test/15581/

Bench: 2889007