### PR TITLE
do not return negative mate too

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -609,7 +609,7 @@ fn search<NODE: NodeType>(
             return Score::ZERO;
         }
 
-        if score >= bound && !is_win(score) {
+        if score >= bound && !is_win(score) && !is_loss(score) {
             if (td.nmp_min_ply > 0 || depth < 16) && score >= beta {
                 return score;
             }


### PR DESCRIPTION
fix #1121 

STC non-regr
Elo   | 2.16 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 21846 W: 5616 L: 5480 D: 10750
Penta | [73, 2286, 6071, 2418, 75]
https://recklesschess.space/test/15624/

LTC non-regr
Elo   | 2.16 +- 2.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.80 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 18960 W: 4679 L: 4561 D: 9720
Penta | [8, 1920, 5516, 2018, 18]
https://recklesschess.space/test/15625/

Bench: 2569707