### PR TITLE
Adjust LMR by laterality

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -884,6 +884,8 @@ fn search<NODE: NodeType>(
 
             if NODE::PV {
                 reduction -= 519 + 437 * (beta - alpha) / td.root_delta;
+            } else {
+                reduction -= 96 - 32 * td.stack[ply].laterality;
             }
 
             if tt_pv {

--- a/src/search.rs
+++ b/src/search.rs
@@ -592,6 +592,7 @@ fn search<NODE: NodeType>(
         td.stack[ply].contcorrhist = td.stack.sentinel().contcorrhist;
         td.stack[ply].piece = Piece::None;
         td.stack[ply].mv = Move::NULL;
+        td.stack[ply].laterality = 0;
 
         td.board.make_null_move();
         td.shared.tt.prefetch(td.board.hash());
@@ -650,7 +651,7 @@ fn search<NODE: NodeType>(
                 continue;
             }
 
-            make_move(td, ply, mv);
+            make_move(td, ply, mv, 0);
 
             let mut score = -qsearch::<NonPV>(td, -probcut_beta, -probcut_beta + 1, ply + 1);
 
@@ -778,7 +779,6 @@ fn search<NODE: NodeType>(
         current_search_count = 0;
 
         move_count += 1;
-        td.stack[ply].move_count = move_count;
 
         let is_quiet = mv.is_quiet();
         let is_direct_check = td.board.is_direct_check(mv);
@@ -853,7 +853,7 @@ fn search<NODE: NodeType>(
 
         let initial_nodes = td.nodes();
 
-        make_move(td, ply, mv);
+        make_move(td, ply, mv, move_count as i32);
 
         let mut new_depth = depth - 1 + if move_count == 1 { extension } else { 0 };
         let mut score = Score::ZERO;
@@ -1342,7 +1342,7 @@ fn qsearch<NODE: NodeType>(td: &mut ThreadData, mut alpha: i32, beta: i32, ply: 
             }
         }
 
-        make_move(td, ply, mv);
+        make_move(td, ply, mv, move_count);
         let score = -qsearch::<NODE>(td, -beta, -alpha, ply + 1);
         undo_move(td, mv);
 
@@ -1459,7 +1459,7 @@ fn update_continuation_histories(td: &mut ThreadData, ply: isize, piece: Piece, 
     }
 }
 
-fn make_move(td: &mut ThreadData, ply: isize, mv: Move) {
+fn make_move(td: &mut ThreadData, ply: isize, mv: Move, move_count: i32) {
     td.shared.tt.prefetch(td.board.key_after(mv));
     td.stack[ply].mv = mv;
     td.stack[ply].piece = td.board.moved_piece(mv);
@@ -1467,6 +1467,9 @@ fn make_move(td: &mut ThreadData, ply: isize, mv: Move) {
         td.continuation_history.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
     td.stack[ply].contcorrhist =
         td.continuation_corrhist.subtable_ptr(td.board.in_check(), mv.is_noisy(), td.board.moved_piece(mv), mv.to());
+    td.stack[ply].move_count = move_count as u16;
+    td.stack[ply].laterality = if ply > 0 { td.stack[ply - 1].laterality } else { 0 }
+        + if move_count > 0 { (move_count.ilog2() as i32 - 1).max(0) } else { 0 };
 
     td.shared.nodes.increment(td.id);
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -41,6 +41,7 @@ pub struct StackEntry {
     pub tt_pv: bool,
     pub move_count: u16,
     pub reduction: i32,
+    pub laterality: i32,
     pub conthist: *mut [[i16; 64]; 13],
     pub contcorrhist: *mut [[i16; 64]; 13],
 }
@@ -57,6 +58,7 @@ impl Default for StackEntry {
             tt_pv: false,
             move_count: 0,
             reduction: 0,
+            laterality: 0,
             conthist: std::ptr::null_mut(),
             contcorrhist: std::ptr::null_mut(),
         }


### PR DESCRIPTION
Adjust LMR by how "far off" the main line we are in terms of accumulated lateral distance.
Inspired by #1124 but taking the orthogonal direction.

STC
Elo   | 6.13 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11624 W: 3037 L: 2832 D: 5755
Penta | [39, 1271, 2985, 1480, 37]

LTC
Elo   | 2.21 +- 1.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38706 W: 9644 L: 9398 D: 19664
Penta | [18, 4320, 10440, 4548, 27]

Bench: 2880101