### PR TITLE
Store 21 bit keys in transposition table

### DIFF
--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -125,13 +125,13 @@ impl Cluster {
         verification_key(self.keys >> (index * Self::KEY_BITS))
     }
 
-    const fn set_key(&mut self, index: usize, key: u32) {
+    const fn set_key(&mut self, index: usize, key: VerificationKey) {
         self.keys &= !(Self::KEY_MASK << (index * Self::KEY_BITS));
         self.keys |= (key as u64) << (index * Self::KEY_BITS);
     }
 
     const fn lookup_key(&self, key: VerificationKey) -> usize {
-        let bits = (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2)) | (1 << (Self::KEY_BITS * 3));
+        let bits = 1 | (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2));
         let needle = key as u64 * bits;
         let zeros = self.keys ^ needle;
         let matches = zeros.wrapping_sub(bits) & !zeros & (bits << (Self::KEY_BITS - 1));

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -110,22 +110,32 @@ struct Cluster {
     keys: u64,
 }
 
+type VerificationKey = u32;
+
+/// Returns the verification key of the hash (bottom 21 bits).
+const fn verification_key(hash: u64) -> VerificationKey {
+    (hash & Cluster::KEY_MASK) as VerificationKey
+}
+
 impl Cluster {
-    const fn key(&self, index: usize) -> u16 {
-        verification_key(self.keys >> (index * 16))
+    const KEY_BITS: usize = 21;
+    const KEY_MASK: u64 = 0x1FFFFF;
+
+    const fn key(&self, index: usize) -> VerificationKey {
+        verification_key(self.keys >> (index * Self::KEY_BITS))
     }
 
-    const fn set_key(&mut self, index: usize, key: u16) {
-        self.keys &= !(0xFFFF << (index * 16));
-        self.keys |= (key as u64) << (index * 16);
+    const fn set_key(&mut self, index: usize, key: u32) {
+        self.keys &= !(Self::KEY_MASK << (index * Self::KEY_BITS));
+        self.keys |= (key as u64) << (index * Self::KEY_BITS);
     }
 
-    const fn lookup_key(&self, key: u16) -> usize {
-        let bits = 0x0001_0001_0001_0001;
+    const fn lookup_key(&self, key: VerificationKey) -> usize {
+        let bits = (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2)) | (1 << (Self::KEY_BITS * 3));
         let needle = key as u64 * bits;
         let zeros = self.keys ^ needle;
-        let matches = zeros.wrapping_sub(bits) & !zeros & (bits << 15);
-        (matches.trailing_zeros() / 16) as usize
+        let matches = zeros.wrapping_sub(bits) & !zeros & (bits << (Self::KEY_BITS - 1));
+        matches.trailing_zeros() as usize / Self::KEY_BITS
     }
 }
 
@@ -298,11 +308,6 @@ const fn index(hash: u64, len: usize) -> usize {
     // Fast hash table index calculation
     // For details, see: https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction
     (((hash as u128) * (len as u128)) >> 64) as usize
-}
-
-/// Returns the verification key of the hash (bottom 16 bits).
-const fn verification_key(hash: u64) -> u16 {
-    hash as u16
 }
 
 /// Adjust mate distance from "plies from the root" to "plies from the current position".

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -132,7 +132,7 @@ impl Cluster {
     }
 
     const fn lookup_key(&self, key: VerificationKey) -> usize {
-        let bits = 1 | (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2)) | (1 << (Self::KEY_BITS * 3));
+        let bits = 1 | (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2));
         let needle = key.0 as u64 * bits;
         let zeros = self.keys ^ needle;
         let matches = zeros.wrapping_sub(bits) & !zeros & (bits << (Self::KEY_BITS - 1));

--- a/src/transposition.rs
+++ b/src/transposition.rs
@@ -110,16 +110,17 @@ struct Cluster {
     keys: u64,
 }
 
-type VerificationKey = u32;
+#[derive(Copy, Clone, PartialEq, Eq)]
+struct VerificationKey(u32);
 
 /// Returns the verification key of the hash (bottom 21 bits).
 const fn verification_key(hash: u64) -> VerificationKey {
-    (hash & Cluster::KEY_MASK) as VerificationKey
+    VerificationKey((hash & Cluster::KEY_MASK) as u32)
 }
 
 impl Cluster {
     const KEY_BITS: usize = 21;
-    const KEY_MASK: u64 = 0x1FFFFF;
+    const KEY_MASK: u64 = (1 << Self::KEY_BITS) - 1;
 
     const fn key(&self, index: usize) -> VerificationKey {
         verification_key(self.keys >> (index * Self::KEY_BITS))
@@ -127,12 +128,12 @@ impl Cluster {
 
     const fn set_key(&mut self, index: usize, key: VerificationKey) {
         self.keys &= !(Self::KEY_MASK << (index * Self::KEY_BITS));
-        self.keys |= (key as u64) << (index * Self::KEY_BITS);
+        self.keys |= (key.0 as u64) << (index * Self::KEY_BITS);
     }
 
     const fn lookup_key(&self, key: VerificationKey) -> usize {
-        let bits = 1 | (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2));
-        let needle = key as u64 * bits;
+        let bits = 1 | (1 << Self::KEY_BITS) | (1 << (Self::KEY_BITS * 2)) | (1 << (Self::KEY_BITS * 3));
+        let needle = key.0 as u64 * bits;
         let zeros = self.keys ^ needle;
         let matches = zeros.wrapping_sub(bits) & !zeros & (bits << (Self::KEY_BITS - 1));
         matches.trailing_zeros() as usize / Self::KEY_BITS


### PR DESCRIPTION
Use up most of remaining unused space in cluster.
One unused bit remaining per cluster. (21 * 3 = 63 bits)

STC
Elo   | 1.49 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 28032 W: 7073 L: 6953 D: 14006
Penta | [90, 3206, 7309, 3316, 95]
https://recklesschess.space/test/15649/

LTC
Elo   | 0.86 +- 1.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.92 (-2.25, 2.89) [-2.75, 0.25]
Games | N: 38652 W: 9589 L: 9493 D: 19570
Penta | [18, 4394, 10408, 4486, 20]
https://recklesschess.space/test/15653/

Bench: 2985186