### PR TITLE
Fix hang on stdin EOF while search is running

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -120,9 +120,9 @@ fn spawn_listener(shared: Arc<SharedContext>) -> std::sync::mpsc::Receiver<Strin
 
             if std::io::stdin().read_line(&mut message).unwrap() == 0 {
                 // EOF received
-                if shared.status.get() != Status::RUNNING {
-                    let _ = tx.send("quit".to_string());
-                }
+                shared.status.set(Status::STOPPED);
+                let _ = tx.send("quit".to_string());
+                break;
             }
 
             match message.trim_end() {


### PR DESCRIPTION
If EOF is received in the middle of search, nothing is sent as spawn_listener only sends quit if status != RUNNING. This causes the process to get stuck in an infinite loop.

Fixes: #1116

Bench: 2569707


----

Was reproduced using this helper script if anyone wants to try locally:
```bash
cargo build --release
{
  echo "uci"
  echo "isready"
  echo "position startpos"
  echo "go infinite"
  sleep 0.5
} | ./target/release/reckless &
PID=$!
sleep 3
if kill -0 $PID 2>/dev/null; then
  echo "Process $PID is still alive and hung :("
fi
```