### PR TITLE
Split L1 double dpbusd accumulators in NNUE forward pass for AVX-512 VNNI

### DIFF
--- a/src/nnue/forward/vectorized.rs
+++ b/src/nnue/forward/vectorized.rs
@@ -56,10 +56,13 @@ pub unsafe fn propagate_l1(
     ft_out: &Aligned<[u8; L1_SIZE]>, nnz: &[u16], bucket: usize, parameters: &Parameters,
 ) -> Aligned<[f32; L2_SIZE]> {
     const CHUNKS: usize = 4;
+    const L2_LANES: usize = L2_SIZE / simd::F32_LANES;
 
-    let mut pre_activations = Aligned::new([simd::zeroed(); L2_SIZE / simd::F32_LANES]);
-
+    let mut pre_activations = Aligned::new([simd::zeroed(); L2_LANES]);
     let packed = std::slice::from_raw_parts(ft_out.as_ptr().cast::<i32>(), L1_SIZE / CHUNKS);
+
+    #[cfg(target_feature = "avx512vnni")]
+    let mut pre_b = Aligned::new([simd::zeroed(); L2_LANES]);
 
     let mut pairs = nnz.chunks_exact(2);
 
@@ -77,9 +80,24 @@ pub unsafe fn propagate_l1(
             let weights1 = *weights1.add(j * CHUNKS).cast();
             let weights2 = *weights2.add(j * CHUNKS).cast();
 
-            let vector = &mut pre_activations[j / simd::F32_LANES];
-            *vector = simd::double_dpbusd(*vector, input1, weights1, input2, weights2);
+            let lane = j / simd::F32_LANES;
+
+            #[cfg(target_feature = "avx512vnni")]
+            {
+                pre_activations[lane] = simd::dpbusd(pre_activations[lane], input1, weights1);
+                pre_b[lane] = simd::dpbusd(pre_b[lane], input2, weights2);
+            }
+
+            #[cfg(not(target_feature = "avx512vnni"))]
+            {
+                pre_activations[lane] = simd::double_dpbusd(pre_activations[lane], input1, weights1, input2, weights2);
+            }
         }
+    }
+
+    #[cfg(target_feature = "avx512vnni")]
+    for lane in 0..L2_LANES {
+        pre_activations[lane] = simd::add_i32(pre_activations[lane], pre_b[lane]);
     }
 
     if let Some(last) = pairs.remainder().first() {
@@ -89,8 +107,8 @@ pub unsafe fn propagate_l1(
 
         for j in (0..L2_SIZE).step_by(simd::F32_LANES) {
             let weights = *weights.add(j * CHUNKS).cast();
-            let vector = &mut pre_activations[j / simd::F32_LANES];
-            *vector = simd::dpbusd(*vector, input, weights);
+            let lane = j / simd::F32_LANES;
+            pre_activations[lane] = simd::dpbusd(pre_activations[lane], input, weights);
         }
     }
 

--- a/src/nnue/simd/avx512.rs
+++ b/src/nnue/simd/avx512.rs
@@ -79,16 +79,15 @@ pub unsafe fn dpbusd(i32s: __m512i, u8s: __m512i, i8s: __m512i) -> __m512i {
     _mm512_dpbusd_epi32(i32s, u8s, i8s)
 }
 
+pub unsafe fn add_i32(a: __m512i, b: __m512i) -> __m512i {
+    _mm512_add_epi32(a, b)
+}
+
 #[cfg(not(target_feature = "avx512vnni"))]
 pub unsafe fn dpbusd(i32s: __m512i, u8s: __m512i, i8s: __m512i) -> __m512i {
     let pairwise = _mm512_maddubs_epi16(u8s, i8s);
     let widened = _mm512_madd_epi16(pairwise, _mm512_set1_epi16(1));
     _mm512_add_epi32(i32s, widened)
-}
-
-#[cfg(target_feature = "avx512vnni")]
-pub unsafe fn double_dpbusd(i32s: __m512i, u8s1: __m512i, i8s1: __m512i, u8s2: __m512i, i8s2: __m512i) -> __m512i {
-    _mm512_dpbusd_epi32(_mm512_dpbusd_epi32(i32s, u8s1, i8s1), u8s2, i8s2)
 }
 
 #[cfg(not(target_feature = "avx512vnni"))]


### PR DESCRIPTION
VSTC
Elo   | 4.48 +- 2.74 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17216 W: 4620 L: 4398 D: 8198
Penta | [110, 1832, 4521, 2016, 129]
https://recklesschess.space/test/15620/

Bench: 2569707